### PR TITLE
[Layers] Add PerLayerEmbeddingLayer, with multi-uint16_quantized output

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -258,6 +258,7 @@ LOCAL_C_INCLUDES += $(NNTRAINER_INCLUDES) \
     $(LOCAL_PATH)/../models/gemma3 \
     $(LOCAL_PATH)/../models/deberta_v2 \
     $(LOCAL_PATH)/../models/gemma4 \
+    $(LOCAL_PATH)/../third_party \
 
 include $(BUILD_EXECUTABLE)
 

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -83,6 +83,7 @@ LOCAL_SRC_FILES := \
     ../layers/embedding_pooling_layer.cpp \
     ../layers/embedding_normalize_layer.cpp \
     ../layers/per_layer_slice.cpp \
+    ../layers/per_layer_embedding.cpp \
     ../layers/scalar_multiply.cpp \
     ../layers/logit_softcapping.cpp \
     ../layers/mha_core.cpp \
@@ -217,6 +218,7 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../layers/embedding_pooling_layer.cpp \
     ../layers/embedding_normalize_layer.cpp \
     ../layers/per_layer_slice.cpp \
+    ../layers/per_layer_embedding.cpp \
     ../layers/scalar_multiply.cpp \
     ../layers/logit_softcapping.cpp \
     ../layers/mha_core.cpp \

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -231,3 +231,17 @@ causallm_logit_softcapping_dep = declare_dependency(
     link_with: causallm_logit_softcapping,
     include_directories: causallm_layer_inc
 )
