### PR TITLE
[neuralnet] enable network sharing

### DIFF
--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -146,7 +146,9 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int compile(ExecutionMode exec_mode_ = ExecutionMode::TRAIN) = 0;
+  virtual int
+  compile(ExecutionMode exec_mode_ = ExecutionMode::TRAIN,
+          std::shared_ptr<ml::train::Model> ref_model = nullptr) = 0;
 
   /**
    * @brief     Compile from symbolic tensor graph.
@@ -161,7 +163,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(Tensor &input, Tensor &output,
-              ExecutionMode mode = ExecutionMode::TRAIN);
+              ExecutionMode mode = ExecutionMode::TRAIN,
+              std::shared_ptr<ml::train::Model> ref_model = nullptr);
 
   /**
    * @brief     Compile from symbolic tensor graph with multiple outputs.
@@ -176,7 +179,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(Tensor &input, std::vector<Tensor> &outputs,
-              ExecutionMode mode = ExecutionMode::TRAIN);
+              ExecutionMode mode = ExecutionMode::TRAIN,
+              std::shared_ptr<ml::train::Model> ref_model = nullptr);
 
   /**
    * @brief     Compile from symbolic tensor graph with multiple inputs and
@@ -192,7 +196,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    */
   int compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
-              ExecutionMode mode = ExecutionMode::TRAIN);
+              ExecutionMode mode = ExecutionMode::TRAIN,
+              std::shared_ptr<ml::train::Model> ref_model = nullptr);
 
   /**
    * @brief     Initialize Network. This should be called after setting the
@@ -200,7 +205,9 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  virtual int initialize(ExecutionMode exec_mode_ = ExecutionMode::TRAIN) = 0;
+  virtual int
+  initialize(ExecutionMode exec_mode_ = ExecutionMode::TRAIN,
+             std::shared_ptr<ml::train::Model> ref_model = nullptr) = 0;
 
   /**
    * @brief     Reinitialize Network. This should be called after initialize

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -469,6 +469,12 @@ public:
   virtual bool getLoadedFromConfig() const = 0;
 
   /**
+   * @brief returns loadedWeight state of a network
+   * @retval loadedWeight value
+   */
+  virtual bool getLoadedWeight() const = 0;
+
+  /**
    * @brief     Get Loss from the previous epoch of training data
    * @retval    loss value
    */

--- a/api/ccapi/src/tensor_api_graph.cpp
+++ b/api/ccapi/src/tensor_api_graph.cpp
@@ -320,25 +320,28 @@ static const char *dtypeToStr(nntrainer::TensorDim::DataType dt) {
   }
 }
 
-int Model::compile(Tensor &input, Tensor &output, ExecutionMode mode) {
+int Model::compile(Tensor &input, Tensor &output, ExecutionMode mode,
+                   std::shared_ptr<ml::train::Model> ref_model) {
   std::vector<Tensor> inputs = {input};
   std::vector<Tensor> outputs = {output};
-  int status = compile(inputs, outputs, mode);
+  int status = compile(inputs, outputs, mode, ref_model);
   input = inputs[0];
   output = outputs[0];
   return status;
 }
 
 int Model::compile(Tensor &input, std::vector<Tensor> &outputs,
-                   ExecutionMode mode) {
+                   ExecutionMode mode,
+                   std::shared_ptr<ml::train::Model> ref_model) {
   std::vector<Tensor> inputs = {input};
-  int status = compile(inputs, outputs, mode);
+  int status = compile(inputs, outputs, mode, ref_model);
   input = inputs[0];
   return status;
 }
 
 int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
-                   ExecutionMode mode) {
+                   ExecutionMode mode,
+                   std::shared_ptr<ml::train::Model> ref_model) {
   struct LayerInfo {
     std::shared_ptr<Layer> layer;
     std::vector<std::string> input_layer_names;
@@ -555,7 +558,7 @@ int Model::compile(std::vector<Tensor> &inputs, std::vector<Tensor> &outputs,
   }
 
   // 4. Initialize the model
-  status = initialize(mode);
+  status = initialize(mode, ref_model);
   if (status != ML_ERROR_NONE) {
     return status;
   }

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -597,6 +597,12 @@ public:
     }
   }
 
