### PR TITLE
[CausalLM/layers] implement SwiGLU backward pass for LoRA training

### DIFF
--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -7,6 +7,8 @@
  * @brief  Implementation of SwiGLU activation function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
+ * @author Sumon Nath <sumon.nath@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
@@ -35,14 +37,29 @@ void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
 
   if (!std::get<nntrainer::props::SkipPrefill>(swiglu_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(swiglu_props).get();
+
+  tensor_idx[SwiGLUParams::sigmoid_gate] =
+    context.requestTensor(context.getInputDimensions()[0], "sigmoid_gate",
+                          nntrainer::Initializer::NONE, false,
+                          nntrainer::TensorLifespan::ITERATION_LIFESPAN);
 }
 
 void SwiGLULayer::forwarding(nntrainer::RunLayerContext &context,
-                             bool training) {}
+                             bool training) {
+
+  nntrainer::Tensor &in1 = context.getInput(INPUT_IDX_1);
+  unsigned int height = in1.getDim().height();
+
+  // Process the full sequence by calling incremental_forwarding once with
+  // from=0 and to=height. This unifies the implementation and ensures
+  // training/inference consistency.
+  incremental_forwarding(context, 0, height, training);
+}
 
 void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                          unsigned int from, unsigned int to,
                                          bool training) {
+
   nntrainer::Tensor &in1 = context.getInput(INPUT_IDX_1);
   nntrainer::Tensor &in2 = context.getInput(INPUT_IDX_2);
   nntrainer::Tensor &out = context.getOutput(OUT_IDX);
@@ -51,12 +68,12 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   if (skip_prefill && is_prefill)
     return;
 
-  int iter = to - from;
+  unsigned int step = to - from;
 
   if (in1.getDataType() == ml::train::TensorDim::DataType::FP32) {
     for (unsigned int b = 0; b < in1.batch(); b++) {
       for (unsigned int c = 0; c < in1.channel(); c++) {
-        for (unsigned int h = 0; h < iter; h++) {
+        for (unsigned int h = 0; h < step; h++) {
           nntrainer::swiglu(in1.width(),
                             out.getData<float>() + out.getIndex(b, c, h, 0),
                             in1.getData<float>() + in1.getIndex(b, c, h, 0),
@@ -68,7 +85,7 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 #ifdef ENABLE_FP16
     for (unsigned int b = 0; b < in1.batch(); b++) {
       for (unsigned int c = 0; c < in1.channel(); c++) {
-        for (unsigned int h = 0; h < iter; h++) {
+        for (unsigned int h = 0; h < step; h++) {
           nntrainer::swiglu(in1.width(),
                             out.getData<_FP16>() + out.getIndex(b, c, h, 0),
                             in1.getData<_FP16>() + in1.getIndex(b, c, h, 0),
@@ -99,8 +116,44 @@ void SwiGLULayer::updateTensorsByInputDimensions(
 }
 
 void SwiGLULayer::calcDerivative(nntrainer::RunLayerContext &context) {
-  // std::throw_with_nested(std::runtime_error("Training is not supported
-  // yet."));
+
+  const nntrainer::Tensor &incoming_deriv =
+    context.getIncomingDerivative(OUT_IDX);
+  nntrainer::Tensor &d_gate = context.getOutgoingDerivative(INPUT_IDX_1);
+  nntrainer::Tensor &d_up = context.getOutgoingDerivative(INPUT_IDX_2);
+  nntrainer::Tensor &gate = context.getInput(INPUT_IDX_1);
+  nntrainer::Tensor &up = context.getInput(INPUT_IDX_2);
+  nntrainer::Tensor &sig_gate =
+    context.getTensor(tensor_idx[SwiGLUParams::sigmoid_gate]);
+
+  if (gate.getDataType() == ml::train::TensorDim::DataType::FP32) {
+    // Generate sig_gate on-the-fly, as forwarding now bypasses it for SIMD
+    // speed
+    gate.apply<float>(
+      [](float x) { return 1.0f / (1.0f + nntrainer::exp_util(-x)); },
+      sig_gate);
+    // d_up = Swish(gate) * dy
+    gate.multiply(sig_gate, d_up);
+    d_up.multiply_i(incoming_deriv);
+
+    // Swish'(gate) = sig_gate + gate * sig_gate * (1 - sig_gate)
+    // We use d_gate as a memory-safe buffer to calculate (1 - sig_gate) to
+    // avoid allocations
+    d_gate.copyData(sig_gate);
+    d_gate.multiply_i(-1.0f);
+    d_gate.add_i(1.0f);
+
+    // d_gate is now (1 - sig_gate)
+    d_gate.multiply_i(gate);
+    d_gate.multiply_i(sig_gate); // gate * sig_gate * (1 - sig_gate)
+    d_gate.add_i(sig_gate);      // Swish'(gate)
+
+    d_gate.multiply_i(up);
+    d_gate.multiply_i(incoming_deriv);
+  } else if (gate.getDataType() == ml::train::TensorDim::DataType::FP16) {
+    throw std::invalid_argument(
+      "SwiGLULayer calcDerivative for FP16 is not yet implemented");
+  }
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -7,12 +7,16 @@
  * @brief  Implementation of custom SwiGLU activation function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
+ * @author Sumon Nath <sumon.nath@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
 
 #ifndef __SWIGLU_LAYER_H__
 #define __SWIGLU_LAYER_H__
+
+#include <array>
 
 #include <layer_context.h>
 #include <layer_devel.h>
@@ -33,13 +37,18 @@ namespace causallm {
  *
  */
 WIN_EXPORT class SwiGLULayer final : public nntrainer::Layer {
+private:
+  std::array<unsigned int, 1> tensor_idx;
+
 public:
   /**
    * @brief Construct a new custom SwiGLU layer object
    *
    */
   WIN_EXPORT SwiGLULayer() :
-    Layer(), swiglu_props(nntrainer::props::SkipPrefill()) {}
+    Layer(), swiglu_props(nntrainer::props::SkipPrefill()) {
+    tensor_idx.fill(std::numeric_limits<unsigned>::max());
+  }
 
   /**
    * @brief Destroy the custom SwiGLU layer object
@@ -81,7 +90,7 @@ public:
    */
   WIN_EXPORT void
   exportTo(nntrainer::Exporter &exporter,
-           const ml::train::ExportMethods &method) const override{};
+           const ml::train::ExportMethods &method) const override {};
 
   /**
    * @copydoc Layer::getType()
@@ -109,6 +118,7 @@ public:
 private:
   std::tuple<nntrainer::props::SkipPrefill> swiglu_props;
   bool skip_prefill = false;
+  enum SwiGLUParams { sigmoid_gate = 0 };
 };
 
 } // namespace causallm


### PR DESCRIPTION
## Dependency of the PR
None — standalone layer change, no dependency on other PRs in this series.

## Commits to be reviewed in this PR

<details><summary>[CausalLM/layers] implement SwiGLU backward pass for LoRA training</summary><br />

Implements `forwarding()` (previously a no-op) and `calcDerivative()` in
`SwiGLULayer` to enable gradient flow during LoRA fine-tuning.

- `finalize()`: request `sigmoid_gate` scratch tensor (ITERATION_LIFESPAN) to cache sigmoid values for reuse in backprop
- `forwarding()`: now implemented — delegates to `incremental_forwarding(0, height, training)` so training and inference share a single code path
- `incremental_forwarding()`: minor rename `_from` → `step` for clarity
- `calcDerivative()`: full Swish′ gradient:
  - `d_up   = Swish(gate) × dy`
  - `d_gate = Swish′(gate) × up × dy`, where `Swish′(g) = σ(g) + g·σ(g)·(1−σ(g))`

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Niket Agarwal <niket.a@samsung.com>
Signed-off-by: Sumon Nath <sumon.nath@samsung.com>

</details>

### Summary

- Add `calcDerivative()` to `SwiGLULayer` — full Swish′ gradient with cached `sigmoid_gate` scratch tensor
- Implement `forwarding()` which was previously a no-op, unifying training and inference paths
- Enables SwiGLU to participate in backpropagation for LoRA fine-tuning of Qwen3

Signed-off-by: Niket Agarwal <niket.a@samsung.com>
Signed-off-by: Sumon Nath <sumon.nath@samsung.com>