+
+causallm_per_layer_embedding_src_abs = [meson.current_source_dir() / 'per_layer_embedding.cpp']
+causallm_per_layer_embedding = shared_library(
+    'per_layer_embedding_layer',
+    causallm_per_layer_embedding_src_abs,
+    include_directories: [causallm_layer_inc, causallm_inc_nlohmann_inc],
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+causallm_per_layer_embedding_dep = declare_dependency(
+    link_with: causallm_per_layer_embedding,
+    include_directories: causallm_layer_inc
+)

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -1,5 +1,6 @@
 causallm_layer_inc_abs = [meson.current_source_dir()]
 causallm_layer_inc = [include_directories('.')]
+causallm_layer_nlohmann_inc = include_directories('..')
 
 causallm_rms_norm_src_abs = [meson.current_source_dir() / 'rms_norm.cpp']
 causallm_swiglu_src_abs = [meson.current_source_dir() / 'swiglu.cpp']
@@ -236,12 +237,12 @@ causallm_per_layer_embedding_src_abs = [meson.current_source_dir() / 'per_layer_
 causallm_per_layer_embedding = shared_library(
     'per_layer_embedding_layer',
     causallm_per_layer_embedding_src_abs,
-    include_directories: [causallm_layer_inc, causallm_inc_nlohmann_inc],
+    include_directories: [causallm_layer_inc, causallm_layer_nlohmann_inc],
     dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
     install: true,
     install_dir: application_install_dir
 )
 causallm_per_layer_embedding_dep = declare_dependency(
     link_with: causallm_per_layer_embedding,
-    include_directories: causallm_layer_inc
+    include_directories: [causallm_layer_inc, causallm_layer_nlohmann_inc]
 )

--- a/Applications/CausalLM/layers/per_layer_embedding.cpp
+++ b/Applications/CausalLM/layers/per_layer_embedding.cpp
@@ -7,12 +7,14 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author haehun.yang <haehun.yang@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  Loads per-layer embeddings from a single file and distributes them
- *         across multiple output tensors (one per consumed model layer).
+ * @brief  Per-layer embedding loader/dequantizer engine and the nntrainer
+ *         multi-output layer wrapping it.
  */
 
 #include "per_layer_embedding.h"
+#include <cerrno>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
@@ -20,6 +22,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <sstream>
+#include <stdexcept>
 #include <sys/stat.h>
 #if defined(_WIN32)
 #include <io.h>
@@ -29,7 +32,7 @@
 #include <unistd.h>
 #endif
 
-#include <nlohmann/json.hpp>
+#include "json.hpp"
 
 using json = nlohmann::json;
 
@@ -69,7 +72,6 @@ std::vector<T> parse_csv(const std::string &s, Conv conv) {
   std::stringstream ss(s);
   std::string item;
   while (std::getline(ss, item, ',')) {
-    // trim surrounding whitespace
     size_t b = item.find_first_not_of(" \t");
     if (b == std::string::npos)
       continue;
@@ -79,20 +81,42 @@ std::vector<T> parse_csv(const std::string &s, Conv conv) {
   return out;
 }
 
+// ── sfixed4 binary sidecar cache ──────────────────────────────────
+// The sfixed4 scale array is shape [vocab, num_layers] (e.g. 262144*35 ≈
+// 9.1M floats); re-parsing it from JSON on every cold start dominates load
+// time. After the first parse a compact binary is dumped next to the manifest
+// and the JSON parse is skipped on later loads. Invalidated on mtime change.
+constexpr char kPleSf4Magic[4] = {'P', 'S', '4', 'C'};
+constexpr uint32_t kPleSf4Version = 1;
+
+#pragma pack(push, 1)
+struct PleSf4CacheHeader {
+  char magic[4];
+  uint32_t version;
+  int64_t manifest_mtime;
+  uint64_t row_elems;
+  uint64_t layers;
+  uint64_t scale_count;
+  uint32_t lut_path_len;
+};
+#pragma pack(pop)
+
+int64_t ple_file_mtime_(const std::string &p) {
+  struct stat st {};
+  return (::stat(p.c_str(), &st) == 0) ? static_cast<int64_t>(st.st_mtime) : -1;
+}
+
+std::string ple_sf4_cache_path_(const std::string &manifest_path) {
+  return manifest_path + ".sf4cache";
+}
+
 } // namespace
 
-PerLayerEmbeddingLayer::PerLayerEmbeddingLayer() :
-  nntrainer::LayerImpl(),
-  ple_props(props::PleFilePath(), props::PleLayerCount(),
-            props::PlePerLayerWidth(), props::PleModelIndices(),
-            props::PleScales(), props::PleOffsets()) {}
-
-PerLayerEmbeddingLayer::~PerLayerEmbeddingLayer() { close_ple_file_(); }
-
-PerLayerEmbeddingLayer::PerLayerEmbeddingLayer(
-  PerLayerEmbeddingLayer &&rhs) noexcept :
-  nntrainer::LayerImpl(std::move(rhs)),
-  ple_props(std::move(rhs.ple_props)),
+// =====================================================================
+// PerLayerEmbeddingEngine
+// =====================================================================
+PerLayerEmbeddingEngine::PerLayerEmbeddingEngine(
+  PerLayerEmbeddingEngine &&rhs) noexcept :
   ple_fd_(rhs.ple_fd_),
   ple_mmap_(rhs.ple_mmap_),
   ple_u16_mmap_(rhs.ple_u16_mmap_),
@@ -103,28 +127,20 @@ PerLayerEmbeddingLayer::PerLayerEmbeddingLayer(
   ple_row_elems_(rhs.ple_row_elems_),
   ple_row_bytes_(rhs.ple_row_bytes_),
   ple_layers_(rhs.ple_layers_),
-  ple_output_count_(rhs.ple_output_count_),
   ple_vocab_(rhs.ple_vocab_),
-  ple_model_index_(std::move(rhs.ple_model_index_)),
-  ple_consumer_scale_(std::move(rhs.ple_consumer_scale_)),
-  ple_consumer_offset_(std::move(rhs.ple_consumer_offset_)),
   ple_scale_(rhs.ple_scale_),
   ple_offset_(rhs.ple_offset_),
   ple_row_layer_scales_(std::move(rhs.ple_row_layer_scales_)) {
-  // Clear the moved-from owning handles so only this object frees them.
   rhs.ple_fd_ = -1;
   rhs.ple_mmap_ = nullptr;
   rhs.ple_u16_mmap_ = nullptr;
   rhs.ple_file_size_ = 0;
 }
 
-PerLayerEmbeddingLayer &
-PerLayerEmbeddingLayer::operator=(PerLayerEmbeddingLayer &&rhs) noexcept {
+PerLayerEmbeddingEngine &
+PerLayerEmbeddingEngine::operator=(PerLayerEmbeddingEngine &&rhs) noexcept {
   if (this != &rhs) {
-    // Release our own mapping before taking ownership of rhs's.
-    close_ple_file_();
-    nntrainer::LayerImpl::operator=(std::move(rhs));
-    ple_props = std::move(rhs.ple_props);
+    close();
     ple_fd_ = rhs.ple_fd_;
     ple_mmap_ = rhs.ple_mmap_;
     ple_u16_mmap_ = rhs.ple_u16_mmap_;
@@ -135,11 +151,7 @@ PerLayerEmbeddingLayer::operator=(PerLayerEmbeddingLayer &&rhs) noexcept {
     ple_row_elems_ = rhs.ple_row_elems_;
     ple_row_bytes_ = rhs.ple_row_bytes_;
     ple_layers_ = rhs.ple_layers_;
-    ple_output_count_ = rhs.ple_output_count_;
     ple_vocab_ = rhs.ple_vocab_;
-    ple_model_index_ = std::move(rhs.ple_model_index_);
-    ple_consumer_scale_ = std::move(rhs.ple_consumer_scale_);
-    ple_consumer_offset_ = std::move(rhs.ple_consumer_offset_);
     ple_scale_ = rhs.ple_scale_;
     ple_offset_ = rhs.ple_offset_;
     ple_row_layer_scales_ = std::move(rhs.ple_row_layer_scales_);
@@ -150,6 +162,387 @@ PerLayerEmbeddingLayer::operator=(PerLayerEmbeddingLayer &&rhs) noexcept {
   }
   return *this;
 }
+
+void PerLayerEmbeddingEngine::close() {
+  if (ple_mmap_) {
+    munmap((void *)ple_mmap_, ple_file_size_);
+    ple_mmap_ = nullptr;
+  }
+  if (ple_u16_mmap_) {
+    munmap((void *)ple_u16_mmap_, ple_file_size_);
+    ple_u16_mmap_ = nullptr;
+  }
+  if (ple_fd_ >= 0) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+  }
+}
+
+void PerLayerEmbeddingEngine::open(const std::string &file_path,
+                                   size_t per_layer_width,
+                                   size_t raw_layer_count_hint) {
+  if (file_path.empty())
+    throw std::runtime_error("PerLayerEmbeddingEngine: file path is empty");
+  NNTR_THROW_IF(per_layer_width == 0, std::invalid_argument)
+    << "PerLayerEmbeddingEngine: per_layer_width is 0";
+
+  ple_per_layer_ = per_layer_width;
+  ple_is_quantized_ = ends_with(file_path, ".json");
+
+  if (ple_is_quantized_)
+    open_manifest_(file_path);
+  else
+    open_raw_u16_(file_path, raw_layer_count_hint);
+}
+
+bool PerLayerEmbeddingEngine::load_sf4_cache_(
+  const std::string &manifest_path) {
+  const std::string cpath = ple_sf4_cache_path_(manifest_path);
+  std::ifstream cf(cpath, std::ios::binary);
+  if (!cf.is_open())
+    return false;
+
+  PleSf4CacheHeader h{};
+  cf.read(reinterpret_cast<char *>(&h), sizeof(h));
+  const bool hdr_ok = static_cast<bool>(cf) &&
+                      std::memcmp(h.magic, kPleSf4Magic, 4) == 0 &&
+                      h.version == kPleSf4Version &&
+                      h.manifest_mtime == ple_file_mtime_(manifest_path);
+  if (!hdr_ok)
+    return false;
+
+  std::string lut_abs(h.lut_path_len, '\0');
+  cf.read(&lut_abs[0], h.lut_path_len);
+
+  ple_is_signed4_ = true;
+  ple_row_elems_ = h.row_elems;
+  ple_layers_ = h.layers;
+  ple_row_bytes_ = (ple_row_elems_ + 1) / 2;
+  ple_scale_ = 1.0f;
+  ple_offset_ = 0;
+  ple_row_layer_scales_.resize(h.scale_count);
+  cf.read(reinterpret_cast<char *>(ple_row_layer_scales_.data()),
+          static_cast<std::streamsize>(h.scale_count * sizeof(float)));
+  if (!static_cast<bool>(cf) || ple_layers_ == 0 ||
+      ple_layers_ * ple_per_layer_ != ple_row_elems_) {
+    reset_();
+    return false;
+  }
+
+  ple_fd_ = ::open(lut_abs.c_str(), O_RDONLY);
+  struct stat st;
+  if (ple_fd_ < 0 || fstat(ple_fd_, &st) != 0) {
+    reset_();
+    return false;
+  }
+  ple_file_size_ = static_cast<size_t>(st.st_size);
+  const size_t exp_vocab = ple_row_bytes_ ? ple_file_size_ / ple_row_bytes_ : 0;
+  const size_t scl_vocab = ple_row_layer_scales_.size() / ple_layers_;
+  if (ple_row_bytes_ == 0 || ple_file_size_ % ple_row_bytes_ != 0 ||
+      scl_vocab != exp_vocab) {
+    reset_();
+    return false;
+  }
+
+  void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
+  if (m == MAP_FAILED) {
+    reset_();
+    return false;
+  }
+  ple_mmap_ = static_cast<const uint8_t *>(m);
+  ple_vocab_ = exp_vocab;
+#ifdef POSIX_MADV_RANDOM
+  posix_madvise((void *)ple_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
+#endif
+  ml_logd(
+    "[PLE] sfixed4 from binary cache %s rows=%zu layers=%zu per_layer=%zu "
+    "scales=%zu (JSON parse skipped)",
+    cpath.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
+    ple_row_layer_scales_.size());
+  return true;
+}
+
+void PerLayerEmbeddingEngine::write_sf4_cache_(
+  const std::string &manifest_path, const std::string &lut_abs) const {
+  // Best-effort + atomic rename; a read-only model dir simply keeps JSON.
+  const std::string cpath = ple_sf4_cache_path_(manifest_path);
+  const std::string tmp = cpath + ".tmp";
+  std::ofstream wf(tmp, std::ios::binary | std::ios::trunc);
+  if (!wf.is_open())
+    return;
+  PleSf4CacheHeader h{};
+  std::memcpy(h.magic, kPleSf4Magic, 4);
+  h.version = kPleSf4Version;
+  h.manifest_mtime = ple_file_mtime_(manifest_path);
+  h.row_elems = ple_row_elems_;
+  h.layers = ple_layers_;
+  h.scale_count = ple_row_layer_scales_.size();
+  h.lut_path_len = static_cast<uint32_t>(lut_abs.size());
+  wf.write(reinterpret_cast<const char *>(&h), sizeof(h));
+  wf.write(lut_abs.data(), static_cast<std::streamsize>(lut_abs.size()));
+  wf.write(
+    reinterpret_cast<const char *>(ple_row_layer_scales_.data()),
+    static_cast<std::streamsize>(ple_row_layer_scales_.size() * sizeof(float)));
+  const bool ok = static_cast<bool>(wf);
+  wf.close();
+  if (ok && wf) {
+    if (std::rename(tmp.c_str(), cpath.c_str()) != 0)
+      std::remove(tmp.c_str());
+  } else {
+    std::remove(tmp.c_str());
+  }
+}
+
+void PerLayerEmbeddingEngine::open_manifest_(const std::string &manifest_path) {
+  // Fast path: sfixed4 binary sidecar cache (skips JSON parse).
+  if (load_sf4_cache_(manifest_path))
+    return;
+
+  std::ifstream mf(manifest_path);
+  if (!mf.is_open())
+    throw std::runtime_error("Failed to open PLE manifest: " + manifest_path);
+
+  json j;
+  mf >> j;
+
+  const std::string lut_rel = j.at("lut-path").get<std::string>();
+  const int row_elems = j.at("size").get<int>();
+  const std::string datatype = j.value("datatype", std::string("ufixed8"));
+  const auto &qp = j.at("quant-param");
+
+  ple_is_signed4_ = (datatype == "sfixed4");
+  if (!ple_is_signed4_ && datatype != "ufixed8")
+    throw std::runtime_error("PLE: unsupported datatype: " + datatype);
+
+  ple_row_elems_ = static_cast<size_t>(row_elems);
+  // sfixed4 packs two 4-bit values per byte; ufixed8 is one byte per element.
+  ple_row_bytes_ = ple_is_signed4_ ? (ple_row_elems_ + 1) / 2 : ple_row_elems_;
+  ple_layers_ = ple_row_elems_ / ple_per_layer_;
+
+  if (ple_layers_ * ple_per_layer_ != ple_row_elems_)
+    throw std::runtime_error("PLE 'size' not divisible by per_layer width");
+
+  if (ple_is_signed4_) {
+    const auto &scale_arr = qp.at("scale");
+    if (!scale_arr.is_array())
+      throw std::runtime_error("PLE sfixed4: quant-param.scale must be array");
+    ple_row_layer_scales_.clear();
+    ple_row_layer_scales_.reserve(scale_arr.size());
+    for (const auto &v : scale_arr)
+      ple_row_layer_scales_.push_back(v.get<float>());
+    if (ple_row_layer_scales_.size() % ple_layers_ != 0)
+      throw std::runtime_error(
+        "PLE sfixed4: scale array length not divisible by num_layers");
+    ple_scale_ = 1.0f;
+    ple_offset_ = 0;
+  } else {
+    ple_scale_ = qp.at("scale").get<float>();
+    ple_offset_ = qp.at("offset").get<int>();
+  }
+
+  std::string lut_abs = rebase_relative_to_model_file(lut_rel, manifest_path);
+
+  ple_fd_ = ::open(lut_abs.c_str(), O_RDONLY);
+  if (ple_fd_ < 0)
+    throw std::runtime_error("open PLE bin: " + lut_abs);
+
+  struct stat st;
+  if (fstat(ple_fd_, &st) < 0) {
+    reset_();
+    throw std::runtime_error("stat PLE bin: " + lut_abs);
+  }
+  ple_file_size_ = static_cast<size_t>(st.st_size);
+  if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
+      ple_file_size_ % ple_row_bytes_ != 0) {
+    reset_();
+    throw std::runtime_error("PLE bin size not a positive multiple of row "
+                             "bytes");
+  }
+  ple_vocab_ = ple_file_size_ / ple_row_bytes_;
+
+  if (ple_is_signed4_) {
+    const size_t scale_vocab = ple_row_layer_scales_.size() / ple_layers_;
+    if (scale_vocab != ple_vocab_)
+      throw std::runtime_error(
+        "PLE sfixed4 scale vocab=" + std::to_string(scale_vocab) +
+        " != bin vocab=" + std::to_string(ple_vocab_));
+  }
+
+  void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
+  if (m == MAP_FAILED) {
+    reset_();
+    throw std::runtime_error("mmap PLE bin: " + lut_abs);
+  }
+  ple_mmap_ = static_cast<const uint8_t *>(m);
+#ifdef POSIX_MADV_RANDOM
+  posix_madvise((void *)ple_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
+#endif
+
+  if (ple_is_signed4_) {
+    ml_logd("[PLE] sfixed4 (rowwise+layerwise) mmaped %s rows=%zu layers=%zu "
+            "per_layer=%zu scales=%zu",
+            lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
+            ple_row_layer_scales_.size());
+    // Persist a sidecar so the next cold start skips the JSON scale parse.
+    write_sf4_cache_(manifest_path, lut_abs);
+  } else {
+    ml_logd("[PLE] ufixed8 (tensorwise) mmaped %s rows=%zu layers=%zu "
+            "per_layer=%zu scale=%f offset=%d",
+            lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
+            ple_scale_, ple_offset_);
+  }
+}
+
+void PerLayerEmbeddingEngine::open_raw_u16_(const std::string &file_path,
+                                            size_t raw_layer_count_hint) {
+  // raw UINT16: row = layers * per_layer uint16, layout derived from the
+  // caller-provided layer count.
+  if (raw_layer_count_hint == 0)
+    throw std::runtime_error(
+      "PLE raw uint16: layer count must be provided before loading");
+  ple_layers_ = raw_layer_count_hint;
+  ple_row_elems_ = ple_layers_ * ple_per_layer_;
+  ple_row_bytes_ = ple_row_elems_ * sizeof(uint16_t);
+  ple_is_signed4_ = false;
+  ple_scale_ = 1.0f;
+  ple_offset_ = 0;
+
+  ple_fd_ = ::open(file_path.c_str(), O_RDONLY);
+  if (ple_fd_ < 0)
+    throw std::runtime_error("open PLE bin: " + file_path);
+
+  struct stat st;
+  if (fstat(ple_fd_, &st) < 0) {
+    reset_();
+    throw std::runtime_error("stat PLE bin: " + file_path);
+  }
+  ple_file_size_ = static_cast<size_t>(st.st_size);
+  if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
+      ple_file_size_ % ple_row_bytes_ != 0) {
+    reset_();
+    throw std::runtime_error(
+      "PLE raw uint16: file size not a positive multiple of row bytes "
+      "(expected multiple of " +
+      std::to_string(ple_row_bytes_) + ")");
+  }
+  ple_vocab_ = ple_file_size_ / ple_row_bytes_;
+
+  void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
+  if (m == MAP_FAILED) {
+    reset_();
+    throw std::runtime_error("mmap PLE bin: " + file_path);
+  }
+  ple_u16_mmap_ = static_cast<const uint16_t *>(m);
+#ifdef POSIX_MADV_RANDOM
+  posix_madvise((void *)ple_u16_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
+#endif
+  ml_logd("[PLE] raw uint16 mmaped %s rows=%zu layers=%zu per_layer=%zu",
+          file_path.c_str(), ple_vocab_, ple_layers_, ple_per_layer_);
+}
+
+void PerLayerEmbeddingEngine::reset_() {
+  if (ple_mmap_) {
+    munmap((void *)ple_mmap_, ple_file_size_);
+    ple_mmap_ = nullptr;
+  }
+  if (ple_u16_mmap_) {
+    munmap((void *)ple_u16_mmap_, ple_file_size_);
+    ple_u16_mmap_ = nullptr;
+  }
+  if (ple_fd_ >= 0) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+  }
+  ple_file_size_ = 0;
+  ple_vocab_ = 0;
+}
+
+void PerLayerEmbeddingEngine::fillToken(
+  int token_id, const std::vector<int> &model_index,
+  const std::vector<float> &consumer_scale,
+  const std::vector<int> &consumer_offset, const std::vector<uint16_t *> &dsts,
+  size_t dst_elem_offset) const {
+  if (!isOpen())
+    return;
+  NNTR_THROW_IF(token_id < 0, std::invalid_argument)
+    << "PerLayerEmbeddingEngine: negative token id " << token_id;
+  const size_t tok = static_cast<size_t>(token_id);
+  NNTR_THROW_IF(tok >= ple_vocab_, std::invalid_argument)
+    << "PerLayerEmbeddingEngine: token id " << tok << " >= vocab "
+    << ple_vocab_;
+
+  const size_t per_layer = ple_per_layer_;
+  const size_t slots = dsts.size();
+
+  if (ple_is_quantized_) {
+    const uint8_t *row = ple_mmap_ + tok * ple_row_bytes_;
+    if (ple_is_signed4_) {
+      const size_t per_layer_bytes = per_layer / 2;
+      const float *row_scales =
+        ple_row_layer_scales_.data() + tok * ple_layers_;
+      for (size_t l = 0; l < slots; ++l) {
+        const size_t ml = static_cast<size_t>(model_index[l]);
+        dequant_sfixed4_requant_u16_(
+          row + ml * per_layer_bytes, per_layer, row_scales[ml],
+          consumer_scale[l], consumer_offset[l], dsts[l] + dst_elem_offset);
+      }
+    } else {
+      const size_t per_layer_bytes = per_layer; // ufixed8: one byte per elem
+      for (size_t l = 0; l < slots; ++l) {
+        const size_t ml = static_cast<size_t>(model_index[l]);
+        dequant_bytes_requant_u16_(
+          row + ml * per_layer_bytes, per_layer, ple_scale_, ple_offset_,
+          consumer_scale[l], consumer_offset[l], dsts[l] + dst_elem_offset);
+      }
+    }
+  } else {
+    const uint16_t *row = ple_u16_mmap_ + tok * ple_row_elems_;
+    for (size_t l = 0; l < slots; ++l) {
+      const size_t ml = static_cast<size_t>(model_index[l]);
+      std::memcpy(dsts[l] + dst_elem_offset, row + ml * per_layer,
+                  per_layer * sizeof(uint16_t));
+    }
+  }
+}
+
+void PerLayerEmbeddingEngine::dequant_sfixed4_requant_u16_(
+  const uint8_t *packed, size_t elems, float row_scale, float out_scale,
+  int out_offset, uint16_t *dst) {
+  const float inv_out = 1.0f / out_scale;
+  auto requant = [&](unsigned nib) -> uint16_t {
+    const float f = static_cast<float>(s4_decode(nib)) * row_scale;
+    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
+    return static_cast<uint16_t>(std::max(0, std::min(65535, q)));
+  };
+  const size_t whole = elems / 2;
+  for (size_t i = 0; i < whole; ++i) {
+    const uint8_t b = packed[i];
+    dst[2 * i] = requant(b & 0x0F);
+    dst[2 * i + 1] = requant((b >> 4) & 0x0F);
+  }
+  if (elems & 1)
+    dst[2 * whole] = requant(packed[whole] & 0x0F);
+}
+
+void PerLayerEmbeddingEngine::dequant_bytes_requant_u16_(
+  const uint8_t *src, size_t elems, float lut_scale, int lut_offset,
+  float out_scale, int out_offset, uint16_t *dst) {
+  const float inv_out = 1.0f / out_scale;
+  for (size_t i = 0; i < elems; ++i) {
+    const float f = (static_cast<float>(src[i]) + lut_offset) * lut_scale;
+    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
+    dst[i] = static_cast<uint16_t>(std::max(0, std::min(65535, q)));
+  }
+}
+
+// =====================================================================
+// PerLayerEmbeddingLayer (thin wrapper over the engine)
+// =====================================================================
+PerLayerEmbeddingLayer::PerLayerEmbeddingLayer() :
+  nntrainer::LayerImpl(),
+  ple_props(props::PleFilePath(), props::PleLayerCount(),
+            props::PlePerLayerWidth(), props::PleModelIndices(),
+            props::PleScales(), props::PleOffsets()) {}
 
 void PerLayerEmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
@@ -164,37 +557,30 @@ void PerLayerEmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
   auto &file_prop = std::get<props::PleFilePath>(ple_props);
   NNTR_THROW_IF(file_prop.empty(), std::invalid_argument)
     << "PerLayerEmbeddingLayer: ple_file_path property not set";
-  const std::string ple_file_name = file_prop.get();
 
   ple_per_layer_ =
     std::get<props::PlePerLayerWidth>(ple_props).empty()
       ? 256
       : static_cast<size_t>(std::get<props::PlePerLayerWidth>(ple_props).get());
-  NNTR_THROW_IF(ple_per_layer_ == 0, std::invalid_argument)
-    << "PerLayerEmbeddingLayer: ple_per_layer_width is 0";
 
-  // Output count must be known before open_ple_file_ for the raw-uint16 path,
-  // whose row layout is derived from it.
+  // Output count must be known before open() for the raw-uint16 layout.
   auto &count_prop = std::get<props::PleLayerCount>(ple_props);
   const bool has_count = !count_prop.empty();
   if (has_count)
     ple_output_count_ = static_cast<size_t>(count_prop.get());
 
-  open_ple_file_(ple_file_name);
+  engine_.open(file_prop.get(), ple_per_layer_, ple_output_count_);
 
   // JSON manifests expose the full model layer count; default the output count
   // to it when not explicitly given.
-  if (!has_count) {
-    NNTR_THROW_IF(!ple_is_quantized_, std::invalid_argument)
-      << "PerLayerEmbeddingLayer: ple_layer_count is required for raw uint16";
-    ple_output_count_ = ple_layers_;
-  }
+  if (!has_count)
+    ple_output_count_ = engine_.numLayers();
 
   NNTR_THROW_IF(ple_output_count_ == 0, std::invalid_argument)
     << "PerLayerEmbeddingLayer: output count is 0";
-  NNTR_THROW_IF(ple_output_count_ > ple_layers_, std::invalid_argument)
+  NNTR_THROW_IF(ple_output_count_ > engine_.numLayers(), std::invalid_argument)
     << "PerLayerEmbeddingLayer: output count (" << ple_output_count_
-    << ") exceeds available layers (" << ple_layers_ << ")";
+    << ") exceeds available layers (" << engine_.numLayers() << ")";
 
   // Resolve per-output model-layer index (identity if unset).
   auto &idx_prop = std::get<props::PleModelIndices>(ple_props);
@@ -213,10 +599,11 @@ void PerLayerEmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
   }
   for (size_t l = 0; l < ple_output_count_; ++l)
     NNTR_THROW_IF(ple_model_index_[l] < 0 ||
-                    static_cast<size_t>(ple_model_index_[l]) >= ple_layers_,
+                    static_cast<size_t>(ple_model_index_[l]) >=
+                      engine_.numLayers(),
                   std::invalid_argument)
       << "PerLayerEmbeddingLayer: model index " << ple_model_index_[l]
-      << " out of range [0," << ple_layers_ << ")";
+      << " out of range [0," << engine_.numLayers() << ")";
 
   // Resolve per-output consumer-space quant scale/offset (1.0 / 0 if unset).
   auto &scale_prop = std::get<props::PleScales>(ple_props);
@@ -271,7 +658,7 @@ void PerLayerEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
 void PerLayerEmbeddingLayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
-  if (!ple_mmap_ && !ple_u16_mmap_)
+  if (!engine_.isOpen())
     return;
 
   auto &input = context.getInput(SINGLE_INOUT_IDX);
@@ -300,51 +687,10 @@ void PerLayerEmbeddingLayer::incremental_forwarding(
     const float *token_data = input.getAddress<float>(b * in_feature_len);
 
     for (int t = 0; t < iter; ++t) {
-      const float tok_f = token_data[t];
-      NNTR_THROW_IF(tok_f < 0.0f, std::invalid_argument)
-        << "PerLayerEmbeddingLayer: negative token id " << tok_f;
-      const size_t token_id = static_cast<size_t>(tok_f);
-      NNTR_THROW_IF(token_id >= ple_vocab_, std::invalid_argument)
-        << "PerLayerEmbeddingLayer: token id " << token_id << " >= vocab "
-        << ple_vocab_;
-
-      const size_t dst_off = static_cast<size_t>(t) * per_layer_elems;
-
-      if (ple_is_quantized_) {
-        const uint8_t *row = ple_mmap_ + token_id * ple_row_bytes_;
-
-        if (ple_is_signed4_) {
-          // sfixed4: two signed 4-bit nibbles per byte (half a byte per elem).
-          const size_t per_layer_bytes = per_layer_elems / 2;
-          const float *row_scales =
-            ple_row_layer_scales_.data() + token_id * ple_layers_;
-          for (size_t l = 0; l < ple_output_count_; ++l) {
-            const size_t ml = static_cast<size_t>(ple_model_index_[l]);
-            dequant_sfixed4_requant_u16_(
-              row + ml * per_layer_bytes, per_layer_elems, row_scales[ml],
-              ple_consumer_scale_[l], ple_consumer_offset_[l],
-              out_base[l] + dst_off);
-          }
-        } else {
-          // ufixed8: one unsigned byte per element.
-          const size_t per_layer_bytes = per_layer_elems;
-          for (size_t l = 0; l < ple_output_count_; ++l) {
-            const size_t ml = static_cast<size_t>(ple_model_index_[l]);
-            dequant_bytes_requant_u16_(
-              row + ml * per_layer_bytes, per_layer_elems, ple_scale_,
-              ple_offset_, ple_consumer_scale_[l], ple_consumer_offset_[l],
-              out_base[l] + dst_off);
-          }
-        }
-      } else {
-        // raw uint16: per-layer slice memcpy (already in consumer space).
-        const uint16_t *row = ple_u16_mmap_ + token_id * ple_row_elems_;
-        for (size_t l = 0; l < ple_output_count_; ++l) {
-          const size_t ml = static_cast<size_t>(ple_model_index_[l]);
-          std::memcpy(out_base[l] + dst_off, row + ml * per_layer_elems,
-                      per_layer_elems * sizeof(uint16_t));
-        }
-      }
+      const int token_id = static_cast<int>(token_data[t]);
+      engine_.fillToken(token_id, ple_model_index_, ple_consumer_scale_,
+                        ple_consumer_offset_, out_base,
+                        static_cast<size_t>(t) * per_layer_elems);
     }
   }
 }
@@ -364,208 +710,6 @@ void PerLayerEmbeddingLayer::setProperty(
   const std::vector<std::string> &values) {
   auto remain_props = nntrainer::loadProperties(values, ple_props);
   LayerImpl::setProperty(remain_props);
-}
-
-void PerLayerEmbeddingLayer::open_ple_file_(const std::string &ple_file_name) {
-  if (ple_file_name.empty())
-    throw std::runtime_error("PerLayerEmbeddingLayer: ple_file_name is empty");
-
-  ple_is_quantized_ = ends_with(ple_file_name, ".json");
-
-  if (ple_is_quantized_) {
-    std::ifstream mf(ple_file_name);
-    if (!mf.is_open())
-      throw std::runtime_error("Failed to open PLE manifest: " + ple_file_name);
-
-    json j;
-    mf >> j;
-
-    const std::string lut_rel = j.at("lut-path").get<std::string>();
-    const int row_elems = j.at("size").get<int>();
-    const std::string datatype = j.value("datatype", std::string("ufixed8"));
-    const auto &qp = j.at("quant-param");
-
-    ple_is_signed4_ = (datatype == "sfixed4");
-    if (!ple_is_signed4_ && datatype != "ufixed8")
-      throw std::runtime_error("PLE: unsupported datatype: " + datatype);
-
-    ple_row_elems_ = static_cast<size_t>(row_elems);
-    // sfixed4 packs two 4-bit values per byte; ufixed8 is one byte per element.
-    ple_row_bytes_ =
-      ple_is_signed4_ ? (ple_row_elems_ + 1) / 2 : ple_row_elems_;
-    ple_layers_ = ple_row_elems_ / ple_per_layer_;
-
-    if (ple_layers_ * ple_per_layer_ != ple_row_elems_)
-      throw std::runtime_error("PLE 'size' not divisible by per_layer width");
-
-    if (ple_is_signed4_) {
-      const auto &scale_arr = qp.at("scale");
-      if (!scale_arr.is_array())
-        throw std::runtime_error(
-          "PLE sfixed4: quant-param.scale must be an array");
-      ple_row_layer_scales_.clear();
-      ple_row_layer_scales_.reserve(scale_arr.size());
-      for (const auto &v : scale_arr)
-        ple_row_layer_scales_.push_back(v.get<float>());
-
-      if (ple_row_layer_scales_.size() % ple_layers_ != 0)
-        throw std::runtime_error(
-          "PLE sfixed4: scale array length not divisible by num_layers");
-      ple_scale_ = 1.0f;
-      ple_offset_ = 0;
-    } else {
-      ple_scale_ = qp.at("scale").get<float>();
-      ple_offset_ = qp.at("offset").get<int>();
-    }
-
-    std::string lut_abs = rebase_relative_to_model_file(lut_rel, ple_file_name);
-
-    ple_fd_ = open(lut_abs.c_str(), O_RDONLY);
-    if (ple_fd_ < 0)
-      throw std::runtime_error("open PLE bin: " + lut_abs);
-
-    struct stat st;
-    if (fstat(ple_fd_, &st) < 0) {
-      ::close(ple_fd_);
-      ple_fd_ = -1;
-      throw std::runtime_error("stat PLE bin: " + lut_abs);
-    }
-    ple_file_size_ = static_cast<size_t>(st.st_size);
-    if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
-        ple_file_size_ % ple_row_bytes_ != 0) {
-      ::close(ple_fd_);
-      ple_fd_ = -1;
-      throw std::runtime_error("PLE bin size not a positive multiple of row "
-                               "bytes");
-    }
-    ple_vocab_ = ple_file_size_ / ple_row_bytes_;
-
-    if (ple_is_signed4_) {
-      const size_t scale_vocab = ple_row_layer_scales_.size() / ple_layers_;
-      if (scale_vocab != ple_vocab_)
-        throw std::runtime_error(
-          "PLE sfixed4 scale vocab=" + std::to_string(scale_vocab) +
-          " != bin vocab=" + std::to_string(ple_vocab_));
-    }
-
-    void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
-    if (m == MAP_FAILED) {
-      ::close(ple_fd_);
-      ple_fd_ = -1;
-      throw std::runtime_error("mmap PLE bin: " + lut_abs);
-    }
-    ple_mmap_ = static_cast<const uint8_t *>(m);
-#ifdef POSIX_MADV_RANDOM
-    posix_madvise((void *)ple_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
-#endif
-
-    if (ple_is_signed4_) {
-      ml_logd("[PLE] sfixed4 (rowwise+layerwise) mmaped %s rows=%zu layers=%zu "
-              "per_layer=%zu scales=%zu",
-              lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
-              ple_row_layer_scales_.size());
-    } else {
-      ml_logd("[PLE] ufixed8 (tensorwise) mmaped %s rows=%zu layers=%zu "
-              "per_layer=%zu scale=%f offset=%d",
-              lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
-              ple_scale_, ple_offset_);
-    }
-    return;
-  }
-
-  // raw UINT16: no manifest. Row layout is derived from the output count, which
-  // the caller (finalize) must have set before reaching here.
-  if (ple_output_count_ == 0)
-    throw std::runtime_error(
-      "PLE raw uint16: ple_layer_count must be set before loading");
-  ple_row_elems_ = ple_output_count_ * ple_per_layer_;
-  ple_row_bytes_ = ple_row_elems_ * sizeof(uint16_t);
-  ple_layers_ = ple_output_count_;
-  ple_is_signed4_ = false;
-  ple_scale_ = 1.0f;
-  ple_offset_ = 0;
-
-  ple_fd_ = open(ple_file_name.c_str(), O_RDONLY);
-  if (ple_fd_ < 0)
-    throw std::runtime_error("open PLE bin: " + ple_file_name);
-
-  struct stat st;
-  if (fstat(ple_fd_, &st) < 0) {
-    ::close(ple_fd_);
-    ple_fd_ = -1;
-    throw std::runtime_error("stat PLE bin: " + ple_file_name);
-  }
-  ple_file_size_ = static_cast<size_t>(st.st_size);
-  if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
-      ple_file_size_ % ple_row_bytes_ != 0) {
-    ::close(ple_fd_);
-    ple_fd_ = -1;
-    throw std::runtime_error(
-      "PLE bin size not a positive multiple of row bytes (expected multiple "
-      "of " +
-      std::to_string(ple_row_bytes_) + ", got " +
-      std::to_string(ple_file_size_) + ")");
-  }
-  ple_vocab_ = ple_file_size_ / ple_row_bytes_;
-
-  void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
-  if (m == MAP_FAILED) {
-    ::close(ple_fd_);
-    ple_fd_ = -1;
-    throw std::runtime_error("mmap PLE bin: " + ple_file_name);
-  }
-  ple_u16_mmap_ = static_cast<const uint16_t *>(m);
-#ifdef POSIX_MADV_RANDOM
-  posix_madvise((void *)ple_u16_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
-#endif
-
-  ml_logd("[PLE] raw uint16 mmaped %s rows=%zu layers=%zu per_layer=%zu",
-          ple_file_name.c_str(), ple_vocab_, ple_layers_, ple_per_layer_);
-}
-
-void PerLayerEmbeddingLayer::close_ple_file_() {
-  if (ple_mmap_) {
-    munmap((void *)ple_mmap_, ple_file_size_);
-    ple_mmap_ = nullptr;
-  }
-  if (ple_u16_mmap_) {
-    munmap((void *)ple_u16_mmap_, ple_file_size_);
-    ple_u16_mmap_ = nullptr;
-  }
-  if (ple_fd_ >= 0) {
-    ::close(ple_fd_);
-    ple_fd_ = -1;
-  }
-}
-
-void PerLayerEmbeddingLayer::dequant_sfixed4_requant_u16_(
-  const uint8_t *packed, size_t elems, float row_scale, float out_scale,
-  int out_offset, uint16_t *dst) const {
-  const float inv_out = 1.0f / out_scale;
-  auto requant = [&](unsigned nib) -> uint16_t {
-    const float f = static_cast<float>(s4_decode(nib)) * row_scale;
-    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
-    return static_cast<uint16_t>(std::max(0, std::min(65535, q)));
-  };
-  const size_t whole = elems / 2;
-  for (size_t i = 0; i < whole; ++i) {
-    const uint8_t b = packed[i];
-    dst[2 * i] = requant(b & 0x0F);
-    dst[2 * i + 1] = requant((b >> 4) & 0x0F);
-  }
-  if (elems & 1)
-    dst[2 * whole] = requant(packed[whole] & 0x0F);
-}
-
-void PerLayerEmbeddingLayer::dequant_bytes_requant_u16_(
-  const uint8_t *src, size_t elems, float lut_scale, int lut_offset,
-  float out_scale, int out_offset, uint16_t *dst) const {
-  const float inv_out = 1.0f / out_scale;
-  for (size_t i = 0; i < elems; ++i) {
-    const float f = (static_cast<float>(src[i]) + lut_offset) * lut_scale;
-    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
-    dst[i] = static_cast<uint16_t>(std::max(0, std::min(65535, q)));
-  }
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/per_layer_embedding.cpp
+++ b/Applications/CausalLM/layers/per_layer_embedding.cpp
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   per_layer_embedding.cpp
+ * @date   17 June 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author haehun.yang <haehun.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Loads per-layer embeddings from a single file and distributes them
+ *         across multiple output tensors (one per consumed model layer).
+ */
+
+#include "per_layer_embedding.h"
+#include <cmath>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <layer_context.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <sstream>
+#include <sys/stat.h>
+#if defined(_WIN32)
+#include <io.h>
+#include <mman_windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace causallm {
+
+namespace {
+
+constexpr size_t SINGLE_INOUT_IDX = 0;
+
+/** @brief return true if string @a s ends with suffix @a suf */
+bool ends_with(const std::string &s, const std::string &suf) {
+  return s.size() >= suf.size() &&
+         0 == s.compare(s.size() - suf.size(), suf.size(), suf);
+}
+
+/** @brief return the directory component of a path (empty if none) */
+std::string dirname(const std::string &p) {
+  auto pos = p.find_last_of('/');
+  return (pos == std::string::npos) ? std::string() : p.substr(0, pos);
+}
+
+/** @brief rebase a relative path against the manifest's directory */
+std::string rebase_relative_to_model_file(const std::string &path,
+                                          const std::string &manifest_path) {
+  if (path.empty() || path[0] == '/' || manifest_path.empty())
+    return path;
+  const std::string base = dirname(manifest_path);
+  if (base.empty()) // bare manifest (e.g. "ple.json"): keep path relative
+    return path;
+  return base + "/" + path;
+}
+
+/** @brief parse a comma-separated list into a vector via the given converter */
+template <typename T, typename Conv>
+std::vector<T> parse_csv(const std::string &s, Conv conv) {
+  std::vector<T> out;
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    // trim surrounding whitespace
+    size_t b = item.find_first_not_of(" \t");
+    if (b == std::string::npos)
+      continue;
+    size_t e = item.find_last_not_of(" \t");
+    out.push_back(conv(item.substr(b, e - b + 1)));
+  }
+  return out;
+}
+
+} // namespace
+
+PerLayerEmbeddingLayer::PerLayerEmbeddingLayer() :
+  nntrainer::LayerImpl(),
+  ple_props(props::PleFilePath(), props::PleLayerCount(),
+            props::PlePerLayerWidth(), props::PleModelIndices(),
+            props::PleScales(), props::PleOffsets()) {}
+
+PerLayerEmbeddingLayer::~PerLayerEmbeddingLayer() { close_ple_file_(); }
+
+PerLayerEmbeddingLayer::PerLayerEmbeddingLayer(
+  PerLayerEmbeddingLayer &&rhs) noexcept :
+  nntrainer::LayerImpl(std::move(rhs)),
+  ple_props(std::move(rhs.ple_props)),
+  ple_fd_(rhs.ple_fd_),
+  ple_mmap_(rhs.ple_mmap_),
+  ple_u16_mmap_(rhs.ple_u16_mmap_),
+  ple_file_size_(rhs.ple_file_size_),
+  ple_is_quantized_(rhs.ple_is_quantized_),
+  ple_is_signed4_(rhs.ple_is_signed4_),
+  ple_per_layer_(rhs.ple_per_layer_),
+  ple_row_elems_(rhs.ple_row_elems_),
+  ple_row_bytes_(rhs.ple_row_bytes_),
+  ple_layers_(rhs.ple_layers_),
+  ple_output_count_(rhs.ple_output_count_),
+  ple_vocab_(rhs.ple_vocab_),
+  ple_model_index_(std::move(rhs.ple_model_index_)),
+  ple_consumer_scale_(std::move(rhs.ple_consumer_scale_)),
+  ple_consumer_offset_(std::move(rhs.ple_consumer_offset_)),
+  ple_scale_(rhs.ple_scale_),
+  ple_offset_(rhs.ple_offset_),
+  ple_row_layer_scales_(std::move(rhs.ple_row_layer_scales_)) {
+  // Clear the moved-from owning handles so only this object frees them.
+  rhs.ple_fd_ = -1;
+  rhs.ple_mmap_ = nullptr;
+  rhs.ple_u16_mmap_ = nullptr;
+  rhs.ple_file_size_ = 0;
+}
+
+PerLayerEmbeddingLayer &
+PerLayerEmbeddingLayer::operator=(PerLayerEmbeddingLayer &&rhs) noexcept {
+  if (this != &rhs) {
+    // Release our own mapping before taking ownership of rhs's.
+    close_ple_file_();
+    nntrainer::LayerImpl::operator=(std::move(rhs));
+    ple_props = std::move(rhs.ple_props);
+    ple_fd_ = rhs.ple_fd_;
+    ple_mmap_ = rhs.ple_mmap_;
+    ple_u16_mmap_ = rhs.ple_u16_mmap_;
+    ple_file_size_ = rhs.ple_file_size_;
+    ple_is_quantized_ = rhs.ple_is_quantized_;
+    ple_is_signed4_ = rhs.ple_is_signed4_;
+    ple_per_layer_ = rhs.ple_per_layer_;
+    ple_row_elems_ = rhs.ple_row_elems_;
+    ple_row_bytes_ = rhs.ple_row_bytes_;
+    ple_layers_ = rhs.ple_layers_;
+    ple_output_count_ = rhs.ple_output_count_;
+    ple_vocab_ = rhs.ple_vocab_;
+    ple_model_index_ = std::move(rhs.ple_model_index_);
+    ple_consumer_scale_ = std::move(rhs.ple_consumer_scale_);
+    ple_consumer_offset_ = std::move(rhs.ple_consumer_offset_);
+    ple_scale_ = rhs.ple_scale_;
+    ple_offset_ = rhs.ple_offset_;
+    ple_row_layer_scales_ = std::move(rhs.ple_row_layer_scales_);
+    rhs.ple_fd_ = -1;
+    rhs.ple_mmap_ = nullptr;
+    rhs.ple_u16_mmap_ = nullptr;
+    rhs.ple_file_size_ = 0;
+  }
+  return *this;
+}
+
+void PerLayerEmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "PerLayerEmbeddingLayer takes only one input";
+
+  // Force the token-ID input to FP32 (see EmbeddingLayer::finalize): the layer
+  // is often the model entry point, so the input dim would otherwise inherit
+  // the activation dtype (e.g. UINT16), but token IDs index a vocab that can
+  // exceed UINT16 range.
+  context.setInputDataType(nntrainer::TensorDim::DataType::FP32);
+
+  auto &file_prop = std::get<props::PleFilePath>(ple_props);
+  NNTR_THROW_IF(file_prop.empty(), std::invalid_argument)
+    << "PerLayerEmbeddingLayer: ple_file_path property not set";
+  const std::string ple_file_name = file_prop.get();
+
+  ple_per_layer_ =
+    std::get<props::PlePerLayerWidth>(ple_props).empty()
+      ? 256
+      : static_cast<size_t>(std::get<props::PlePerLayerWidth>(ple_props).get());
+  NNTR_THROW_IF(ple_per_layer_ == 0, std::invalid_argument)
+    << "PerLayerEmbeddingLayer: ple_per_layer_width is 0";
+
+  // Output count must be known before open_ple_file_ for the raw-uint16 path,
+  // whose row layout is derived from it.
+  auto &count_prop = std::get<props::PleLayerCount>(ple_props);
+  const bool has_count = !count_prop.empty();
+  if (has_count)
+    ple_output_count_ = static_cast<size_t>(count_prop.get());
+
+  open_ple_file_(ple_file_name);
+
+  // JSON manifests expose the full model layer count; default the output count
+  // to it when not explicitly given.
+  if (!has_count) {
+    NNTR_THROW_IF(!ple_is_quantized_, std::invalid_argument)
+      << "PerLayerEmbeddingLayer: ple_layer_count is required for raw uint16";
+    ple_output_count_ = ple_layers_;
+  }
+
+  NNTR_THROW_IF(ple_output_count_ == 0, std::invalid_argument)
+    << "PerLayerEmbeddingLayer: output count is 0";
+  NNTR_THROW_IF(ple_output_count_ > ple_layers_, std::invalid_argument)
+    << "PerLayerEmbeddingLayer: output count (" << ple_output_count_
+    << ") exceeds available layers (" << ple_layers_ << ")";
+
+  // Resolve per-output model-layer index (identity if unset).
+  auto &idx_prop = std::get<props::PleModelIndices>(ple_props);
+  if (idx_prop.empty()) {
+    ple_model_index_.resize(ple_output_count_);
+    for (size_t l = 0; l < ple_output_count_; ++l)
+      ple_model_index_[l] = static_cast<int>(l);
+  } else {
+    ple_model_index_ = parse_csv<int>(
+      idx_prop.get(), [](const std::string &t) { return std::stoi(t); });
+    NNTR_THROW_IF(ple_model_index_.size() != ple_output_count_,
+                  std::invalid_argument)
+      << "PerLayerEmbeddingLayer: ple_model_indices count ("
+      << ple_model_index_.size() << ") != output count (" << ple_output_count_
+      << ")";
+  }
+  for (size_t l = 0; l < ple_output_count_; ++l)
+    NNTR_THROW_IF(ple_model_index_[l] < 0 ||
+                    static_cast<size_t>(ple_model_index_[l]) >= ple_layers_,
+                  std::invalid_argument)
+      << "PerLayerEmbeddingLayer: model index " << ple_model_index_[l]
+      << " out of range [0," << ple_layers_ << ")";
+
+  // Resolve per-output consumer-space quant scale/offset (1.0 / 0 if unset).
+  auto &scale_prop = std::get<props::PleScales>(ple_props);
+  if (scale_prop.empty()) {
+    ple_consumer_scale_.assign(ple_output_count_, 1.0f);
+  } else {
+    ple_consumer_scale_ = parse_csv<float>(
+      scale_prop.get(), [](const std::string &t) { return std::stof(t); });
+    NNTR_THROW_IF(ple_consumer_scale_.size() != ple_output_count_,
+                  std::invalid_argument)
+      << "PerLayerEmbeddingLayer: ple_scales count ("
+      << ple_consumer_scale_.size() << ") != output count ("
+      << ple_output_count_ << ")";
+  }
+
+  auto &offset_prop = std::get<props::PleOffsets>(ple_props);
+  if (offset_prop.empty()) {
+    ple_consumer_offset_.assign(ple_output_count_, 0);
+  } else {
+    ple_consumer_offset_ = parse_csv<int>(
+      offset_prop.get(), [](const std::string &t) { return std::stoi(t); });
+    NNTR_THROW_IF(ple_consumer_offset_.size() != ple_output_count_,
+                  std::invalid_argument)
+      << "PerLayerEmbeddingLayer: ple_offsets count ("
+      << ple_consumer_offset_.size() << ") != output count ("
+      << ple_output_count_ << ")";
+  }
+
+  // Each output carries the per-layer embedding for the whole sequence:
+  //   [batch, 1, seq_len, ple_per_layer_], UINT16.
+  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  nntrainer::TensorDim out_dim = in_dim;
+  out_dim.height(in_dim.width());
+  out_dim.width(ple_per_layer_);
+  out_dim.setTensorType(
+    {context.getFormat(), nntrainer::TensorDim::DataType::UINT16});
+
+  std::vector<nntrainer::VarGradSpecV2> out_specs;
+  out_specs.reserve(ple_output_count_);
+  for (size_t l = 0; l < ple_output_count_; ++l)
+    out_specs.push_back(nntrainer::InitLayerContext::outSpec(out_dim, "out"));
+  context.requestOutputs(std::move(out_specs));
+}
+
+void PerLayerEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
+                                        bool training) {
+  // Mirror incremental_forwarding over the full sequence width.
+  auto &input = context.getInput(SINGLE_INOUT_IDX);
+  incremental_forwarding(context, 0, input.width(), training);
+}
+
+void PerLayerEmbeddingLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+  if (!ple_mmap_ && !ple_u16_mmap_)
+    return;
+
+  auto &input = context.getInput(SINGLE_INOUT_IDX);
+
+  const size_t per_layer_elems = ple_per_layer_;
+  const unsigned int b_size = input.batch();
+  const unsigned int in_feature_len = input.getDim().getFeatureLen();
+  const int iter = static_cast<int>(to - from);
+  if (iter <= 0)
+    return;
+
+  // Per-batch element stride into each output tensor (all outputs share dims).
+  const size_t out_feature_len =
+    context.getOutput(SINGLE_INOUT_IDX).getDim().getFeatureLen();
+
+  // Cache per-output base pointers once per batch to avoid repeated lookups.
+  std::vector<uint16_t *> out_base(ple_output_count_);
+
+  for (unsigned int b = 0; b < b_size; ++b) {
+    for (size_t l = 0; l < ple_output_count_; ++l)
+      out_base[l] = context.getOutput(l).getData<uint16_t>(b * out_feature_len);
+
+    // Token IDs are stored as FP32 (forced in finalize). Like EmbeddingLayer
+    // and the other CausalLM step-layers, the per-step input/output are indexed
+    // from 0 over [0, to-from) (NOT offset by `from`); `from` only sizes iter.
+    const float *token_data = input.getAddress<float>(b * in_feature_len);
+
+    for (int t = 0; t < iter; ++t) {
+      const float tok_f = token_data[t];
+      NNTR_THROW_IF(tok_f < 0.0f, std::invalid_argument)
+        << "PerLayerEmbeddingLayer: negative token id " << tok_f;
+      const size_t token_id = static_cast<size_t>(tok_f);
+      NNTR_THROW_IF(token_id >= ple_vocab_, std::invalid_argument)
+        << "PerLayerEmbeddingLayer: token id " << token_id << " >= vocab "
+        << ple_vocab_;
+
+      const size_t dst_off = static_cast<size_t>(t) * per_layer_elems;
+
+      if (ple_is_quantized_) {
+        const uint8_t *row = ple_mmap_ + token_id * ple_row_bytes_;
+
+        if (ple_is_signed4_) {
+          // sfixed4: two signed 4-bit nibbles per byte (half a byte per elem).
+          const size_t per_layer_bytes = per_layer_elems / 2;
+          const float *row_scales =
+            ple_row_layer_scales_.data() + token_id * ple_layers_;
+          for (size_t l = 0; l < ple_output_count_; ++l) {
+            const size_t ml = static_cast<size_t>(ple_model_index_[l]);
+            dequant_sfixed4_requant_u16_(
+              row + ml * per_layer_bytes, per_layer_elems, row_scales[ml],
+              ple_consumer_scale_[l], ple_consumer_offset_[l],
+              out_base[l] + dst_off);
+          }
+        } else {
+          // ufixed8: one unsigned byte per element.
+          const size_t per_layer_bytes = per_layer_elems;
+          for (size_t l = 0; l < ple_output_count_; ++l) {
+            const size_t ml = static_cast<size_t>(ple_model_index_[l]);
+            dequant_bytes_requant_u16_(
+              row + ml * per_layer_bytes, per_layer_elems, ple_scale_,
+              ple_offset_, ple_consumer_scale_[l], ple_consumer_offset_[l],
+              out_base[l] + dst_off);
+          }
+        }
+      } else {
+        // raw uint16: per-layer slice memcpy (already in consumer space).
+        const uint16_t *row = ple_u16_mmap_ + token_id * ple_row_elems_;
+        for (size_t l = 0; l < ple_output_count_; ++l) {
+          const size_t ml = static_cast<size_t>(ple_model_index_[l]);
+          std::memcpy(out_base[l] + dst_off, row + ml * per_layer_elems,
+                      per_layer_elems * sizeof(uint16_t));
+        }
+      }
+    }
+  }
+}
+
+void PerLayerEmbeddingLayer::calcDerivative(
+  nntrainer::RunLayerContext &context) {
+  throw std::runtime_error(
+    "PerLayerEmbeddingLayer does not support backwarding");
+}
+
+void PerLayerEmbeddingLayer::calcGradient(nntrainer::RunLayerContext &context) {
+  throw std::runtime_error(
+    "PerLayerEmbeddingLayer does not support backwarding");
+}
+
+void PerLayerEmbeddingLayer::setProperty(
+  const std::vector<std::string> &values) {
+  auto remain_props = nntrainer::loadProperties(values, ple_props);
+  LayerImpl::setProperty(remain_props);
+}
+
+void PerLayerEmbeddingLayer::open_ple_file_(const std::string &ple_file_name) {
+  if (ple_file_name.empty())
+    throw std::runtime_error("PerLayerEmbeddingLayer: ple_file_name is empty");
+
+  ple_is_quantized_ = ends_with(ple_file_name, ".json");
+
+  if (ple_is_quantized_) {
+    std::ifstream mf(ple_file_name);
+    if (!mf.is_open())
+      throw std::runtime_error("Failed to open PLE manifest: " + ple_file_name);
+
+    json j;
+    mf >> j;
+
+    const std::string lut_rel = j.at("lut-path").get<std::string>();
+    const int row_elems = j.at("size").get<int>();
+    const std::string datatype = j.value("datatype", std::string("ufixed8"));
+    const auto &qp = j.at("quant-param");
+
+    ple_is_signed4_ = (datatype == "sfixed4");
+    if (!ple_is_signed4_ && datatype != "ufixed8")
+      throw std::runtime_error("PLE: unsupported datatype: " + datatype);
+
+    ple_row_elems_ = static_cast<size_t>(row_elems);
+    // sfixed4 packs two 4-bit values per byte; ufixed8 is one byte per element.
+    ple_row_bytes_ =
+      ple_is_signed4_ ? (ple_row_elems_ + 1) / 2 : ple_row_elems_;
+    ple_layers_ = ple_row_elems_ / ple_per_layer_;
+
+    if (ple_layers_ * ple_per_layer_ != ple_row_elems_)
+      throw std::runtime_error("PLE 'size' not divisible by per_layer width");
+
+    if (ple_is_signed4_) {
+      const auto &scale_arr = qp.at("scale");
+      if (!scale_arr.is_array())
+        throw std::runtime_error(
+          "PLE sfixed4: quant-param.scale must be an array");
+      ple_row_layer_scales_.clear();
+      ple_row_layer_scales_.reserve(scale_arr.size());
+      for (const auto &v : scale_arr)
+        ple_row_layer_scales_.push_back(v.get<float>());
+
+      if (ple_row_layer_scales_.size() % ple_layers_ != 0)
+        throw std::runtime_error(
+          "PLE sfixed4: scale array length not divisible by num_layers");
+      ple_scale_ = 1.0f;
+      ple_offset_ = 0;
+    } else {
+      ple_scale_ = qp.at("scale").get<float>();
+      ple_offset_ = qp.at("offset").get<int>();
+    }
+
+    std::string lut_abs = rebase_relative_to_model_file(lut_rel, ple_file_name);
+
+    ple_fd_ = open(lut_abs.c_str(), O_RDONLY);
+    if (ple_fd_ < 0)
+      throw std::runtime_error("open PLE bin: " + lut_abs);
+
+    struct stat st;
+    if (fstat(ple_fd_, &st) < 0) {
+      ::close(ple_fd_);
+      ple_fd_ = -1;
+      throw std::runtime_error("stat PLE bin: " + lut_abs);
+    }
+    ple_file_size_ = static_cast<size_t>(st.st_size);
+    if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
+        ple_file_size_ % ple_row_bytes_ != 0) {
+      ::close(ple_fd_);
+      ple_fd_ = -1;
+      throw std::runtime_error("PLE bin size not a positive multiple of row "
+                               "bytes");
+    }
+    ple_vocab_ = ple_file_size_ / ple_row_bytes_;
+
+    if (ple_is_signed4_) {
+      const size_t scale_vocab = ple_row_layer_scales_.size() / ple_layers_;
+      if (scale_vocab != ple_vocab_)
+        throw std::runtime_error(
+          "PLE sfixed4 scale vocab=" + std::to_string(scale_vocab) +
+          " != bin vocab=" + std::to_string(ple_vocab_));
+    }
+
+    void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
+    if (m == MAP_FAILED) {
+      ::close(ple_fd_);
+      ple_fd_ = -1;
+      throw std::runtime_error("mmap PLE bin: " + lut_abs);
+    }
+    ple_mmap_ = static_cast<const uint8_t *>(m);
+#ifdef POSIX_MADV_RANDOM
+    posix_madvise((void *)ple_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
+#endif
+
+    if (ple_is_signed4_) {
+      ml_logd("[PLE] sfixed4 (rowwise+layerwise) mmaped %s rows=%zu layers=%zu "
+              "per_layer=%zu scales=%zu",
+              lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
+              ple_row_layer_scales_.size());
+    } else {
+      ml_logd("[PLE] ufixed8 (tensorwise) mmaped %s rows=%zu layers=%zu "
+              "per_layer=%zu scale=%f offset=%d",
+              lut_abs.c_str(), ple_vocab_, ple_layers_, ple_per_layer_,
+              ple_scale_, ple_offset_);
+    }
+    return;
+  }
+
+  // raw UINT16: no manifest. Row layout is derived from the output count, which
+  // the caller (finalize) must have set before reaching here.
+  if (ple_output_count_ == 0)
+    throw std::runtime_error(
+      "PLE raw uint16: ple_layer_count must be set before loading");
+  ple_row_elems_ = ple_output_count_ * ple_per_layer_;
+  ple_row_bytes_ = ple_row_elems_ * sizeof(uint16_t);
+  ple_layers_ = ple_output_count_;
+  ple_is_signed4_ = false;
+  ple_scale_ = 1.0f;
+  ple_offset_ = 0;
+
+  ple_fd_ = open(ple_file_name.c_str(), O_RDONLY);
+  if (ple_fd_ < 0)
+    throw std::runtime_error("open PLE bin: " + ple_file_name);
+
+  struct stat st;
+  if (fstat(ple_fd_, &st) < 0) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+    throw std::runtime_error("stat PLE bin: " + ple_file_name);
+  }
+  ple_file_size_ = static_cast<size_t>(st.st_size);
+  if (ple_row_bytes_ == 0 || ple_file_size_ == 0 ||
+      ple_file_size_ % ple_row_bytes_ != 0) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+    throw std::runtime_error(
+      "PLE bin size not a positive multiple of row bytes (expected multiple "
+      "of " +
+      std::to_string(ple_row_bytes_) + ", got " +
+      std::to_string(ple_file_size_) + ")");
+  }
+  ple_vocab_ = ple_file_size_ / ple_row_bytes_;
+
+  void *m = mmap(nullptr, ple_file_size_, PROT_READ, MAP_PRIVATE, ple_fd_, 0);
+  if (m == MAP_FAILED) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+    throw std::runtime_error("mmap PLE bin: " + ple_file_name);
+  }
+  ple_u16_mmap_ = static_cast<const uint16_t *>(m);
+#ifdef POSIX_MADV_RANDOM
+  posix_madvise((void *)ple_u16_mmap_, ple_file_size_, POSIX_MADV_RANDOM);
+#endif
+
+  ml_logd("[PLE] raw uint16 mmaped %s rows=%zu layers=%zu per_layer=%zu",
+          ple_file_name.c_str(), ple_vocab_, ple_layers_, ple_per_layer_);
+}
+
+void PerLayerEmbeddingLayer::close_ple_file_() {
+  if (ple_mmap_) {
+    munmap((void *)ple_mmap_, ple_file_size_);
+    ple_mmap_ = nullptr;
+  }
+  if (ple_u16_mmap_) {
+    munmap((void *)ple_u16_mmap_, ple_file_size_);
+    ple_u16_mmap_ = nullptr;
+  }
+  if (ple_fd_ >= 0) {
+    ::close(ple_fd_);
+    ple_fd_ = -1;
+  }
+}
+
+void PerLayerEmbeddingLayer::dequant_sfixed4_requant_u16_(
+  const uint8_t *packed, size_t elems, float row_scale, float out_scale,
+  int out_offset, uint16_t *dst) const {
+  const float inv_out = 1.0f / out_scale;
+  auto requant = [&](unsigned nib) -> uint16_t {
+    const float f = static_cast<float>(s4_decode(nib)) * row_scale;
+    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
+    return static_cast<uint16_t>(std::max(0, std::min(65535, q)));
+  };
+  const size_t whole = elems / 2;
+  for (size_t i = 0; i < whole; ++i) {
+    const uint8_t b = packed[i];
+    dst[2 * i] = requant(b & 0x0F);
+    dst[2 * i + 1] = requant((b >> 4) & 0x0F);
+  }
+  if (elems & 1)
+    dst[2 * whole] = requant(packed[whole] & 0x0F);
+}
+
+void PerLayerEmbeddingLayer::dequant_bytes_requant_u16_(
+  const uint8_t *src, size_t elems, float lut_scale, int lut_offset,
+  float out_scale, int out_offset, uint16_t *dst) const {
+  const float inv_out = 1.0f / out_scale;
+  for (size_t i = 0; i < elems; ++i) {
+    const float f = (static_cast<float>(src[i]) + lut_offset) * lut_scale;
+    int q = static_cast<int>(std::lrintf(f * inv_out)) - out_offset;
+    dst[i] = static_cast<uint16_t>(std::max(0, std::min(65535, q)));
+  }
+}
+
+#ifdef PLUGGABLE
+nntrainer::Layer *create_per_layer_embedding_layer() {
+  return new PerLayerEmbeddingLayer();
+}
+void destroy_per_layer_embedding_layer(nntrainer::Layer *layer) {
+  delete layer;
+}
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{
+  create_per_layer_embedding_layer, destroy_per_layer_embedding_layer};
+}
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/per_layer_embedding.h
+++ b/Applications/CausalLM/layers/per_layer_embedding.h
@@ -7,8 +7,9 @@
  * @see    https://github.com/nnstreamer/nntrainer
  * @author haehun.yang <haehun.yang@samsung.com>
  * @bug    No known bugs except for NYI items