+  std::shared_ptr<Manager> getTensorManager() { return tensor_manager; }
+
+  void setRefGraph(std::shared_ptr<NetworkGraph> ref_graph) {
+    tensor_manager->setRefManager(ref_graph->getTensorManager());
+  }
+
 private:
   std::map<std::string, std::string> sub_in_out; /** This is map to identify
                  input and output layer name of subgraph */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -124,8 +124,10 @@ NeuralNetwork::NeuralNetwork() :
   initialized(false),
   compiled(false),
   loadedFromConfig(false),
+  loadedWeight(false),
   exec_mode(ExecutionMode::TRAIN),
-  ct_engine(&Engine::Global()) {}
+  ct_engine(&Engine::Global()),
+  ref_model(nullptr) {}
 
 NeuralNetwork::NeuralNetwork(const Engine *ct_engine_) :
   model_props(props::LossType(), {}, {}, props::ClipGradByGlobalNorm(),
@@ -143,8 +145,10 @@ NeuralNetwork::NeuralNetwork(const Engine *ct_engine_) :
   initialized(false),
   compiled(false),
   loadedFromConfig(false),
+  loadedWeight(false),
   exec_mode(ExecutionMode::TRAIN),
-  ct_engine(ct_engine_) {}
+  ct_engine(ct_engine_),
+  ref_model(nullptr) {}
 
 int NeuralNetwork::loadFromConfig(const std::string &config) {
   if (loadedFromConfig == true) {
@@ -352,9 +356,7 @@ int NeuralNetwork::initialize(ExecutionMode mode,
   }
 
   if (ref_model.get()) {
-    ref_model_graph = std::make_shared<NetworkGraph>(
-      std::dynamic_pointer_cast<NeuralNetwork>(ref_model)->getNetworkGraph());
-    model_graph.setRefGraph(ref_model_graph);
+    setRefModel(ref_model);
   }
 
   // Allocate weights
@@ -995,6 +997,13 @@ void NeuralNetwork::load(const std::string &file_path,
 
   switch (format) {
   case ml::train::ModelFormat::MODEL_FORMAT_BIN: {
+    if (ref_model) {
+      NNTR_THROW_IF(!ref_model->getLoadedWeight(), std::invalid_argument)
+        << "Model load failed: reference model weights not loaded.";
+
+      ml_logd("Skipping model load: reference model is already loaded.");
+      return;
+    }
     NNTR_THROW_IF(!initialized, std::runtime_error)
       << "Cannot load if not initialized yet, path: " << file_path
       << " format: " << static_cast<unsigned>(format);
@@ -1342,6 +1351,8 @@ void NeuralNetwork::load(const std::string &file_path,
     throw nntrainer::exception::not_supported(
       "loading with given format is not supported yet");
   }
+
+  loadedWeight = true;
 }
 
 float NeuralNetwork::getLoss() {
@@ -1942,6 +1953,8 @@ void swap(NeuralNetwork &lhs, NeuralNetwork &rhs) {
     swap(lhs.graph_representation, rhs.graph_representation);
     swap(lhs.compiled, rhs.compiled);
     swap(lhs.loadedFromConfig, rhs.loadedFromConfig);
+    swap(lhs.loadedWeight, rhs.loadedWeight);
+    swap(lhs.ref_model, rhs.ref_model);
   }
 }
 
@@ -2319,4 +2332,50 @@ void NeuralNetwork::exports(const ml::train::ExportMethods &method,
     throw std::runtime_error{"Unsupported export method"};
   }
 }
+
+void NeuralNetwork::setRefModel(std::shared_ptr<ml::train::Model> ref_model_) {
+  NNTR_THROW_IF(!ref_model_->getInitialized(), std::invalid_argument)
+    << "The reference model has not been initialized, so the reference will be "
+       "omitted.";
+
+  auto ref_model_graph = std::make_shared<NetworkGraph>(
+    std::dynamic_pointer_cast<NeuralNetwork>(ref_model_)->getNetworkGraph());
+
+  NNTR_THROW_IF(!verifyRefModel(ref_model_graph), std::invalid_argument)
+    << "The reference model is not match with current model";
+
+  ref_model = ref_model_;
+  model_graph.setRefGraph(ref_model_graph);
+}
+
+bool NeuralNetwork::verifyRefModel(
+  std::shared_ptr<NetworkGraph> ref_model_graph) {
+  for (auto iter = model_graph.cbegin(), ref_iter = ref_model_graph->cbegin();
+       iter != model_graph.cend() || ref_iter != ref_model_graph->cend();
+       iter++, ref_iter++) {
+    if (iter == model_graph.cend() || ref_iter == ref_model_graph->cend()) {
+      return false;
+    }
+
+    auto weights = (*iter)->getRunContext().getWeights();
+    auto ref_weights = (*ref_iter)->getRunContext().getWeights();
+
+    if (weights.size() != ref_weights.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < weights.size(); ++i) {
+      auto weight = weights[i];
+      auto ref_weight = ref_weights[i];
+
+      if (weight->getVariable().getDim() !=
+          ref_weight->getVariable().getDim()) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -190,7 +190,8 @@ void NeuralNetwork::setTrainConfig(const std::vector<std::string> &values) {
     << " of first element: " << left_props.front();
 }
 
-int NeuralNetwork::compile(ExecutionMode mode) {
+int NeuralNetwork::compile(ExecutionMode mode,
+                           std::shared_ptr<ml::train::Model> ref_model) {
 
   exec_mode = mode;
 
@@ -278,7 +279,8 @@ int NeuralNetwork::compile(ExecutionMode mode) {
   return status;
 }
 
-int NeuralNetwork::initialize(ExecutionMode mode) {
+int NeuralNetwork::initialize(ExecutionMode mode,
+                              std::shared_ptr<ml::train::Model> ref_model) {
   int status = ML_ERROR_NONE;
 
   if (mode != exec_mode) {
@@ -347,6 +349,12 @@ int NeuralNetwork::initialize(ExecutionMode mode) {
         return opt->getOptimizerVariableDim(dim);
       };
     model_graph.requestOptimizerVariable(cb, true);
+  }
+
+  if (ref_model.get()) {
+    ref_model_graph = std::make_shared<NetworkGraph>(
+      std::dynamic_pointer_cast<NeuralNetwork>(ref_model)->getNetworkGraph());
+    model_graph.setRefGraph(ref_model_graph);
   }
 
   // Allocate weights

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -124,6 +124,12 @@ public:
   bool getLoadedFromConfig() const override { return loadedFromConfig; }
 
   /**
+   * @brief returns loadedWeight state of a network
+   * @retval loadedWeight value
+   */
+  bool getLoadedWeight() const override { return loadedWeight; }
+
+  /**
    * @brief     Get Loss from the previous epoch of training data
    * @retval    loss value
    */
@@ -708,6 +714,8 @@ private:
 
   bool loadedFromConfig; /**< Check if config is loaded to prevent load twice */
 
+  bool loadedWeight; /**< Check if weights are loaded to prevent load twice */
+
   RunStats validation; /** validation statistics of the model */
   RunStats training;   /** training statistics of the model */
   RunStats testing;    /** testing statistics of the model */
@@ -718,7 +726,7 @@ private:
     nullptr; /** Configurations bound to current engine */
 
   NetworkGraph model_graph; /** Network Model Graph */
-  std::shared_ptr<NetworkGraph> ref_model_graph;
+  std::shared_ptr<ml::train::Model> ref_model;
 
   /**< Set in compile() for graphs that contain a QNN/HTP engine. When true,
    * inference() reuses the already-allocated tensor pool across calls instead
@@ -800,6 +808,19 @@ private:
    * @retval true if matches, false is error
    */
   bool validateInput(sharedConstTensors X);
+
+  /**
+   * @brief Set reference model
+   * @param[in] ref_model_ reference model
+   */
+  void setRefModel(std::shared_ptr<ml::train::Model> ref_model_);
+
+  /**
+   * @brief Verifying if reference model graph matches the current model graph.
+   * @param[in] ref_model_graph reference model graph
+   * @retval true if matches, false if not match
+   */
+  bool verifyRefModel(std::shared_ptr<NetworkGraph> ref_model_graph);
 };
 
 } /* namespace nntrainer */

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -162,7 +162,8 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int compile(ExecutionMode mode = ExecutionMode::TRAIN) override;
+  int compile(ExecutionMode mode = ExecutionMode::TRAIN,
+              std::shared_ptr<ml::train::Model> ref_model = nullptr) override;
 
   /**
    * @brief     set Property of Network
@@ -178,7 +179,9 @@ public:
    * @retval #ML_ERROR_NONE Successful.
    * @retval #ML_ERROR_INVALID_PARAMETER invalid parameter.
    */
-  int initialize(ExecutionMode mode = ExecutionMode::TRAIN) override;
+  int initialize(
+    ExecutionMode mode = ExecutionMode::TRAIN,
+    std::shared_ptr<ml::train::Model> ref_model = nullptr) override;
 
   /**
    * @brief     Reinitialize Network. This should be called after initialize
@@ -715,6 +718,7 @@ private:
     nullptr; /** Configurations bound to current engine */
 
   NetworkGraph model_graph; /** Network Model Graph */
+  std::shared_ptr<NetworkGraph> ref_model_graph;
 
   /**< Set in compile() for graphs that contain a QNN/HTP engine. When true,
    * inference() reuses the already-allocated tensor pool across calls instead

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -152,8 +152,11 @@ void Manager::reinitialize() {
 
 void Manager::allocateWeights(unsigned int max_exec_order_, bool init) {
   max_exec_order = max_exec_order_;
-  if (!weight_pool.isAllocated()) {
+  if (!weight_pool.isAllocated() && !weight_pool.getRefPool()) {
     finalizeTensorPool(weight_pool, 0, max_exec_order_);
+    if (ref_weight_pool) {
+      weight_pool.setRefPool(ref_weight_pool);
+    }
     weight_pool.allocate(init);
   }
 }

--- a/nntrainer/tensor/manager.h
+++ b/nntrainer/tensor/manager.h
@@ -148,6 +148,7 @@ public:
     weight_pool(enable_fsu_, fsu_path, "weight_pool", exec_mode_, allocator),
     tensor_pool(enable_fsu_ && (exec_mode_ == ExecutionMode::TRAIN), fsu_path,
                 "tensor_pool", exec_mode_, allocator),
+    ref_weight_pool(nullptr),
     enable_fsu(enable_fsu_),
     enable_optimizations(true),
     fsu_lookahead(lookahead),
@@ -574,6 +575,12 @@ public:
     weight_pool.setWeightOffset(offsets);
   }
 
+  TensorPool *getWeightPool() { return &weight_pool; }
+
+  void setRefManager(std::shared_ptr<Manager> ref_manager) {
+    ref_weight_pool = ref_manager->getWeightPool();
+  }
+
 private:
   /** @todo: merge this list to one */
   std::vector<std::unique_ptr<Weight>> weights_v2; /**< weights for the layers
@@ -590,6 +597,8 @@ private:
 
   TensorPool weight_pool; /**< tensor pool to request tensors */
   TensorPool tensor_pool; /**< tensor pool to request tensors */
+
+  TensorPool *ref_weight_pool;
 
   /** async load task <execution order, weight completed id> */
   std::map<unsigned int, int> async_task_weight_load;

--- a/nntrainer/tensor/tensor_pool.cpp
+++ b/nntrainer/tensor/tensor_pool.cpp
@@ -222,7 +222,9 @@ void TensorPool::setBatchSize(const std::string &name, unsigned int batch) {
 void TensorPool::allocate(bool init) {
   if (minMemoryRequirement() == 0)
     return;
-  mem_pool->allocate();
+  if (!ref_pool) {
+    mem_pool->allocate();
+  }
 
   /** set the pointers using the token for all the tensors */
   for (auto &spec : pool) {
@@ -230,7 +232,12 @@ void TensorPool::allocate(bool init) {
     if (!details || details->token == 0) {
       continue;
     }
-    spec.tensor->setData(mem_pool->getMemory(details->token), 0, init);
+    if (!ref_pool) {
+      spec.tensor->setData(mem_pool->getMemory(details->token), 0, init);
+    } else {
+      spec.tensor->setData(ref_pool->getMemoryPool()->getMemory(details->token),
+                           0, init);
+    }
     ml_logi("Memory Alloc Details (Tensor): %s : %zu : address %p",
             spec.tensor->getName().c_str(), spec.tensor->getMemoryBytes(),
             spec.tensor->getData());

--- a/nntrainer/tensor/tensor_pool.h
+++ b/nntrainer/tensor/tensor_pool.h
@@ -46,7 +46,8 @@ public:
   TensorPool() :
     allocator_(std::make_shared<MemAllocator>()),
     mem_pool(std::make_unique<MemoryPool>(allocator_)),
-    cache_loader(nullptr) {}
+    cache_loader(nullptr),
+    ref_pool(nullptr) {}
 
   /**
    * @brief     Constructor of TensorPool
@@ -61,7 +62,7 @@ public:
     ml::train::ExecutionMode execution_mode = ml::train::ExecutionMode::TRAIN,
     std::shared_ptr<MemAllocator> allocator =
       std::make_shared<MemAllocator>()) :
-    allocator_(std::move(allocator)) {
+    allocator_(std::move(allocator)), ref_pool(nullptr) {
     if (enable_fsu) {
       auto cache_pool = std::make_shared<CachePool>(fsu_path, fsu_name,
                                                     execution_mode, allocator_);
@@ -369,6 +370,12 @@ public:
     }
   }
 
+  std::shared_ptr<MemoryPool> getMemoryPool() { return mem_pool; }
+
+  TensorPool *getRefPool() { return ref_pool; }
+
+  void setRefPool(TensorPool *ref) { ref_pool = ref; }
+
 private:
   /**
    * @brief Source tensor detailed specification
@@ -472,6 +479,8 @@ private:
                      without re-resolving from the engine. */
   std::shared_ptr<MemoryPool> mem_pool;      /**< memory pool for the tensors */
   std::unique_ptr<CacheLoader> cache_loader; /**< memory pool for the tensors */
+
+  TensorPool *ref_pool;
 
   /**
    * @brief     Check if the lifespan leads to long term valitidy

--- a/test/unittest/meson.build
+++ b/test/unittest/meson.build
@@ -78,6 +78,7 @@ test_target = [
   ['unittest_nntrainer_save_with_dtype', []],
   ['unittest_safetensors_quantize', []],
   ['unittest_thread_manager', []],
+  ['unittest_weight_sharing', []],
   #['unittest_nntrainer_task', []],
 ]
 

--- a/test/unittest/unittest_weight_sharing.cpp
+++ b/test/unittest/unittest_weight_sharing.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Hyeonseok Lee <hs89.lee@samsung.com>
+ *
+ * @file unittest_weight_sharing.cpp
+ * @date 04 Mar 2026
+ * @brief This file contains test and specification of network weight sharing
+ * @see	https://github.com/nntrainer/nntrainer
+ * @author Hyeonseok Lee <hs89.lee@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#include <gtest/gtest.h>
+#include <neuralnet.h>
+
+TEST(WeightSharing, sharing_p) {
+  std::shared_ptr<ml::train::Model> model1, model2;
+  model1 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  model2 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  std::shared_ptr<ml::train::Layer> input1 =
+    ml::train::layer::Input({"name=input1", "input_shape=1:1:1"});
+  std::shared_ptr<ml::train::Layer> input2 =
+    ml::train::layer::Input({"name=input2", "input_shape=1:1:1"});
+
+  model1->addLayer(input1);
+  model2->addLayer(input2);
+
+  std::shared_ptr<ml::train::Layer> fc1 =
+    ml::train::layer::FullyConnected({"name=fc1", "unit=2"});
+  std::shared_ptr<ml::train::Layer> fc2 =
+    ml::train::layer::FullyConnected({"name=fc2", "unit=2"});
+
+  model1->addLayer(fc1);
+  model2->addLayer(fc2);
+
+  model1->compile(ml::train::ExecutionMode::INFERENCE);
+  model2->compile(ml::train::ExecutionMode::INFERENCE);
+
+  model1->initialize(ml::train::ExecutionMode::INFERENCE);
+  model2->initialize(ml::train::ExecutionMode::INFERENCE, model1);
+
+  std::shared_ptr<ml::train::Layer> layer1;
+  std::shared_ptr<ml::train::Layer> layer2;
+
+  model1->getLayer("fc1", &layer1);
+  model2->getLayer("fc2", &layer2);
+
+  EXPECT_EQ(layer1->getWeights()[0], layer2->getWeights()[0]);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_weight_sharing.cpp
+++ b/test/unittest/unittest_weight_sharing.cpp
@@ -48,6 +48,63 @@ TEST(WeightSharing, sharing_p) {
   EXPECT_EQ(layer1->getWeights()[0], layer2->getWeights()[0]);
 }
 
+TEST(WeightSharing, sharing_initialize_n) {
+  std::shared_ptr<ml::train::Model> model1, model2;
+  model1 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  model2 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  std::shared_ptr<ml::train::Layer> input1 =
+    ml::train::layer::Input({"name=input1", "input_shape=1:1:1"});
+  std::shared_ptr<ml::train::Layer> input2 =
+    ml::train::layer::Input({"name=input2", "input_shape=1:1:1"});
+
+  model1->addLayer(input1);
+  model2->addLayer(input2);
+
+  std::shared_ptr<ml::train::Layer> fc1 =
+    ml::train::layer::FullyConnected({"name=fc1", "unit=2"});
+  std::shared_ptr<ml::train::Layer> fc2 =
+    ml::train::layer::FullyConnected({"name=fc2", "unit=2"});
+
+  model1->addLayer(fc1);
+  model2->addLayer(fc2);
+
+  model1->compile(ml::train::ExecutionMode::INFERENCE);
+  model2->compile(ml::train::ExecutionMode::INFERENCE);
+
+  EXPECT_THROW(model2->initialize(ml::train::ExecutionMode::INFERENCE, model1),
+               std::invalid_argument);
+}
+
+TEST(WeightSharing, sharing_unmatched_ref_n) {
+  std::shared_ptr<ml::train::Model> model1, model2;
+  model1 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+  model2 = ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  std::shared_ptr<ml::train::Layer> input1 =
+    ml::train::layer::Input({"name=input1", "input_shape=1:1:1"});
+  std::shared_ptr<ml::train::Layer> input2 =
+    ml::train::layer::Input({"name=input2", "input_shape=1:1:1"});
+
+  model1->addLayer(input1);
+  model2->addLayer(input2);
+
+  std::shared_ptr<ml::train::Layer> fc1 =
+    ml::train::layer::FullyConnected({"name=fc1", "unit=2"});
+  std::shared_ptr<ml::train::Layer> fc2 =
+    ml::train::layer::FullyConnected({"name=fc2", "unit=3"});
+
+  model1->addLayer(fc1);
+  model2->addLayer(fc2);
+
+  model1->compile(ml::train::ExecutionMode::INFERENCE);
+  model2->compile(ml::train::ExecutionMode::INFERENCE);
+
+  model1->initialize(ml::train::ExecutionMode::INFERENCE);
+  EXPECT_THROW(model2->initialize(ml::train::ExecutionMode::INFERENCE, model1),
+               std::invalid_argument);
+}
+
 /**
  * @brief Main gtest
  */


### PR DESCRIPTION
    [neuralnet] enable network sharing
    
     - Modified model compile and initialize to take a model reference pointer as a parameter for network sharing
     - Added test case for network sharing

    **Self evaluation:**
    1. Build test: [X]Passed [ ]Failed [ ]Skipped
    2. Run test: [X]Passed [ ]Failed [ ]Skipped
    
    Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>