- * @brief  Multi-output embedding layer that loads per-layer embeddings from a
- *         single file and distributes them across multiple output tensors.
+ * @brief  Per-layer embedding loader/dequantizer, exposed both as a standalone
+ *         engine (PerLayerEmbeddingEngine) and as an nntrainer multi-output
+ *         layer (PerLayerEmbeddingLayer).
  */
 
 #ifndef __PER_LAYER_EMBEDDING_H__
@@ -25,6 +26,7 @@
 
 #include <base_properties.h>
 #include <common_properties.h>
+#include <cstdint>
 #include <layer_context.h>
 #include <layer_impl.h>
 #include <memory>
@@ -69,8 +71,7 @@ public:
 /**
  * @brief Comma-separated model-layer index for each output slot.
  *        Maps dense output slot l -> source model layer index. When empty,
- *        the identity mapping (l -> l) is used. See the source-indexing note
- *        in the original Gemma4_E2B_QNN::fill_prefill_ple_chunk_().
+ *        the identity mapping (l -> l) is used.
  */
 class PleModelIndices : public nntrainer::Property<std::string> {
 public:
@@ -101,56 +102,152 @@ public:
 } // namespace props
 
 /**
+ * @class PerLayerEmbeddingEngine
+ * @brief Standalone per-layer embedding loader + dequantizer, independent of
+ *        any nntrainer graph/RunLayerContext.
+ *
+ * The engine owns a memory-mapped per-layer embedding file and produces, for a
+ * given token id, the per-layer UINT16 embedding chunks written into arbitrary
+ * destination buffers. It is the single source of PLE logic shared by both the
+ * nntrainer PerLayerEmbeddingLayer and the QNN runners (which dequant directly
+ * into QNN graph input buffers).
+ *
+ * Three file formats (auto-detected by extension / manifest datatype):
+ * - *.json + "sfixed4": rowwise signed 4-bit (two nibbles per byte), per-row-
+ *   per-layer scales. A binary sidecar (`<manifest>.sf4cache`) is written on
+ *   first parse so later cold starts skip the multi-million-float JSON parse.
+ * - *.json + "ufixed8": tensorwise unsigned 8-bit (one byte per element),
+ *   single scale/offset.
+ * - raw uint16 binary: already in consumer space; per-layer fill is a memcpy.
+ */
+class PerLayerEmbeddingEngine {
+public:
+  WIN_EXPORT PerLayerEmbeddingEngine() = default;
+  WIN_EXPORT ~PerLayerEmbeddingEngine() { close(); }
+
+  // Move-only: uniquely owns a file descriptor and mmap region.
+  WIN_EXPORT PerLayerEmbeddingEngine(PerLayerEmbeddingEngine &&rhs) noexcept;
+  WIN_EXPORT PerLayerEmbeddingEngine &
+  operator=(PerLayerEmbeddingEngine &&rhs) noexcept;
+
+  /**
+   * @brief Load and mmap the per-layer embedding file.
+   * @param file_path manifest (*.json) or raw uint16 binary
+   * @param per_layer_width elements per layer in a row (e.g. 256 / 192)
+   * @param raw_layer_count_hint number of layers for the raw-uint16 format
+   *        (the row layout is derived from it); ignored for JSON manifests
+   */
+  WIN_EXPORT void open(const std::string &file_path, size_t per_layer_width,
+                       size_t raw_layer_count_hint = 0);
+
+  /** @brief munmap the file and close the descriptor */
+  WIN_EXPORT void close();
+
+  /** @brief true once a file has been successfully mapped */
+  WIN_EXPORT bool isOpen() const {
+    return ple_mmap_ != nullptr || ple_u16_mmap_ != nullptr;
+  }
+
+  /** @brief number of model layers stored per row */
+  WIN_EXPORT size_t numLayers() const { return ple_layers_; }
+  /** @brief elements per layer */
+  WIN_EXPORT size_t perLayerWidth() const { return ple_per_layer_; }
+  /** @brief number of rows (vocabulary size) */
+  WIN_EXPORT size_t vocab() const { return ple_vocab_; }
+
+  /**
+   * @brief Dequantize one token's per-layer embeddings into destination
+   *        buffers (one buffer per output slot).
+   *
+   * For output slot @c l the source row chunk @c model_index[l] is dequantized
+   * and requantized to the consumer space (@c consumer_scale[l],
+   * @c consumer_offset[l]) and written as @c perLayerWidth() UINT16 values to
+   * @c dsts[l] + @c dst_elem_offset.
+   *
+   * @param token_id row index into the embedding table
+   * @param model_index per-slot source model-layer index
+   * @param consumer_scale per-slot consumer-space scale
+   * @param consumer_offset per-slot consumer-space offset
+   * @param dsts per-slot destination base pointers
+   * @param dst_elem_offset element offset added to each destination
+   */
+  WIN_EXPORT void fillToken(int token_id, const std::vector<int> &model_index,
+                            const std::vector<float> &consumer_scale,
+                            const std::vector<int> &consumer_offset,
+                            const std::vector<uint16_t *> &dsts,
+                            size_t dst_elem_offset) const;
+
+private:
+  // File I/O and mmap
+  int ple_fd_ = -1;
+  const uint8_t *ple_mmap_ = nullptr;
+  const uint16_t *ple_u16_mmap_ = nullptr;
+  size_t ple_file_size_ = 0;
+
+  // Format detection
+  bool ple_is_quantized_ =
+    false;                      // manifest-backed (sfixed4/ufixed8) vs raw u16
+  bool ple_is_signed4_ = false; // sfixed4 (signed 4-bit nibbles); else ufixed8
+
+  // Layout metadata
+  size_t ple_per_layer_ = 0; // width per layer
+  size_t ple_row_elems_ = 0; // total row width (layers * per_layer)
+  size_t ple_row_bytes_ = 0; // bytes per row
+  size_t ple_layers_ = 0;    // model layers stored per row
+  size_t ple_vocab_ = 0;     // number of rows
+
+  // Source-side quantization parameters
+  float ple_scale_ = 1.0f;                  // ufixed8 only
+  int ple_offset_ = 0;                      // ufixed8 only
+  std::vector<float> ple_row_layer_scales_; // sfixed4: [vocab][layers]
+
+  void open_manifest_(const std::string &manifest_path);
+  void open_raw_u16_(const std::string &file_path, size_t raw_layer_count_hint);
+  // sfixed4 binary sidecar cache (skips the JSON scale-array parse).
+  bool load_sf4_cache_(const std::string &manifest_path);
+  void write_sf4_cache_(const std::string &manifest_path,
+                        const std::string &lut_abs) const;
+  void reset_();
+
+  /** @brief sign-extend a 4-bit value (0..15 -> -8..7) */
+  static inline int s4_decode(unsigned nib) {
+    return (nib & 0x8u) ? static_cast<int>(nib) - 16 : static_cast<int>(nib);
+  }
+  static void dequant_sfixed4_requant_u16_(const uint8_t *packed, size_t elems,
+                                           float row_scale, float out_scale,
+                                           int out_offset, uint16_t *dst);
+  static void dequant_bytes_requant_u16_(const uint8_t *src, size_t elems,
+                                         float lut_scale, int lut_offset,
+                                         float out_scale, int out_offset,
+                                         uint16_t *dst);
+};
+
+/**
  * @class PerLayerEmbeddingLayer
- * @brief Multi-output embedding layer that loads per-layer embeddings from a
- *        single file and distributes them across multiple output tensors.
+ * @brief Multi-output nntrainer layer that distributes per-layer embeddings
+ *        from a single file across multiple output tensors.
  *
- * Supports three file formats (auto-detected by extension / manifest datatype):
- * - *.json manifest with datatype "sfixed4": rowwise signed 4-bit quantized
- *   (two nibbles per byte), per-row-per-layer scales.
- * - *.json manifest with datatype "ufixed8": tensorwise unsigned 8-bit
- *   quantized (one byte per element), single scale/offset.
- * - raw uint16 binary: unquantized, already in consumer space.
+ * Thin wrapper over PerLayerEmbeddingEngine.
+ * Input: 1 tensor of token IDs (forced FP32 in finalize, matching
+ * EmbeddingLayer). Outputs: ple_layer_count UINT16 tensors, one per consumed
+ * model layer.
  *
- * Input: 1 tensor of token IDs. The input dtype is forced to FP32 in
- * finalize() (matching EmbeddingLayer), since the layer is often the model
- * entry point and token IDs index a vocab that can exceed UINT16 range.
- * Outputs: ple_layer_count UINT16 tensors, one per consumed model layer.
- *
- * Properties (see causallm::props above):
- * - ple_file_path        : manifest or raw binary path (required)
- * - ple_layer_count      : number of output tensors (req. for raw uint16)
- * - ple_per_layer_width  : elements per layer (default 256)
- * - ple_model_indices    : output slot -> source model-layer index (optional)
- * - ple_scales           : consumer-space scale per output (optional, def 1.0)
- * - ple_offsets          : consumer-space offset per output (optional, def 0)
+ * Properties (see causallm::props above): ple_file_path (required),
+ * ple_layer_count (req. for raw uint16), ple_per_layer_width (default 256),
+ * ple_model_indices / ple_scales / ple_offsets (optional per-slot config).
  */
 WIN_EXPORT class PerLayerEmbeddingLayer : public nntrainer::LayerImpl {
 public:
-  /**
-   * @brief Constructor
-   */
+  /** @brief Constructor */
   WIN_EXPORT PerLayerEmbeddingLayer();
 
-  /**
-   * @brief Destructor
-   */
-  WIN_EXPORT ~PerLayerEmbeddingLayer();
+  /** @brief Destructor (engine RAII releases the mapping) */
+  WIN_EXPORT ~PerLayerEmbeddingLayer() = default;
 
-  /**
-   * @brief Move constructor. The layer uniquely owns a file descriptor and an
-   * mmap region, so a defaulted move would shallow-copy them and let the
-   * moved-from destructor munmap/close the still-referenced mapping (double
-   * free / use-after-unmap). This transfers ownership and clears the source.
-   * Copy operations are implicitly deleted by declaring these moves.
-   */
-  PerLayerEmbeddingLayer(PerLayerEmbeddingLayer &&rhs) noexcept;
-
-  /**
-   * @brief Move assignment. Releases this object's own mapping first, then
-   * transfers ownership from @a rhs and clears it.
-   */
-  PerLayerEmbeddingLayer &operator=(PerLayerEmbeddingLayer &&rhs) noexcept;
+  // Move-only (the engine owns the fd/mmap and is itself move-only).
+  PerLayerEmbeddingLayer(PerLayerEmbeddingLayer &&rhs) noexcept = default;
+  PerLayerEmbeddingLayer &
+  operator=(PerLayerEmbeddingLayer &&rhs) noexcept = default;
 
   /**
    * @copydoc Layer::finalize(InitLayerContext &context)
@@ -205,83 +302,13 @@ private:
              props::PleModelIndices, props::PleScales, props::PleOffsets>
     ple_props;
 
-  // File I/O and mmap
-  int ple_fd_ = -1;
-  const uint8_t *ple_mmap_ = nullptr;
-  const uint16_t *ple_u16_mmap_ = nullptr;
-  size_t ple_file_size_ = 0;
+  PerLayerEmbeddingEngine engine_;
 
-  // Format detection
-  bool ple_is_quantized_ =
-    false;                      // manifest-backed (sfixed4/ufixed8) vs raw u16
-  bool ple_is_signed4_ = false; // sfixed4 (signed 4-bit nibbles); else ufixed8
-
-  // Layout metadata
-  size_t ple_per_layer_ = 0;    // Width per layer
-  size_t ple_row_elems_ = 0;    // Total vocab row width
-  size_t ple_row_bytes_ = 0;    // Byte count per row
-  size_t ple_layers_ = 0;       // Total model layer count in the file
-  size_t ple_output_count_ = 0; // Number of output tensors to fill
-  size_t ple_vocab_ = 0;        // Number of rows (vocab size) for bounds check
-
-  // Per-output-slot mapping and consumer-space quant params
+  size_t ple_per_layer_ = 0;
+  size_t ple_output_count_ = 0;
   std::vector<int> ple_model_index_;      // output slot -> source model layer
   std::vector<float> ple_consumer_scale_; // requant scale per output slot
   std::vector<int> ple_consumer_offset_;  // requant offset per output slot
-
-  // Quantization parameters (source side)
-  float ple_scale_ = 1.0f;
-  int ple_offset_ = 0;
-  std::vector<float> ple_row_layer_scales_;
-
-  /**
-   * @brief open and mmap the per-layer embedding file, parsing the manifest
-   * @param filename path to the JSON manifest or raw uint16 binary
-   */
-  void open_ple_file_(const std::string &filename);
-
-  /**
-   * @brief munmap the embedding file and close its descriptor
-   */
-  void close_ple_file_();
-
-  /**
-   * @brief decode a signed 4-bit nibble (two's complement) to int
-   * @param nib 4-bit value
-   * @return sign-extended integer in [-8, 7]
-   */
-  static inline int s4_decode(unsigned nib) {
-    return (nib & 0x8u) ? static_cast<int>(nib) - 16 : static_cast<int>(nib);
-  }
-
-  /**
-   * @brief dequantize a signed-4bit row slice and requantize to UINT16
-   * @param src packed nibble source
-   * @param len number of elements
-   * @param src_scale per-row source scale
-   * @param dst_scale consumer-space scale
-   * @param dst_offset consumer-space offset
-   * @param dst UINT16 destination
-   */
-  void dequant_sfixed4_requant_u16_(const uint8_t *src, size_t len,
-                                    float src_scale, float dst_scale,
-                                    int dst_offset, uint16_t *dst) const;
-
-  /**
-   * @brief dequantize an unsigned 8-bit (one byte per element) row slice and
-   *        requantize to UINT16
-   * @param src byte source (one element per byte)
-   * @param len number of elements
-   * @param src_scale source LUT scale
-   * @param src_offset source LUT offset
-   * @param dst_scale consumer-space scale
-   * @param dst_offset consumer-space offset
-   * @param dst UINT16 destination
-   */
-  void dequant_bytes_requant_u16_(const uint8_t *src, size_t len,
-                                  float src_scale, int src_offset,
-                                  float dst_scale, int dst_offset,
-                                  uint16_t *dst) const;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/per_layer_embedding.h
+++ b/Applications/CausalLM/layers/per_layer_embedding.h
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   per_layer_embedding.h
+ * @date   17 June 2026
+ * @see    https://github.com/nnstreamer/nntrainer
+ * @author haehun.yang <haehun.yang@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Multi-output embedding layer that loads per-layer embeddings from a
+ *         single file and distributes them across multiple output tensors.
+ */
+
+#ifndef __PER_LAYER_EMBEDDING_H__
+#define __PER_LAYER_EMBEDDING_H__
+#ifdef __cplusplus
+
+#pragma once
+
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <base_properties.h>
+#include <common_properties.h>
+#include <layer_context.h>
+#include <layer_impl.h>
+#include <memory>
+#include <node_exporter.h>
+#include <string>
+#include <tuple>
+#include <util_func.h>
+#include <vector>
+
+namespace causallm {
+
+namespace props {
+
+/**
+ * @brief Path to the per-layer embedding file (JSON manifest or raw binary).
+ */
+class PleFilePath : public nntrainer::Property<std::string> {
+public:
+  static constexpr const char *key = "ple_file_path";
+  using prop_tag = nntrainer::str_prop_tag;
+};
+
+/**
+ * @brief Number of output tensors to fill (one per consumed model layer).
+ *        Optional for JSON manifests (auto-detected); REQUIRED for raw uint16.
+ */
+class PleLayerCount : public nntrainer::PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "ple_layer_count";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Number of elements per layer in each embedding row (default 256).
+ */
+class PlePerLayerWidth : public nntrainer::PositiveIntegerProperty {
+public:
+  static constexpr const char *key = "ple_per_layer_width";
+  using prop_tag = nntrainer::uint_prop_tag;
+};
+
+/**
+ * @brief Comma-separated model-layer index for each output slot.
+ *        Maps dense output slot l -> source model layer index. When empty,
+ *        the identity mapping (l -> l) is used. See the source-indexing note
+ *        in the original Gemma4_E2B_QNN::fill_prefill_ple_chunk_().
+ */
+class PleModelIndices : public nntrainer::Property<std::string> {
+public:
+  static constexpr const char *key = "ple_model_indices";
+  using prop_tag = nntrainer::str_prop_tag;
+};
+
+/**
+ * @brief Comma-separated consumer-space quant scale per output slot.
+ *        When empty, all scales default to 1.0 (no requant).
+ */
+class PleScales : public nntrainer::Property<std::string> {
+public:
+  static constexpr const char *key = "ple_scales";
+  using prop_tag = nntrainer::str_prop_tag;
+};
+
+/**
+ * @brief Comma-separated consumer-space quant offset per output slot.
+ *        When empty, all offsets default to 0.
+ */
+class PleOffsets : public nntrainer::Property<std::string> {
+public:
+  static constexpr const char *key = "ple_offsets";
+  using prop_tag = nntrainer::str_prop_tag;
+};
+
+} // namespace props
+
+/**
+ * @class PerLayerEmbeddingLayer
+ * @brief Multi-output embedding layer that loads per-layer embeddings from a
+ *        single file and distributes them across multiple output tensors.
+ *
+ * Supports three file formats (auto-detected by extension / manifest datatype):
+ * - *.json manifest with datatype "sfixed4": rowwise signed 4-bit quantized
+ *   (two nibbles per byte), per-row-per-layer scales.
+ * - *.json manifest with datatype "ufixed8": tensorwise unsigned 8-bit
+ *   quantized (one byte per element), single scale/offset.
+ * - raw uint16 binary: unquantized, already in consumer space.
+ *
+ * Input: 1 tensor of token IDs. The input dtype is forced to FP32 in
+ * finalize() (matching EmbeddingLayer), since the layer is often the model
+ * entry point and token IDs index a vocab that can exceed UINT16 range.
+ * Outputs: ple_layer_count UINT16 tensors, one per consumed model layer.
+ *
+ * Properties (see causallm::props above):
+ * - ple_file_path        : manifest or raw binary path (required)
+ * - ple_layer_count      : number of output tensors (req. for raw uint16)
+ * - ple_per_layer_width  : elements per layer (default 256)
+ * - ple_model_indices    : output slot -> source model-layer index (optional)
+ * - ple_scales           : consumer-space scale per output (optional, def 1.0)
+ * - ple_offsets          : consumer-space offset per output (optional, def 0)
+ */
+WIN_EXPORT class PerLayerEmbeddingLayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief Constructor
+   */
+  WIN_EXPORT PerLayerEmbeddingLayer();
+
+  /**
+   * @brief Destructor
+   */
+  WIN_EXPORT ~PerLayerEmbeddingLayer();
+
+  /**
+   * @brief Move constructor. The layer uniquely owns a file descriptor and an
+   * mmap region, so a defaulted move would shallow-copy them and let the
+   * moved-from destructor munmap/close the still-referenced mapping (double
+   * free / use-after-unmap). This transfers ownership and clears the source.
+   * Copy operations are implicitly deleted by declaring these moves.
+   */
+  PerLayerEmbeddingLayer(PerLayerEmbeddingLayer &&rhs) noexcept;
+
+  /**
+   * @brief Move assignment. Releases this object's own mapping first, then
+   * transfers ownership from @a rhs and clears it.
+   */
+  PerLayerEmbeddingLayer &operator=(PerLayerEmbeddingLayer &&rhs) noexcept;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  /**
+   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+   * int from, unsigned int to, bool training)
+   */
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  WIN_EXPORT const std::string getType() const override { return type; }
+
+  using Layer::setProperty;
+
+  /**
+   * @copydoc Layer::setProperty(const std::vector<std::string> &values)
+   */
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+
+  inline static const std::string type = "per_layer_embedding_layer";
+
+private:
+  std::tuple<props::PleFilePath, props::PleLayerCount, props::PlePerLayerWidth,
+             props::PleModelIndices, props::PleScales, props::PleOffsets>
+    ple_props;
+
+  // File I/O and mmap
+  int ple_fd_ = -1;
+  const uint8_t *ple_mmap_ = nullptr;
+  const uint16_t *ple_u16_mmap_ = nullptr;
+  size_t ple_file_size_ = 0;
+
+  // Format detection
+  bool ple_is_quantized_ =
+    false;                      // manifest-backed (sfixed4/ufixed8) vs raw u16
+  bool ple_is_signed4_ = false; // sfixed4 (signed 4-bit nibbles); else ufixed8
+
+  // Layout metadata
+  size_t ple_per_layer_ = 0;    // Width per layer
+  size_t ple_row_elems_ = 0;    // Total vocab row width
+  size_t ple_row_bytes_ = 0;    // Byte count per row
+  size_t ple_layers_ = 0;       // Total model layer count in the file
+  size_t ple_output_count_ = 0; // Number of output tensors to fill
+  size_t ple_vocab_ = 0;        // Number of rows (vocab size) for bounds check
+
+  // Per-output-slot mapping and consumer-space quant params
+  std::vector<int> ple_model_index_;      // output slot -> source model layer
+  std::vector<float> ple_consumer_scale_; // requant scale per output slot
+  std::vector<int> ple_consumer_offset_;  // requant offset per output slot
+
+  // Quantization parameters (source side)
+  float ple_scale_ = 1.0f;
+  int ple_offset_ = 0;
+  std::vector<float> ple_row_layer_scales_;
+
+  /**
+   * @brief open and mmap the per-layer embedding file, parsing the manifest
+   * @param filename path to the JSON manifest or raw uint16 binary
+   */
+  void open_ple_file_(const std::string &filename);
+
+  /**
+   * @brief munmap the embedding file and close its descriptor
+   */
+  void close_ple_file_();
+
+  /**
+   * @brief decode a signed 4-bit nibble (two's complement) to int
+   * @param nib 4-bit value
+   * @return sign-extended integer in [-8, 7]
+   */
+  static inline int s4_decode(unsigned nib) {
+    return (nib & 0x8u) ? static_cast<int>(nib) - 16 : static_cast<int>(nib);
+  }
+
+  /**
+   * @brief dequantize a signed-4bit row slice and requantize to UINT16
+   * @param src packed nibble source
+   * @param len number of elements
+   * @param src_scale per-row source scale
+   * @param dst_scale consumer-space scale
+   * @param dst_offset consumer-space offset
+   * @param dst UINT16 destination
+   */
+  void dequant_sfixed4_requant_u16_(const uint8_t *src, size_t len,
+                                    float src_scale, float dst_scale,
+                                    int dst_offset, uint16_t *dst) const;
+
+  /**
+   * @brief dequantize an unsigned 8-bit (one byte per element) row slice and
+   *        requantize to UINT16
+   * @param src byte source (one element per byte)
+   * @param len number of elements
+   * @param src_scale source LUT scale
+   * @param src_offset source LUT offset
+   * @param dst_scale consumer-space scale
+   * @param dst_offset consumer-space offset
+   * @param dst UINT16 destination
+   */
+  void dequant_bytes_requant_u16_(const uint8_t *src, size_t len,
+                                  float src_scale, int src_offset,
+                                  float dst_scale, int dst_offset,
+                                  uint16_t *dst) const;
+};
+
+} // namespace causallm
+
+#endif // __cplusplus
+#endif // __PER_LAYER_EMBEDDING_H__

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -36,6 +36,7 @@ causallm_layer_dependencies += [
     causallm_deberta_attention_layer_dep,
     causallm_shared_fully_connected_layer_dep,
     causallm_per_layer_slice_dep,
+    causallm_per_layer_embedding_dep,
     causallm_scalar_multiply_dep,
     causallm_logit_softcapping_dep,
 ]


### PR DESCRIPTION
## Dependency of the PR
None

## Commits to be reviewed in this PR
[feat(layers): add PerLayerEmbeddingLayer for multi-output per-layer embeddings](https://github.com/nntrainer/nntrainer/commit/7d7605c5c85a44cb054988e42f1ce45e8924bca4)

<details><summary>
Add PerLayerEmbeddingLayer
</summary><br />

Implement a new nntrainer layer that loads per-layer embeddings from a single
file and distributes them across multiple output tensors. This extracts the
per-layer embedding handling logic from model-specific implementations into a reusable layer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: haehun.yang <haehun.yang@samsung.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

</details>
