### PR TITLE
[LoRA] add QAT and quantized deployment support for LoRA adapters

### DIFF
--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -6,14 +6,21 @@
  * @date   10 July 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>
+ * @author Anirudh <b.saianirud@samsung.com>
+ * @author Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug    No known bugs except for NYI items
  * @brief  This file defines Transformer's basic actions
  */
 
+#include <cmath>
+#include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <mutex>
+#include <unordered_set>
 
 #include <app_context.h>
+#include <cpu_backend.h>
 #include <engine.h>
 #include <model.h>
 
@@ -22,6 +29,7 @@
 #include <transformer.h>
 
 #include <embedding_layer.h>
+#include <fc_layer.h>
 #include <mha_core.h>
 #include <neuralnet.h>
 #include <qs4cx_tensor.h>
@@ -194,8 +202,38 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
   NORM_EPS = cfg["rms_norm_eps"];
   GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;
 
+  LORA_RANK = nntr_cfg.contains("lora_rank")
+                ? nntr_cfg["lora_rank"].get<unsigned int>()
+                : 0;
+  LORA_ALPHA = nntr_cfg.contains("lora_alpha")
+                 ? nntr_cfg["lora_alpha"].get<unsigned int>()
+                 : 0;
+  LORA_QAT = nntr_cfg.contains("lora_qat") && nntr_cfg["lora_qat"].get<bool>();
+  LORA_Q4 = nntr_cfg.contains("lora_weight_q4") &&
+            nntr_cfg["lora_weight_q4"].get<bool>();
+  LORA_TARGET = nntr_cfg.contains("lora_target")
+                  ? nntr_cfg["lora_target"].get<std::vector<std::string>>()
+                  : std::vector<std::string>{};
+
   return;
 };
+
+bool Transformer::hasLoRA(const std::string &module_type) const {
+  if (LORA_RANK == 0 || LORA_TARGET.empty())
+    return false;
+  return std::find(LORA_TARGET.begin(), LORA_TARGET.end(), module_type) !=
+         LORA_TARGET.end();
+}
+
+void Transformer::appendLoRAProps(std::vector<std::string> &props) const {
+  props.push_back(withKey("lora_rank", LORA_RANK));
+  if (LORA_ALPHA > 0)
+    props.push_back(withKey("lora_alpha", LORA_ALPHA));
+  if (LORA_QAT)
+    props.push_back(withKey("lora_qat", std::string("true")));
+  if (LORA_Q4)
+    props.push_back(withKey("lora_weight_q4", std::string("true")));
+}
 
 /**
  * @brief Build and compile the symbolic transformer graph.
@@ -246,10 +284,12 @@ std::pair<Tensor, Tensor> Transformer::constructModel() {
   NNTR_THROW_IF(TIE_WORD_EMBEDDINGS && !EMBEDDING_FILE_NAME.empty(),
                 std::invalid_argument)
     << "embedding_file_name requires untied embedding_layer";
-  LayerHandle embedding(createLayer(
-    embedding_type,
+  auto emb_props =
     buildEmbeddingLayerProperties("embedding0", NUM_VOCAB, DIM, EMBEDDING_DTYPE,
-                                  EMBEDDING_SCALE, EMBEDDING_FILE_NAME)));
+                                  EMBEDDING_SCALE, EMBEDDING_FILE_NAME);
+  if (LORA_RANK > 0)
+    emb_props.push_back(withKey("trainable", "false"));
+  LayerHandle embedding(createLayer(embedding_type, emb_props));
   Tensor h = embedding(x);
 
   // transformer decoder blocks
@@ -257,15 +297,102 @@ std::pair<Tensor, Tensor> Transformer::constructModel() {
     h = createTransformerDecoderBlock(i, h);
   }
 
-  // final rms_norm
-  LayerHandle out_norm(
-    createLayer("rms_norm", {withKey("name", "output_norm"),
-                             withKey("epsilon", std::to_string(NORM_EPS)),
-                             withKey("packed", "false")}));
+  // final rms_norm (frozen in LoRA mode)
+  std::vector<std::string> out_norm_props = {
+    withKey("name", "output_norm"),
+    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+  if (LORA_RANK > 0)
+    out_norm_props.push_back(withKey("trainable", "false"));
+  LayerHandle out_norm(createLayer("rms_norm", out_norm_props));
   h = out_norm(h);
 
   return {x, h};
 };
+
+void Transformer::initializeForTraining(float lr, unsigned int epochs) {
+  registerCustomLayers();
+  constructModel();
+
+  try {
+    model->addLayer(ml::train::createLayer("cross_softmax", {"name=loss"}));
+  } catch (const std::exception &e) {
+    std::cerr << "[initializeForTraining] loss layer: " << e.what()
+              << std::endl;
+  }
+
+  std::vector<std::string> model_props = {
+    withKey("batch_size", BATCH_SIZE), withKey("epochs", epochs),
+    withKey("model_tensor_type", MODEL_TENSOR_TYPE)};
+  model->setProperty(model_props);
+
+  auto optimizer =
+    ml::train::createOptimizer("adam", {"learning_rate=" + std::to_string(lr)});
+  if (model->setOptimizer(std::move(optimizer)))
+    throw std::invalid_argument("Failed to set optimizer.");
+
+  int compile_ret = model->compile(ml::train::ExecutionMode::TRAIN);
+  if (compile_ret) {
+    std::cerr << "[initializeForTraining] compile() returned " << compile_ret
+              << std::endl;
+    throw std::invalid_argument("Model compilation for training failed.");
+  }
+
+  int init_ret = model->initialize(ml::train::ExecutionMode::TRAIN);
+  if (init_ret) {
+    std::cerr << "[initializeForTraining] initialize() returned " << init_ret
+              << std::endl;
+    throw std::invalid_argument("Model initialization for training failed.");
+  }
+
+  is_initialized = true;
+}
+
+// Returns the ordered layer names matching NeuralNetwork::save() graph
+// traversal. Used by load_weight, save_weight_lora, and load_weight_lora to
+// iterate weights in a consistent, deterministic order.
+static std::vector<std::string> buildOrderedLayerNames(int num_layers) {
+  std::vector<std::string> names;
+  names.push_back("embedding0");
+  for (int i = 0; i < num_layers; ++i) {
+    std::string p = "layer" + std::to_string(i);
+    names.push_back(p + "_attention_norm");
+    names.push_back(p + "_wq");
+    names.push_back(p + "_q_norm");
+    names.push_back(p + "_wk");
+    names.push_back(p + "_k_norm");
+    names.push_back(p + "_wv");
+    names.push_back(p + "_mha_core" + std::to_string(i));
+    names.push_back(p + "_attention_out");
+    names.push_back(p + "_ffn_norm");
+    names.push_back(p + "_ffn_up");
+    names.push_back(p + "_ffn_gate");
+    names.push_back(p + "_ffn_down");
+    names.push_back(p + "_swiglu");
+    names.push_back(p + "_attention_add");
+    names.push_back(p + "_ffn_add");
+  }
+  names.push_back("output_norm");
+  names.push_back("output_of_causallm");
+  return names;
+}
+
+// Returns the byte count that the nntrainer .bin serialiser writes for a
+// weight tensor.  Block-quantised formats have sub-byte per-element cost, so
+// getDataLen() * getDataTypeSize() is wrong for Q4_0, Q4_K, Q6_K.
+static size_t weight_bytes(const ml::train::TensorDim &dim) {
+  using DT = ml::train::TensorDim::DataType;
+  size_t n = static_cast<size_t>(dim.getDataLen());
+  switch (dim.getDataType()) {
+  case DT::Q4_0:
+    return (n / 32) * 18; // block_q4_0: 32 elems → 2B scale + 16B nibbles
+  case DT::Q4_K:
+    return (n / 256) * 144; // block_q4_K: 256 elems → 144 bytes
+  case DT::Q6_K:
+    return (n / 256) * 210; // block_q6_K: 256 elems → 210 bytes
+  default:
+    return n * dim.getDataTypeSize();
+  }
+}
 
 std::vector<std::string> Transformer::buildEmbeddingLayerProperties(
   const std::string &name, unsigned int in_dim, unsigned int out_dim,
@@ -295,12 +422,62 @@ void Transformer::load_weight(const std::string &weight_path) {
       "initialize() before load_weight().");
   }
 
-  try {
-    model->load(weight_path, formatFromExtension(weight_path));
-  } catch (const std::exception &e) {
-    throw std::runtime_error("Failed to load model weights: " +
-                             std::string(e.what()));
+  // The pretrained BIN file was saved WITHOUT LoRA adapter slots.
+  // model->load() assigns offsets positionally, so every loraA/loraB weight
+  // in the LoRA model shifts subsequent base weights by ~32-64 KB, completely
+  // scrambling the loaded pretrained weights.
+  //
+  // Fix: read the file manually, advancing the file pointer only for base
+  // weights (not loraA/loraB), so each base weight reads from its correct
+  // position in the pretrained file.
+  std::ifstream f(weight_path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open model weights: " + weight_path);
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+
+  std::unordered_set<float *> visited;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      // Deduplicate shared tensors (e.g. TieWordEmbedding "Embedding").
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      bool is_lora = (wname.find(":loraA") != std::string::npos ||
+                      wname.find(":loraB") != std::string::npos);
+      if (is_lora)
+        continue; // Skip: not in pretrained file. Keeps initialized value.
+
+      size_t bytes = weight_bytes(wdims[wi]);
+      f.read(reinterpret_cast<char *>(wdata[wi]), bytes);
+      if (!f)
+        throw std::runtime_error("load_weight: read failed at weight '" +
+                                 wname + "' (offset " +
+                                 std::to_string(f.tellg()) + ")");
+    }
   }
+  std::cout << "[load_weight] Loaded base weights from " << weight_path
+            << " (LoRA adapters kept at initialized values)\n";
 };
 
 /**
@@ -373,6 +550,749 @@ void Transformer::repack_weight() {
                              std::string(e.what()));
   }
 };
+void Transformer::save_weight_lora(const std::string &weight_path) {
+  if (!is_initialized)
+    throw std::runtime_error(
+      "Model not initialized before save_weight_lora().");
+
+  // If QAT was active, do one inference forward on a dummy input to trigger
+  // the snap of loraA/loraB to the EMA-calibrated Q6_K grid before saving.
+  // We removed force-feed from the training loop to avoid corrupting Adam
+  // state, so we do it here — once, at the moment we actually need it. NOTE:
+  // currently we skip the snap here and save raw FP32 LoRA weights.
+  // nntr_quantize will apply Q6_K to them at quantization time; the EMA stats
+  // stored in lora_a_rmin/rmax are used as the calibrated scale hint.
+
+  std::ofstream f(weight_path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open " + weight_path + " for writing.");
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+  size_t total_bytes = 0;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      if (wname.find(":loraA") == std::string::npos &&
+          wname.find(":loraB") == std::string::npos)
+        continue;
+
+      size_t bytes =
+        static_cast<size_t>(wdims[wi].getDataLen()) * sizeof(float);
+      f.write(reinterpret_cast<const char *>(wdata[wi]), bytes);
+      total_bytes += bytes;
+    }
+  }
+
+  std::cout << "[save_weight_lora] Saved LoRA adapters to " << weight_path
+            << " (" << (total_bytes / 1024 / 1024) << " MB)\n";
+}
+
+void Transformer::load_weight_lora(const std::string &base_path,
+                                   const std::string &lora_path) {
+  load_weight(base_path);
+
+  std::ifstream f(lora_path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open LoRA adapters: " + lora_path);
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      if (wname.find(":loraA") == std::string::npos &&
+          wname.find(":loraB") == std::string::npos)
+        continue;
+
+      size_t bytes =
+        static_cast<size_t>(wdims[wi].getDataLen()) * sizeof(float);
+      f.read(reinterpret_cast<char *>(wdata[wi]), bytes);
+      if (!f)
+        throw std::runtime_error("load_weight_lora: read failed at '" + wname +
+                                 "'");
+    }
+  }
+
+  std::cout << "[load_weight_lora] Loaded LoRA adapters from " << lora_path
+            << "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Q6_K helpers (self-contained, no extra headers needed)
+// ---------------------------------------------------------------------------
+
+struct q6k_block_t {
+  uint8_t ql[128];   // lower 4 bits of 256 quants
+  uint8_t qh[64];    // upper 2 bits of 256 quants
+  int8_t scales[16]; // sub-block scales
+  uint16_t d;        // super-block scale (FP16)
+};
+static_assert(sizeof(q6k_block_t) == 210, "Q6_K block must be 210 bytes");
+
+static uint16_t q6k_fp32_to_fp16(float f) {
+  uint32_t x;
+  std::memcpy(&x, &f, sizeof(x));
+  uint16_t sign = (x >> 31) & 1;
+  int exp = (int)((x >> 23) & 0xFF) - 127;
+  uint32_t mant = x & 0x7FFFFF;
+  if (exp == 128)
+    return (uint16_t)(sign << 15) | (mant ? 0x7E00 : 0x7C00);
+  if (exp > 15)
+    return (uint16_t)(sign << 15) | 0x7C00;
+  if (exp < -14)
+    return (uint16_t)(sign << 15);
+  return (uint16_t)((sign << 15) | ((exp + 15) << 10) | (mant >> 13));
+}
+
+static float q6k_fp16_to_fp32(uint16_t h) {
+  uint32_t sign = (h >> 15) & 1;
+  uint32_t exp = (h >> 10) & 0x1F;
+  uint32_t mant = h & 0x3FF;
+  uint32_t x;
+  if (exp == 0x1F) {
+    x = (sign << 31) | 0x7F800000 | (mant << 13);
+  } else if (exp == 0) {
+    x = sign << 31; // flush denormals to zero
+  } else {
+    x = (sign << 31) | ((exp + 112) << 23) | (mant << 13);
+  }
+  float f;
+  std::memcpy(&f, &x, sizeof(f));
+  return f;
+}
+
+// Encode FP32 data into Q6_K blocks using forced global scale from QAT EMA.
+// d = fp32_to_fp16(max(|ema_min|,|ema_max|) / 31), scales[i]=1 for all
+// sub-blocks.
+static std::vector<uint8_t> build_q6k_forced(const float *data, size_t N,
+                                             float ema_min, float ema_max) {
+  constexpr size_t QK = 256;
+  float amax = std::max(std::abs(ema_min), std::abs(ema_max));
+  if (amax < 1e-10f)
+    amax = 1e-10f;
+  float forced_d_f32 = amax / 31.0f;
+  uint16_t forced_d = q6k_fp32_to_fp16(forced_d_f32);
+
+  size_t n_blocks = (N + QK - 1) / QK;
+  std::vector<uint8_t> out(n_blocks * sizeof(q6k_block_t), 0);
+  auto *blocks = reinterpret_cast<q6k_block_t *>(out.data());
+
+  uint8_t L[QK];
+  for (size_t b = 0; b < n_blocks; ++b) {
+    auto &blk = blocks[b];
+    blk.d = forced_d;
+    for (int s = 0; s < 16; ++s)
+      blk.scales[s] = 1;
+
+    const float *x = data + b * QK;
+    size_t remaining = std::min(QK, N - b * QK);
+
+    for (size_t j = 0; j < QK; ++j) {
+      float v = (j < remaining) ? x[j] : 0.0f;
+      int q = (int)std::round(v / forced_d_f32);
+      q = std::max(-32, std::min(31, q));
+      L[j] = (uint8_t)(q + 32); // unsigned [0, 63]
+    }
+
+    // Pack ql/qh — mirrors quantize_row_q6_K_impl encoding
+    uint8_t *ql = blk.ql;
+    uint8_t *qh = blk.qh;
+    for (size_t j = 0; j < QK; j += 128) {
+      for (int l = 0; l < 32; ++l) {
+        uint8_t q1 = L[j + l + 0] & 0xF;
+        uint8_t q2 = L[j + l + 32] & 0xF;
+        uint8_t q3 = L[j + l + 64] & 0xF;
+        uint8_t q4 = L[j + l + 96] & 0xF;
+        ql[l + 0] = q1 | (q3 << 4);
+        ql[l + 32] = q2 | (q4 << 4);
+        qh[l] = ((L[j + l + 0] >> 4) & 3) | (((L[j + l + 32] >> 4) & 3) << 2) |
+                (((L[j + l + 64] >> 4) & 3) << 4) |
+                (((L[j + l + 96] >> 4) & 3) << 6);
+      }
+      ql += 64;
+      qh += 32;
+    }
+  }
+  return out;
+}
+
+// Dequantize Q6_K block buffer back to FP32 — mirrors dequantize_row_q6_K_impl.
+static void dequantize_q6k(const void *buf, float *out, size_t N) {
+  constexpr size_t QK = 256;
+  size_t n_blocks = (N + QK - 1) / QK;
+  const auto *blocks = reinterpret_cast<const q6k_block_t *>(buf);
+
+  for (size_t b = 0; b < n_blocks; ++b) {
+    const auto &blk = blocks[b];
+    float d = q6k_fp16_to_fp32(blk.d);
+
+    const uint8_t *ql = blk.ql;
+    const uint8_t *qh = blk.qh;
+    const int8_t *sc = blk.scales;
+    float *y = out + b * QK;
+
+    for (int n = 0; n < 2; ++n) { // two halves of 128 elements each
+      for (int l = 0; l < 32; ++l) {
+        int is = l / 16;
+        int8_t q1 =
+          (int8_t)((ql[l + 0] & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+        int8_t q2 =
+          (int8_t)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+        int8_t q3 =
+          (int8_t)(((ql[l + 0] >> 4)) | (((qh[l] >> 4) & 3) << 4)) - 32;
+        int8_t q4 =
+          (int8_t)(((ql[l + 32] >> 4)) | (((qh[l] >> 6) & 3) << 4)) - 32;
+        size_t base = (size_t)(b * QK + n * 128);
+        if (base + l + 0 < N)
+          y[n * 128 + l + 0] = d * sc[is + 0] * q1;
+        if (base + l + 32 < N)
+          y[n * 128 + l + 32] = d * sc[is + 2] * q2;
+        if (base + l + 64 < N)
+          y[n * 128 + l + 64] = d * sc[is + 4] * q3;
+        if (base + l + 96 < N)
+          y[n * 128 + l + 96] = d * sc[is + 6] * q4;
+      }
+      ql += 64;
+      qh += 32;
+      sc += 8;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Q4_0 helpers (block = 32 elements, 18 bytes: 2B FP16 scale + 16B nibbles)
+// ---------------------------------------------------------------------------
+
+// Build repacked Q4_0 bytes from FP32 weight stored in nntrainer (K, N) layout.
+// Mirrors the quantizer.cpp pipeline: transpose K×N→N×K, then quantize_q4_0,
+// then repack_q4_0. The repacked format is required by
+// __ggml_q4_0_4x8_q8_0_GEMM.
+static std::vector<uint8_t> build_q4_0_natural(const float *data_KN, size_t K,
+                                               size_t N) {
+  std::vector<float> transposed(N * K);
+  for (size_t n = 0; n < N; ++n)
+    for (size_t k = 0; k < K; ++k)
+      transposed[n * K + k] = data_KN[k * N + n];
+
+  size_t out_size = (N * K / 32) * 18;
+  std::vector<uint8_t> tmp(out_size);
+  nntrainer::quantize_q4_0(transposed.data(), tmp.data(), (int64_t)N,
+                           (int64_t)K, nullptr);
+
+  std::vector<uint8_t> out(out_size);
+  nntrainer::repack_q4_0(out.data(), tmp.data(), out_size, (unsigned int)N,
+                         (unsigned int)K);
+  return out;
+}
+
+// Minimal FP32→FP16 for writing Q4_0 block scale fields.
+static uint16_t q40_fp32_to_fp16(float v) {
+  union {
+    float f;
+    uint32_t u;
+  } x{v};
+  const uint32_t s = (x.u >> 16) & 0x8000u;
+  const int e = ((x.u >> 23) & 0xFFu) - 127 + 15;
+  const uint32_t m = x.u & 0x7FFFFFu;
+  if (e <= 0)
+    return (uint16_t)s;
+  if (e >= 31)
+    return (uint16_t)(s | 0x7C00u);
+  return (uint16_t)(s | ((uint32_t)e << 10) | (m >> 13));
+}
+
+// Build repacked Q4_0 bytes using pre-specified per-block EMA scales
+// (force-feed). block_d_NK must be indexed in N×K layout — the same layout
+// tracked by fakeQuantizeQ4_0. Matches build_q4_0_natural's output format
+// exactly so the repacked bytes can be loaded and run through gemm_q4_0
+// unchanged.
+static std::vector<uint8_t>
+build_q4_0_forced_blocks(const float *data_KN, size_t K, size_t N,
+                         const std::vector<float> &block_d_NK) {
+  std::vector<float> transposed(N * K);
+  for (size_t n = 0; n < N; ++n)
+    for (size_t k = 0; k < K; ++k)
+      transposed[n * K + k] = data_KN[k * N + n];
+
+  const size_t num_blocks = N * K / 32;
+  const size_t out_size = num_blocks * 18;
+  std::vector<uint8_t> tmp(out_size, 0);
+
+  for (size_t b = 0; b < num_blocks; ++b) {
+    const float *blk_data = transposed.data() + b * 32;
+    float d =
+      (b < block_d_NK.size() && block_d_NK[b] > 1e-10f) ? block_d_NK[b] : 1.0f;
+
+    uint16_t d_fp16 = q40_fp32_to_fp16(d);
+    uint8_t *blk = tmp.data() + b * 18;
+    std::memcpy(blk, &d_fp16, 2);
+
+    // Q4_0: quant stored as q+8 ∈ [0,15]; lower nibble = elem[j], upper =
+    // elem[j+16]
+    for (int j = 0; j < 16; ++j) {
+      int q0 = (int)std::round(blk_data[j] / d) + 8;
+      int q1 = (int)std::round(blk_data[j + 16] / d) + 8;
+      q0 = std::max(0, std::min(15, q0));
+      q1 = std::max(0, std::min(15, q1));
+      blk[2 + j] = (uint8_t)((q0 & 0x0F) | ((q1 & 0x0F) << 4));
+    }
+  }
+
+  std::vector<uint8_t> out(out_size);
+  nntrainer::repack_q4_0(out.data(), tmp.data(), out_size, (unsigned)N,
+                         (unsigned)K);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+
+void Transformer::save_weight_lora_q6k(const std::string &path) {
+  if (!is_initialized)
+    throw std::runtime_error(
+      "Model not initialized before save_weight_lora_q6k().");
+  if (!LORA_QAT)
+    throw std::runtime_error(
+      "save_weight_lora_q6k() requires LORA_QAT=true (no EMA stats).");
+
+  std::ofstream f(path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open " + path + " for writing.");
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+  size_t total_blocks = 0;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    auto stats = nntrainer::FullyConnectedLayer::getRegisteredStats(lname);
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      bool is_loraA = wname.find(":loraA") != std::string::npos;
+      bool is_loraB = wname.find(":loraB") != std::string::npos;
+      if (!is_loraA && !is_loraB)
+        continue;
+
+      if (!stats.valid)
+        throw std::runtime_error(
+          "No QAT EMA stats for layer '" + lname +
+          "'. "
+          "Ensure at least one training forward pass ran with lora_qat=true.");
+
+      float ema_min = is_loraA ? stats.a_min : stats.b_min;
+      float ema_max = is_loraA ? stats.a_max : stats.b_max;
+
+      uint32_t N = static_cast<uint32_t>(wdims[wi].getDataLen());
+      auto q6k_bytes = build_q6k_forced(wdata[wi], N, ema_min, ema_max);
+
+      f.write(reinterpret_cast<const char *>(&N), sizeof(N));
+      f.write(reinterpret_cast<const char *>(q6k_bytes.data()),
+              q6k_bytes.size());
+      total_blocks += q6k_bytes.size() / sizeof(q6k_block_t);
+    }
+  }
+
+  std::cout << "[save_weight_lora_q6k] Saved Q6_K LoRA adapters to " << path
+            << " (" << total_blocks << " blocks, "
+            << (total_blocks * 210 / 1024) << " KB)\n";
+}
+
+void Transformer::load_weight_lora_q6k(const std::string &base_path,
+                                       const std::string &lora_q6k_path) {
+  load_weight(base_path);
+
+  std::ifstream f(lora_q6k_path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open Q6_K LoRA file: " + lora_q6k_path);
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      if (wname.find(":loraA") == std::string::npos &&
+          wname.find(":loraB") == std::string::npos)
+        continue;
+
+      uint32_t N = 0;
+      f.read(reinterpret_cast<char *>(&N), sizeof(N));
+      if (!f)
+        throw std::runtime_error(
+          "load_weight_lora_q6k: failed reading element count at '" + wname +
+          "'");
+
+      uint32_t expected = static_cast<uint32_t>(wdims[wi].getDataLen());
+      if (N != expected)
+        throw std::runtime_error(
+          "load_weight_lora_q6k: element count mismatch for '" + wname +
+          "': file=" + std::to_string(N) +
+          " model=" + std::to_string(expected));
+
+      constexpr size_t QK = 256;
+      size_t n_blocks = (N + QK - 1) / QK;
+      size_t block_bytes = n_blocks * sizeof(q6k_block_t);
+
+      std::vector<uint8_t> buf(block_bytes);
+      f.read(reinterpret_cast<char *>(buf.data()), block_bytes);
+      if (!f)
+        throw std::runtime_error(
+          "load_weight_lora_q6k: failed reading Q6_K data for '" + wname + "'");
+
+      dequantize_q6k(buf.data(), wdata[wi], N);
+    }
+  }
+
+  std::cout << "[load_weight_lora_q6k] Loaded Q6_K LoRA adapters from "
+            << lora_q6k_path << "\n";
+}
+
+void Transformer::save_weight_lora_q4(const std::string &path) {
+  if (!is_initialized)
+    throw std::runtime_error(
+      "Model not initialized before save_weight_lora_q4().");
+
+  std::ofstream f(path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open " + path + " for writing.");
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+  size_t total_blocks = 0;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      if (wname.find(":loraA") == std::string::npos &&
+          wname.find(":loraB") == std::string::npos)
+        continue;
+
+      uint32_t total_elems = static_cast<uint32_t>(wdims[wi].getDataLen());
+      size_t K_dim = wdims[wi].height();
+      size_t N_dim = wdims[wi].width();
+
+      // QAT: force-feed EMA block scales (N×K layout) tracked during training.
+      // Non-QAT: use GGML natural per-block scales.
+      std::vector<uint8_t> q4_bytes;
+      if (LORA_QAT) {
+        auto [a_bd, b_bd] =
+          nntrainer::FullyConnectedLayer::getRegisteredBlockScales(lname);
+        const bool is_loraA = (wname.find(":loraA") != std::string::npos);
+        const auto &block_d = is_loraA ? a_bd : b_bd;
+        if (!block_d.empty())
+          q4_bytes = build_q4_0_forced_blocks(wdata[wi], K_dim, N_dim, block_d);
+        else
+          q4_bytes = build_q4_0_natural(wdata[wi], K_dim, N_dim);
+      } else {
+        q4_bytes = build_q4_0_natural(wdata[wi], K_dim, N_dim);
+      }
+
+      f.write(reinterpret_cast<const char *>(&total_elems),
+              sizeof(total_elems));
+      f.write(reinterpret_cast<const char *>(q4_bytes.data()), q4_bytes.size());
+      total_blocks += q4_bytes.size() / 18;
+    }
+  }
+
+  std::cout << "[save_weight_lora_q4] Saved Q4_0 LoRA adapters to " << path
+            << " (" << total_blocks << " blocks, " << (total_blocks * 18 / 1024)
+            << " KB)\n";
+}
+
+void Transformer::load_weight_lora_q4(const std::string &base_path,
+                                      const std::string &lora_q4_path) {
+  load_weight(base_path);
+
+  std::ifstream f(lora_q4_path, std::ios::binary);
+  if (!f.is_open())
+    throw std::runtime_error("Failed to open Q4_0 LoRA file: " + lora_q4_path);
+
+  auto layer_names = buildOrderedLayerNames(NUM_LAYERS);
+  std::unordered_set<float *> visited;
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      if (!wdata[wi])
+        continue;
+      if (!visited.insert(wdata[wi]).second)
+        continue;
+
+      const std::string &wname = layer->getWeightName(wi);
+      if (wname.find(":loraA") == std::string::npos &&
+          wname.find(":loraB") == std::string::npos)
+        continue;
+
+      uint32_t N = 0;
+      f.read(reinterpret_cast<char *>(&N), sizeof(N));
+      if (!f)
+        throw std::runtime_error(
+          "load_weight_lora_q4: failed reading element count at '" + wname +
+          "'");
+
+      uint32_t expected = static_cast<uint32_t>(wdims[wi].getDataLen());
+      if (N != expected)
+        throw std::runtime_error(
+          "load_weight_lora_q4: element count mismatch for '" + wname +
+          "': file=" + std::to_string(N) +
+          " model=" + std::to_string(expected));
+
+      // Write repacked Q4_0 bytes directly into the Q4_0 tensor buffer.
+      size_t block_bytes = (N / 32) * 18;
+      f.read(reinterpret_cast<char *>(wdata[wi]), block_bytes);
+      if (!f)
+        throw std::runtime_error(
+          "load_weight_lora_q4: failed reading Q4_0 data for '" + wname + "'");
+    }
+  }
+
+  std::cout << "[load_weight_lora_q4] Loaded Q4_0 LoRA adapters from "
+            << lora_q4_path << "\n";
+}
+
+void Transformer::setDataset(const ml::train::DatasetModeType &mode,
+                             std::shared_ptr<ml::train::Dataset> dataset) {
+  if (!is_initialized)
+    throw std::runtime_error("Model not initialized before setDataset().");
+  if (model->setDataset(mode, dataset))
+    throw std::runtime_error("Failed to set dataset on model.");
+}
+
+void Transformer::train() {
+  if (!is_initialized)
+    throw std::runtime_error("Model not initialized before train().");
+  if (model->train())
+    throw std::runtime_error("model->train() returned error.");
+}
+
+void Transformer::train(std::function<void(void *)> epoch_cb, void *epoch_data,
+                        std::function<bool(void *)> stop_cb, void *stop_data) {
+  if (!is_initialized)
+    throw std::runtime_error("Model not initialized before train().");
+  auto actual_stop = stop_cb ? stop_cb : [](void *) -> bool { return false; };
+  if (model->train({}, actual_stop, stop_data, epoch_cb, epoch_data))
+    throw std::runtime_error("model->train() returned error.");
+}
+
+ml::train::RunStats Transformer::getTrainingStats() {
+  return model->getTrainingStats();
+}
+
+ml::train::RunStats Transformer::getValidStats() {
+  return model->getValidStats();
+}
+
+void Transformer::summarize(std::ostream &out, unsigned int type) {
+  if (!is_initialized)
+    throw std::runtime_error("Model not initialized before summarize().");
+  model->summarize(out, static_cast<ml_train_summary_type_e>(type));
+}
+
+void Transformer::printLoRAQATStats() const {
+  if (!LORA_QAT || LORA_RANK == 0 || !is_initialized)
+    return;
+
+  static const char *suffixes[] = {
+    "_wq", "_wk", "_wv", "_attention_out", "_ffn_up", "_ffn_gate", "_ffn_down"};
+  std::string prefix = "layer0";
+
+  std::cout << "  [QAT] LoRA EMA stats (layer 0):\n";
+  for (const char *suf : suffixes) {
+    std::string lname = prefix + suf;
+    auto s = nntrainer::FullyConnectedLayer::getRegisteredStats(lname);
+    if (!s.valid)
+      continue;
+    std::cout << "    " << lname << "  A:[" << s.a_min << ", " << s.a_max
+              << "] scale=" << s.a_scale << "  B:[" << s.b_min << ", "
+              << s.b_max << "] scale=" << s.b_scale << "\n";
+  }
+  std::cout << std::flush;
+}
+
+void Transformer::exportWeightsToFile(const std::string &path) {
+  if (!is_initialized)
+    throw std::runtime_error(
+      "Model not initialized before exportWeightsToFile().");
+  std::ofstream f(path);
+  if (!f.is_open())
+    throw std::runtime_error("Cannot open " + path + " for weight export.");
+
+  std::vector<std::string> layer_names;
+  layer_names.push_back("embedding0");
+  for (int i = 0; i < NUM_LAYERS; ++i) {
+    std::string p = "layer" + std::to_string(i);
+    layer_names.push_back(p + "_attention_norm");
+    layer_names.push_back(p + "_wq");
+    layer_names.push_back(p + "_q_norm"); // Qwen3 QK norm
+    layer_names.push_back(p + "_wk");
+    layer_names.push_back(p + "_k_norm"); // Qwen3 QK norm
+    layer_names.push_back(p + "_wv");
+    layer_names.push_back(p + "_attention_out");
+    layer_names.push_back(p + "_ffn_norm");
+    layer_names.push_back(p + "_ffn_up");
+    layer_names.push_back(p + "_ffn_gate");
+    layer_names.push_back(p + "_ffn_down");
+  }
+  layer_names.push_back("output_norm");
+  layer_names.push_back("output_of_causallm");
+
+  for (const auto &lname : layer_names) {
+    std::shared_ptr<ml::train::Layer> layer;
+    try {
+      if (model->getLayer(lname.c_str(), &layer) != 0)
+        continue;
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<float *> wdata;
+    std::vector<ml::train::TensorDim> wdims;
+    try {
+      layer->getWeights(wdata, wdims);
+    } catch (...) {
+      continue;
+    }
+
+    for (unsigned int wi = 0; wi < wdata.size(); ++wi) {
+      try {
+        const std::string &wname = layer->getWeightName(wi);
+        unsigned int n = wdims[wi].getDataLen();
+        double norm = 0.0;
+        if (wdata[wi]) {
+          for (unsigned int k = 0; k < n; ++k)
+            norm += static_cast<double>(wdata[wi][k]) * wdata[wi][k];
+          norm = std::sqrt(norm);
+        }
+        f << lname << "/" << wname << ": " << std::fixed << std::setprecision(6)
+          << norm << "\n";
+      } catch (...) {
+        continue;
+      }
+    }
+  }
+}
 
 /**
  * @brief Run a transformer model for a prompt.
@@ -395,11 +1315,12 @@ void Transformer::run(const WSTR prompt, bool do_sample,
 Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
                                                   Tensor input) {
 
-  LayerHandle attn_norm(createLayer(
-    "rms_norm",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
-     withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+  std::vector<std::string> attn_norm_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
+    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+  if (LORA_RANK > 0)
+    attn_norm_props.push_back(withKey("trainable", "false"));
+  LayerHandle attn_norm(createLayer("rms_norm", attn_norm_props));
   Tensor normed = attn_norm(input);
 
   Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
@@ -410,11 +1331,12 @@ Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
     {withKey("name", "layer" + std::to_string(layer_id) + "_decoder_add")}));
   Tensor residual = decoder_add({input, att_out});
 
-  LayerHandle ffn_norm(createLayer(
-    "rms_norm",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
-     withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+  std::vector<std::string> ffn_norm_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
+    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+  if (LORA_RANK > 0)
+    ffn_norm_props.push_back(withKey("trainable", "false"));
+  LayerHandle ffn_norm(createLayer("rms_norm", ffn_norm_props));
   Tensor ffn_normed = ffn_norm(residual);
 
   Tensor ffn_out = createMlp(layer_id, DIM, INTERMEDIATE_SIZE, ffn_normed);
@@ -467,27 +1389,39 @@ Tensor Transformer::createAttention(const int layer_id, int seq_len,
                                     Tensor key, Tensor value) {
 
   // Q layer
-  LayerHandle wq(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_wq"),
-     withKey("unit", head_dim * n_heads), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
+  std::vector<std::string> wq_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_wq"),
+    withKey("unit", head_dim * n_heads), withKey("disable_bias", "true"),
+    withKey("weight_initializer", "ones")};
+  if (hasLoRA("wq"))
+    appendLoRAProps(wq_props);
+  else if (LORA_RANK > 0)
+    wq_props.push_back(withKey("trainable", "false"));
+  LayerHandle wq(createLayer("fully_connected", wq_props));
   Tensor q = wq(query);
 
   // K layer
-  LayerHandle wk(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_wk"),
-     withKey("unit", head_dim * n_heads / GQA_SIZE),
-     withKey("disable_bias", "true"), withKey("weight_initializer", "ones")}));
+  std::vector<std::string> wk_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_wk"),
+    withKey("unit", head_dim * n_heads / GQA_SIZE),
+    withKey("disable_bias", "true"), withKey("weight_initializer", "ones")};
+  if (hasLoRA("wk"))
+    appendLoRAProps(wk_props);
+  else if (LORA_RANK > 0)
+    wk_props.push_back(withKey("trainable", "false"));
+  LayerHandle wk(createLayer("fully_connected", wk_props));
   Tensor k = wk(key);
 
   // V layer
-  LayerHandle wv(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_wv"),
-     withKey("unit", head_dim * n_heads / GQA_SIZE),
-     withKey("disable_bias", "true"), withKey("weight_initializer", "ones")}));
+  std::vector<std::string> wv_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_wv"),
+    withKey("unit", head_dim * n_heads / GQA_SIZE),
+    withKey("disable_bias", "true"), withKey("weight_initializer", "ones")};
+  if (hasLoRA("wv"))
+    appendLoRAProps(wv_props);
+  else if (LORA_RANK > 0)
+    wv_props.push_back(withKey("trainable", "false"));
+  LayerHandle wv(createLayer("fully_connected", wv_props));
   Tensor v = wv(value);
 
   // External KV cache placeholders (per-layer). Their actual storage is owned
@@ -509,11 +1443,15 @@ Tensor Transformer::createAttention(const int layer_id, int seq_len,
   Tensor a = mha({q, k, v, cache_k, cache_v});
 
   // O layer
-  LayerHandle wo(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_attention_out"),
-     withKey("unit", DIM), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
+  std::vector<std::string> wo_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_attention_out"),
+    withKey("unit", DIM), withKey("disable_bias", "true"),
+    withKey("weight_initializer", "ones")};
+  if (hasLoRA("wo"))
+    appendLoRAProps(wo_props);
+  else if (LORA_RANK > 0)
+    wo_props.push_back(withKey("trainable", "false"));
+  LayerHandle wo(createLayer("fully_connected", wo_props));
   return wo(a);
 }
 
@@ -523,18 +1461,26 @@ Tensor Transformer::createAttention(const int layer_id, int seq_len,
 Tensor Transformer::createMlp(const int layer_id, int dim, int hidden_dim,
                               Tensor input) {
 
-  LayerHandle ffn_up(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_up"),
-     withKey("unit", hidden_dim), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
+  std::vector<std::string> ffn_up_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_ffn_up"),
+    withKey("unit", hidden_dim), withKey("disable_bias", "true"),
+    withKey("weight_initializer", "ones")};
+  if (hasLoRA("ffn_up"))
+    appendLoRAProps(ffn_up_props);
+  else if (LORA_RANK > 0)
+    ffn_up_props.push_back(withKey("trainable", "false"));
+  LayerHandle ffn_up(createLayer("fully_connected", ffn_up_props));
   Tensor up = ffn_up(input);
 
-  LayerHandle ffn_gate(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_gate"),
-     withKey("unit", hidden_dim), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
+  std::vector<std::string> ffn_gate_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_ffn_gate"),
+    withKey("unit", hidden_dim), withKey("disable_bias", "true"),
+    withKey("weight_initializer", "ones")};
+  if (hasLoRA("ffn_gate"))
+    appendLoRAProps(ffn_gate_props);
+  else if (LORA_RANK > 0)
+    ffn_gate_props.push_back(withKey("trainable", "false"));
+  LayerHandle ffn_gate(createLayer("fully_connected", ffn_gate_props));
   Tensor gate = ffn_gate(input);
 
   /// @note nntrainer binary stores mlp weights in up, gate order.
@@ -547,11 +1493,15 @@ Tensor Transformer::createMlp(const int layer_id, int dim, int hidden_dim,
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
   Tensor act = swiglu({up, gate}, {1, 0});
 
-  LayerHandle ffn_down(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_down"),
-     withKey("unit", dim), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
+  std::vector<std::string> ffn_down_props = {
+    withKey("name", "layer" + std::to_string(layer_id) + "_ffn_down"),
+    withKey("unit", dim), withKey("disable_bias", "true"),
+    withKey("weight_initializer", "ones")};
+  if (hasLoRA("ffn_down"))
+    appendLoRAProps(ffn_down_props);
+  else if (LORA_RANK > 0)
+    ffn_down_props.push_back(withKey("trainable", "false"));
+  LayerHandle ffn_down(createLayer("fully_connected", ffn_down_props));
   return ffn_down(act);
 }
 

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -6,6 +6,8 @@
  * @date   31 Dec 2025
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>
+ * @author Anirudh <b.saianirud@samsung.com>
+ * @author Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug    No known bugs except for NYI items
  * @note   This transformer.h constructs a class for Transformer model which can
  * be a parent of CausalLM and Encoder models with transformer structure.
@@ -34,6 +36,7 @@
 #define WCHAR_P std::string &
 #endif
 
+#include <functional>
 #include <layer.h>
 #include <map>
 #include <model.h>
@@ -133,9 +136,17 @@ public:
   virtual ~Transformer() {}
 
   /**
-   * @brief Initialize and Construct the Transformer model
+   * @brief Initialize and Construct the Transformer model (inference mode)
    */
   virtual void initialize();
+
+  /**
+   * @brief Initialize model for LoRA fine-tuning (training mode).
+   *        Adds cross_softmax loss, Adam optimizer, compiles in TRAIN mode.
+   * @param lr   Learning rate for Adam optimizer
+   * @param epochs Number of training epochs
+   */
+  virtual void initializeForTraining(float lr, unsigned int epochs);
 
   /**
    * @brief Load the model weights from a file
@@ -153,6 +164,100 @@ public:
    * @brief Save the weight to a file
    */
   virtual void save_weight(const std::string &weight_path);
+  /**
+   * @brief Save only LoRA adapter weights (loraA/loraB) to a file.
+   *        For use after LoRA training.
+   */
+  virtual void save_weight_lora(const std::string &weight_path);
+
+  /**
+   * @brief Load base weights, then overlay LoRA adapter weights on top.
+   */
+  virtual void load_weight_lora(const std::string &base_path,
+                                const std::string &lora_path);
+
+  /**
+   * @brief Save LoRA adapters as Q6_K with force-fed scales from QAT EMA stats.
+   *        Only valid after QAT training (lora_qat=true).
+   *        File format per adapter: uint32_t N + ceil(N/256)*210 raw Q6_K
+   * bytes.
+   */
+  virtual void save_weight_lora_q6k(const std::string &path);
+
+  /**
+   * @brief Load base weights, then load Q6_K LoRA adapters and dequantize to
+   * FP32.
+   */
+  virtual void load_weight_lora_q6k(const std::string &base_path,
+                                    const std::string &lora_q6k_path);
+
+  /**
+   * @brief Save LoRA adapters as Q4_0 with force-fed scales from QAT EMA stats.
+   *        Only valid after QAT training with --lora_q4 (lora_qat +
+   * lora_weight_q4). File format per adapter: uint32_t N + (N/32)*18 raw Q4_0
+   * block bytes. Requires lora_rank % 32 == 0 (rank=32 recommended).
+   */
+  virtual void save_weight_lora_q4(const std::string &path);
+
+  /**
+   * @brief Load base weights, then load Q4_0 LoRA adapters directly into Q4_0
+   * tensors. No dequantization — the W4A8 kernel fires at runtime.
+   */
+  virtual void load_weight_lora_q4(const std::string &base_path,
+                                   const std::string &lora_q4_path);
+
+  /**
+   * @brief Set a dataset on the underlying nntrainer model.
+   */
+  virtual void setDataset(const ml::train::DatasetModeType &mode,
+                          std::shared_ptr<ml::train::Dataset> dataset);
+
+  /**
+   * @brief Run training on the model (wraps model->train()).
+   */
+  virtual void train();
+
+  /**
+   * @brief Run training with an epoch-end callback and optional early-stop
+   *        predicate.
+   * @param epoch_cb   Called at the end of each epoch (after stats are
+   * updated).
+   * @param epoch_data Passed as-is to epoch_cb.
+   * @param stop_cb    Returns true to stop training early. nullptr = never
+   * stop.
+   * @param stop_data  Passed as-is to stop_cb.
+   */
+  virtual void train(std::function<void(void *)> epoch_cb, void *epoch_data,
+                     std::function<bool(void *)> stop_cb = nullptr,
+                     void *stop_data = nullptr);
+
+  /**
+   * @brief Return training stats from the last completed epoch.
+   */
+  virtual ml::train::RunStats getTrainingStats();
+
+  /**
+   * @brief Return validation stats from the last completed epoch.
+   */
+  virtual ml::train::RunStats getValidStats();
+
+  /**
+   * @brief Print model summary to a stream.
+   */
+  virtual void summarize(std::ostream &out, unsigned int type);
+
+  /**
+   * @brief Export weight names and norms to a text file for debugging.
+   */
+  virtual void exportWeightsToFile(const std::string &path);
+
+  /**
+   * @brief Print per-epoch QAT calibration stats for the first transformer
+   * block's LoRA adapters (wq, wk, wv, wo, ffn_up, ffn_gate, ffn_down). No-op
+   * when LORA_QAT is false or LoRA not active.
+   */
+  virtual void printLoRAQATStats() const;
+
   /**
    * @brief Save the weight to a file with type conversion
    * @param weight_path Path to save the weight file
@@ -349,6 +454,17 @@ protected:
   formatFromExtension(const std::string &weight_path);
 
   /**
+   * @brief Returns true if module_type (e.g. "q_proj") is in LORA_TARGET and
+   * LORA_RANK > 0.
+   */
+  bool hasLoRA(const std::string &module_type) const;
+
+  /**
+   * @brief Append lora_rank (and lora_alpha if set) to a layer property list.
+   */
+  void appendLoRAProps(std::vector<std::string> &props) const;
+
+  /**
    * @brief register Outputs
    */
   bool is_initialized = false; /**< Flag to check if the model is initialized */
@@ -389,6 +505,15 @@ protected:
   float ATTN_LOGIT_SOFTCAPPING = 0.0f; /**< attention logit softcapping */
   bool IS_CAUSAL = true;
 
+  unsigned int LORA_RANK = 0;  /**< LoRA rank (0 = disabled) */
+  unsigned int LORA_ALPHA = 0; /**< LoRA alpha (0 = use scaling=1) */
+  bool LORA_QAT =
+    false; /**< enable fake-quant on LoRA adapters (QAT training) */
+  bool LORA_Q4 =
+    false; /**< Q4_0 LoRA: W4A8 inference + Q4_0 fake-quant range */
+  std::vector<std::string> LORA_TARGET; /**< module names to apply LoRA to,
+                                            e.g. {"q_proj","v_proj"} */
+
   // Performance metrics
   TransformerPerformanceMetrics performance_metrics;
 
@@ -400,6 +525,8 @@ protected:
  * @return JSON object
  * @throws std::runtime_error on file open or parse failure
  */
+std::string LoadBytesFromFile(const std::string &path);
+
 inline json LoadJsonFile(const std::string &file_path) {
   std::ifstream file(file_path);
   if (!file.is_open()) {

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -8,6 +8,8 @@
  * layers
  * @see	   https://github.com/nntrainer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author Anirudh <b.saianirud@samsung.com>
+ * @author Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug    No known bugs except for NYI items
  */
 #ifndef __COMMON_PROPERTIES_H__
@@ -1524,6 +1526,27 @@ class LoraAlpha : public PositiveIntegerProperty {
 public:
   static constexpr const char *key = "lora_alpha"; /**< unique key to access */
   using prop_tag = uint_prop_tag;                  /**< property type */
+};
+
+/**
+ * @brief Enable QAT (fake quantization) on LoRA adapters
+ */
+class LoraQAT : public Property<bool> {
+public:
+  static constexpr const char *key = "lora_qat"; /**< unique key to access */
+  using prop_tag = bool_prop_tag;                 /**< property type */
+};
+
+/**
+ * @brief Store LoRA adapters as Q4_0 (4-bit, block=32).
+ *        Inference: loraA/loraB registered as Q4_0 tensors (W4A8 kernel).
+ *        Training+QAT: fake-quantize range uses Q4_0 grid [-8, 7].
+ *        Requires lora_rank to be a multiple of 32.
+ */
+class LoraWeightQ4 : public Property<bool> {
+public:
+  static constexpr const char *key = "lora_weight_q4"; /**< unique key */
+  using prop_tag = bool_prop_tag;                       /**< property type */
 };
 
 /**

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -17,9 +17,19 @@
  * @brief	This is Fully Connected Layer Class for Neural Network
  * @see		https://github.com/nntrainer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Anirudh <b.saianirud@samsung.com>
+ * @author	Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug		No known bugs except for NYI items
  *
  */
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <numeric>
+#include <unordered_map>
 
 #include <common_properties.h>
 #include <fc_layer.h>
@@ -30,8 +40,6 @@
 #include <node_exporter.h>
 #include <util_func.h>
 
-#include <iostream>
-
 namespace nntrainer {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
@@ -39,13 +47,104 @@ static constexpr size_t SINGLE_INOUT_IDX = 0;
 enum FCParams { weight, bias };
 enum LORAParams { loraA, loraB, loraTmp, loraOut };
 
+// Static registries: layer_name → QAT stats / per-block EMA scales.
+std::mutex FullyConnectedLayer::s_registry_mutex;
+std::unordered_map<std::string, FullyConnectedLayer::LoRAQATStats>
+  FullyConnectedLayer::s_qat_registry;
+std::unordered_map<std::string,
+  std::pair<std::vector<float>, std::vector<float>>>
+  FullyConnectedLayer::s_block_d_registry;
+
 FullyConnectedLayer::FullyConnectedLayer() :
   LayerImpl(),
   lora_scaling(1.0f),
-  fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha()),
-  quantizer(nullptr) {
+  fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha(), props::LoraQAT(),
+           props::LoraWeightQ4()),
+  quantizer(nullptr),
+  momentum(0.1f) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
   lora_idx.fill(std::numeric_limits<unsigned>::max());
+}
+
+FullyConnectedLayer::~FullyConnectedLayer() = default;
+
+// Per-block Q4_0 fake-quantization with EMA block scales tracked in N×K layout.
+//
+// Blocks are defined in N×K layout (the transposed layout that build_q4_0_natural
+// and the GEMM kernel use). This ensures the EMA scales exactly match the block
+// boundaries used at save time, so force-feeding works correctly.
+//
+// Training:  compute fresh d_fresh per N×K block, bootstrap EMA on first call,
+//            then update: block_d[b] = (1-m)*block_d[b] + m*d_fresh.
+//            Quantize using updated EMA scale.
+// Validation: use current EMA without updating.
+// STE: gradient passes through the clamp+round unchanged.
+Tensor FullyConnectedLayer::fakeQuantizeQ4_0(const Tensor &x,
+                                              std::vector<float> &block_d,
+                                              bool training) {
+  // x is stored K×N in nntrainer (height=K, width=N)
+  const size_t K = x.getDim().height();
+  const size_t N = x.getDim().width();
+  const size_t num_blocks_NK = (K * N) / 32;
+
+  if (block_d.empty())
+    block_d.resize(num_blocks_NK, 0.0f);
+
+  // Compute fresh per-block scales in N×K layout.
+  // For N×K linear index nk = b*32+j: n = nk/K, k = nk%K → K×N index = k*N+n.
+  for (size_t b = 0; b < num_blocks_NK; ++b) {
+    float max_abs = 0.0f;
+    for (size_t j = 0; j < 32; ++j) {
+      const size_t nk  = b * 32 + j;
+      const size_t n   = nk / K;
+      const size_t k   = nk % K;
+      max_abs = std::max(max_abs, std::abs(x.getValue<float>(k * N + n)));
+    }
+    const float d_fresh = (max_abs > 1e-8f) ? max_abs / 8.0f : 0.0f;
+    if (training) {
+      if (block_d[b] < 1e-10f)
+        block_d[b] = d_fresh;
+      else
+        block_d[b] = (1.0f - momentum) * block_d[b] + momentum * d_fresh;
+    }
+  }
+
+  // Apply fake-quant iterating K×N order; map each element to its N×K block.
+  // apply() iterates K×N linearly: index i = k*N + n → k = i/N, n = i%N
+  // → N×K index nk = n*K + k → block = nk/32.
+  Tensor x_fq = x.clone();
+  size_t i = 0;
+  std::function<float(float)> fn = [&i, K, N, &block_d](float v) -> float {
+    const size_t k  = i / N;
+    const size_t n  = i % N;
+    const size_t b  = (n * K + k) / 32;
+    ++i;
+    const float d = block_d[b];
+    if (d < 1e-10f) return v;
+    float q = std::round(v / d);
+    q = std::max(-8.0f, std::min(7.0f, q));
+    return q * d;
+  };
+  x_fq.apply<float>(fn, x_fq);
+  return x_fq;
+}
+
+FullyConnectedLayer::LoRAQATStats
+FullyConnectedLayer::getRegisteredStats(const std::string &layer_name) {
+  std::lock_guard<std::mutex> lock(s_registry_mutex);
+  auto it = s_qat_registry.find(layer_name);
+  if (it != s_qat_registry.end())
+    return it->second;
+  return {};
+}
+
+std::pair<std::vector<float>, std::vector<float>>
+FullyConnectedLayer::getRegisteredBlockScales(const std::string &layer_name) {
+  std::lock_guard<std::mutex> lock(s_registry_mutex);
+  auto it = s_block_d_registry.find(layer_name);
+  if (it != s_block_d_registry.end())
+    return it->second;
+  return {};
 }
 
 void FullyConnectedLayer::finalize(InitLayerContext &context) {
@@ -112,31 +211,43 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
     TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
     is_nchw ? 0b0011 : 0b0101);
 
+  // Base weight is trainable only when LoRA is not active for this layer.
+  // When lora_rank > 0, only loraA/loraB update; W is frozen.
   weight_idx[FCParams::weight] = context.requestWeight(
     weight_dim, weight_initializer, weight_regularizer,
-    weight_regularizer_constant, weight_decay, "weight", true);
+    weight_regularizer_constant, weight_decay, "weight", (lora_rank == 0));
 
   if (disable_bias.empty() || disable_bias.get() == false) {
     weight_idx[FCParams::bias] =
       context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
-                            1.0f, bias_decay, "bias", true);
+                            1.0f, bias_decay, "bias", (lora_rank == 0));
   }
 
   /** create weights for LoRA */
   if (lora_rank) {
 
+    const bool lora_qat_mode = !std::get<props::LoraQAT>(fc_props).empty() &&
+                               std::get<props::LoraQAT>(fc_props).get();
+    const bool lora_q4       = !std::get<props::LoraWeightQ4>(fc_props).empty() &&
+                               std::get<props::LoraWeightQ4>(fc_props).get();
+    // Inference with Q4_0: use Q4_0 tensor dtype → W4A8 kernel fires at runtime.
+    // Training (QAT): keep FP32 for gradients; fake-quant range adjusted below.
+    const auto lora_dtype = (lora_q4 && !lora_qat_mode)
+                              ? TensorDim::DataType::Q4_0
+                              : TensorDim::DataType::FP32;
+
     /** loraA Dimension : (1, 1, in_dim.width, lora_rank) */
     TensorDim loraA_dim(
       1, is_nchw ? 1 : lora_rank, is_nchw ? in_dim.width() : 1,
       is_nchw ? lora_rank : in_dim.channel(),
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      TensorDim::TensorType(context.getFormat(), lora_dtype),
       is_nchw ? 0b0011 : 0b0101);
 
     /** loraB Dimension : (1, 1, lora_rank, unit) */
     TensorDim loraB_dim(
       1, is_nchw ? 1 : unit, is_nchw ? lora_rank : 1,
       is_nchw ? unit : lora_rank,
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      TensorDim::TensorType(context.getFormat(), lora_dtype),
       is_nchw ? 0b0011 : 0b0101);
 
     /** loraTmp Dimension : (B, 1, in_dim.height(), lora_rank) */
@@ -155,13 +266,25 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
                             context.getActivationDataType()),
       is_nchw ? 0b1011 : 0b1101);
 
+    // Q4_0 inference: NONE init (will be overwritten from file), not trainable.
+    // QAT + FP32 training: A=random, B=zeros — standard LoRA init (Hu et al. 2022).
+    // With A=zeros,B=random (old QAT init) loraB gets near-zero gradient since
+    // grad_loraB = output_grad * loraA^T ≈ 0, so loraB never learns.
+    const bool use_q4_tensors = lora_q4 && !lora_qat_mode;
+    const Initializer loraA_init = use_q4_tensors
+      ? Initializer::NONE : Initializer::LECUN_NORMAL;
+    const Initializer loraB_init = use_q4_tensors
+      ? Initializer::NONE : Initializer::ZEROS;
+
     lora_idx[LORAParams::loraA] = context.requestWeight(
-      loraA_dim, Initializer::ZEROS, weight_regularizer,
-      weight_regularizer_constant, weight_decay, "loraA", true);
+      loraA_dim, loraA_init,
+      weight_regularizer, weight_regularizer_constant, weight_decay,
+      "loraA", !use_q4_tensors);
 
     lora_idx[LORAParams::loraB] = context.requestWeight(
-      loraB_dim, Initializer::LECUN_NORMAL, weight_regularizer,
-      weight_regularizer_constant, weight_decay, "loraB", true);
+      loraB_dim, loraB_init,
+      weight_regularizer, weight_regularizer_constant, weight_decay,
+      "loraB", !use_q4_tensors);
 
     lora_idx[LORAParams::loraTmp] =
       context.requestTensor(loraTmp_dim, "hidden_tmp_lora", Initializer::NONE,
@@ -170,6 +293,14 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
     lora_idx[LORAParams::loraOut] =
       context.requestTensor(loraOut_dim, "hidden_lora", Initializer::NONE, true,
                             TensorLifespan::FORWARD_FUNC_LIFESPAN);
+
+    if (lora_qat_mode) {
+      layer_name_ = context.getName();
+      static int qat_layer_count = 0;
+      if (++qat_layer_count == 1)
+        std::cerr << "[QAT] LoRA QAT active: per-block Q4_0 fake-quant "
+                     "(16 levels, block=32, symmetric).\n";
+    }
   }
 
   ///@todo this quantizaer should be moved to tensor, not layer!
@@ -225,8 +356,32 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
     Tensor &hidden_tmp_lora = context.getTensor(lora_idx[LORAParams::loraTmp]);
     Tensor &hidden_out_lora = context.getTensor(lora_idx[LORAParams::loraOut]);
 
-    input_.dot(loraA, hidden_tmp_lora, false, false);
-    hidden_tmp_lora.dot(loraB, hidden_out_lora, false, false);
+    const bool lora_qat = !std::get<props::LoraQAT>(fc_props).empty() &&
+                           std::get<props::LoraQAT>(fc_props).get();
+    if (lora_qat) {
+      // Per-block EMA fake-quant: training updates EMA, validation reads it.
+      a_fq = fakeQuantizeQ4_0(loraA, lora_a_block_d, training);
+      b_fq = fakeQuantizeQ4_0(loraB, lora_b_block_d, training);
+      // Push current EMA stats to both registries.
+      if (!lora_a_block_d.empty() && !lora_b_block_d.empty()) {
+        LoRAQATStats s;
+        s.a_min = loraA.minValue();  s.a_max = loraA.maxValue();
+        s.a_scale = std::accumulate(lora_a_block_d.begin(), lora_a_block_d.end(), 0.0f)
+                    / static_cast<float>(lora_a_block_d.size());
+        s.b_min = loraB.minValue();  s.b_max = loraB.maxValue();
+        s.b_scale = std::accumulate(lora_b_block_d.begin(), lora_b_block_d.end(), 0.0f)
+                    / static_cast<float>(lora_b_block_d.size());
+        s.valid = true;
+        std::lock_guard<std::mutex> lk(s_registry_mutex);
+        s_qat_registry[layer_name_]    = s;
+        s_block_d_registry[layer_name_] = {lora_a_block_d, lora_b_block_d};
+      }
+      input_.dot(a_fq, hidden_tmp_lora, false, false);
+      hidden_tmp_lora.dot(b_fq, hidden_out_lora, false, false);
+    } else {
+      input_.dot(loraA, hidden_tmp_lora, false, false);
+      hidden_tmp_lora.dot(loraB, hidden_out_lora, false, false);
+    }
     hidden_out_lora.multiply_i(lora_scaling);
     hidden_.add_i(hidden_out_lora);
   }
@@ -245,7 +400,7 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
   Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  Tensor loraA, loraB, hidden_tmp_lora, hidden_out_lora;
+  Tensor loraA, loraB;
 
   bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
@@ -254,8 +409,9 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   if (!std::get<props::LoraRank>(fc_props).empty()) {
     loraA = context.getWeight(lora_idx[LORAParams::loraA]);
     loraB = context.getWeight(lora_idx[LORAParams::loraB]);
-    hidden_tmp_lora = context.getTensor(lora_idx[LORAParams::loraTmp]);
-    hidden_out_lora = context.getTensor(lora_idx[LORAParams::loraOut]);
+    // loraTmp/loraOut are NOT fetched from context here: they use
+    // FORWARD_GRAD_LIFESPAN which may not be allocated in inference mode.
+    // Instead, local tensors are allocated per batch step below.
   }
 
   TensorDim input_dim = input_.getDim();
@@ -281,24 +437,12 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
     input_step.dot(weight, hidden_step, false, false);
 
     if (!std::get<props::LoraRank>(fc_props).empty()) {
-      nntrainer::TensorDim hidden_tmp_lora_step_dim = hidden_tmp_lora.getDim();
-      hidden_tmp_lora_step_dim.batch(1);
-      if (hidden_tmp_lora_step_dim.height() > 1)
-        hidden_tmp_lora_step_dim.height(to - from);
-
-      nntrainer::TensorDim hidden_out_lora_step_dim = hidden_out_lora.getDim();
-      hidden_out_lora_step_dim.batch(1);
-      if (hidden_out_lora_step_dim.height() > 1)
-        hidden_out_lora_step_dim.height(to - from);
-
-      nntrainer::Tensor hidden_tmp_lora_step =
-        hidden_tmp_lora.getSharedDataTensor(
-          hidden_tmp_lora_step_dim,
-          b * hidden_tmp_lora.height() * hidden_tmp_lora.width(), true);
-      nntrainer::Tensor hidden_out_lora_step =
-        hidden_out_lora.getSharedDataTensor(
-          hidden_out_lora_step_dim,
-          b * hidden_out_lora.height() * hidden_out_lora.width(), true);
+      // Allocate local intermediates — avoids context.getTensor which may fail
+      // in inference mode (FORWARD_GRAD_LIFESPAN not allocated without backward).
+      TensorDim tmp_step_dim = input_step_dim;
+      tmp_step_dim.width(loraA.getDim().width()); // lora_rank
+      nntrainer::Tensor hidden_tmp_lora_step(tmp_step_dim);
+      nntrainer::Tensor hidden_out_lora_step(hidden_step_dim);
 
       input_step.dot(loraA, hidden_tmp_lora_step, false, false);
       hidden_tmp_lora_step.dot(loraB, hidden_out_lora_step, false, false);
@@ -321,10 +465,38 @@ void FullyConnectedLayer::calcDerivative(RunLayerContext &context) {
   Tensor &ret_ = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
 
   if (!std::get<props::LoraRank>(fc_props).empty()) {
-    Tensor &lora_A = context.getWeight(lora_idx[LORAParams::loraA]);
-    Tensor &lora_B = context.getWeight(lora_idx[LORAParams::loraB]);
-    ret_.dot_deriv_wrt_1(weight.add(lora_A.dot(lora_B).multiply(lora_scaling)),
-                         derivative_, false, false);
+    // MODE 2 (LoRA QAT): effective weight = W_frozen + a_fq · b_fq · scaling
+    // dL/dx = dL/dy * [W + a_fq · b_fq · scaling]^T
+    // Using a_fq/b_fq (from forward) matches Pranjal's qat_fc_layer reference.
+    // Base is frozen in LoRA training so this gradient feeds no weight update,
+    // but using a_fq/b_fq is theoretically correct for the forward computation.
+    Tensor w_fp32;
+    using DT = TensorDim::DataType;
+    if (quantizer != nullptr) {
+      Tensor &lora_A = context.getWeight(lora_idx[LORAParams::loraA]);
+      w_fp32 = quantizer->dequantize(weight, lora_A.getDataType());
+    } else if (weight.getDataType() == DT::Q4_0) {
+      auto dq = Quantization::createQuantizer(nntrainer::QScheme::Q4_0);
+      w_fp32 = dq->dequantize(weight, DT::FP32);
+    } else if (weight.getDataType() == DT::Q6_K) {
+      auto dq = Quantization::createQuantizer(nntrainer::QScheme::Q6_K);
+      w_fp32 = dq->dequantize(weight, DT::FP32);
+    } else {
+      w_fp32 = weight;
+    }
+
+    const bool lora_qat_deriv = !std::get<props::LoraQAT>(fc_props).empty() &&
+                                std::get<props::LoraQAT>(fc_props).get();
+    Tensor lora_contrib;
+    if (lora_qat_deriv) {
+      // chain-rule STE: dL/dx uses the same a_fq/b_fq that the forward used
+      lora_contrib = a_fq.dot(b_fq).multiply(lora_scaling);
+    } else {
+      Tensor &lora_A = context.getWeight(lora_idx[LORAParams::loraA]);
+      Tensor &lora_B = context.getWeight(lora_idx[LORAParams::loraB]);
+      lora_contrib = lora_A.dot(lora_B).multiply(lora_scaling);
+    }
+    ret_.dot_deriv_wrt_1(w_fp32.add(lora_contrib), derivative_, false, false);
   } else {
     ret_.dot_deriv_wrt_1(weight, derivative_, false, false);
   }
@@ -358,24 +530,39 @@ void FullyConnectedLayer::calcGradient(RunLayerContext &context) {
       djdw, derivative_, false, false,
       !context.isGradientFirstAccess(weight_idx[FCParams::weight]));
   } else {
-    /** (lora) calcGradient - compute gradients of LoRA params only */
+    // LoRA calcGradient with chain-rule STE.
+    // QAT path: backward uses b_fq (from forward) for dL/dA, matching
+    // the actual computation in forwarding. B=LECUN_NORMAL init ensures
+    // b_fq is non-zero from batch 1, so A gets gradient immediately.
+    // Non-QAT path: uses raw loraB as before.
+
     Tensor &djdla = context.getWeightGrad(lora_idx[LORAParams::loraA]);
     Tensor &djdlb = context.getWeightGrad(lora_idx[LORAParams::loraB]);
     Tensor &djdtmp = context.getTensorGrad(lora_idx[LORAParams::loraTmp]);
 
     const Tensor &derivative_ = context.getIncomingDerivative(SINGLE_INOUT_IDX);
     Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
-    Tensor &loraA = context.getWeight(lora_idx[LORAParams::loraA]);
-    Tensor &loraB = context.getWeight(lora_idx[LORAParams::loraB]);
     Tensor &loraTmp = context.getTensor(lora_idx[LORAParams::loraTmp]);
     const auto &lora_derivative_ = derivative_.multiply(lora_scaling);
 
     loraTmp.dot_deriv_wrt_2(
       djdlb, lora_derivative_, false, false,
       !context.isGradientFirstAccess(lora_idx[LORAParams::loraB]));
-    djdtmp.dot_deriv_wrt_1(
-      loraB, lora_derivative_, false, false,
-      !context.isGradientFirstAccess(lora_idx[LORAParams::loraTmp]));
+
+    const bool lora_qat_grad = !std::get<props::LoraQAT>(fc_props).empty() &&
+                               std::get<props::LoraQAT>(fc_props).get();
+    if (lora_qat_grad) {
+      // chain-rule STE: dL/d(loraTmp) = dL/dy_lora · b_fq^T
+      djdtmp.dot_deriv_wrt_1(
+        b_fq, lora_derivative_, false, false,
+        !context.isGradientFirstAccess(lora_idx[LORAParams::loraTmp]));
+    } else {
+      Tensor &loraB = context.getWeight(lora_idx[LORAParams::loraB]);
+      djdtmp.dot_deriv_wrt_1(
+        loraB, lora_derivative_, false, false,
+        !context.isGradientFirstAccess(lora_idx[LORAParams::loraTmp]));
+    }
+
     input_.dot_deriv_wrt_2(
       djdla, djdtmp, false, false,
       !context.isGradientFirstAccess(lora_idx[LORAParams::loraA]));

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -7,6 +7,8 @@
  * @brief  This is Fully Connected Layer Class of Neural Network
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @author Anirudh <b.saianirud@samsung.com>
+ * @author Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
@@ -16,7 +18,14 @@
 #ifdef __cplusplus
 
 #include <common_properties.h>
+#include <functional>
 #include <layer_impl.h>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <tensor.h>
+#include <unordered_map>
+#include <vector>
 
 namespace nntrainer {
 
@@ -33,8 +42,9 @@ public:
 
   /**
    * @brief     Destructor of Fully Connected Layer
+   * Prints final QAT calibration stats when lora_qat was active.
    */
-  ~FullyConnectedLayer() = default;
+  ~FullyConnectedLayer();
 
   /**
    *  @brief  Move constructor.
@@ -111,18 +121,64 @@ public:
 
   static constexpr const char *type = "fully_connected";
 
+  struct LoRAQATStats {
+    float a_min = 0, a_max = 0, a_scale = 0;
+    float b_min = 0, b_max = 0, b_scale = 0;
+    bool valid = false;
+  };
+
+  /** Look up per-block stats for a layer by name (updated each forward).
+   * Thread-safe. */
+  static LoRAQATStats getRegisteredStats(const std::string &layer_name);
+
+  /**
+   * Look up per-block EMA scales (N×K layout) for a layer. Returns empty
+   * vectors if the layer hasn't run a QAT forward pass yet. Thread-safe.
+   */
+  static std::pair<std::vector<float>, std::vector<float>>
+  getRegisteredBlockScales(const std::string &layer_name);
+
 private:
+  static std::mutex s_registry_mutex;
+  static std::unordered_map<std::string, LoRAQATStats> s_qat_registry;
+  static std::unordered_map<std::string,
+                            std::pair<std::vector<float>, std::vector<float>>>
+    s_block_d_registry;
+
   float lora_scaling;
-  std::tuple<props::Unit, props::LoraRank, props::LoraAlpha>
+  std::tuple<props::Unit, props::LoraRank, props::LoraAlpha, props::LoraQAT,
+             props::LoraWeightQ4>
     fc_props;                             /**< fc layer properties :
                                                 unit - number of output neurons,
                                                 lora_rank - rank of lora (optional)
-                                                lora_scaling - scaling factor of LoRA apply, i.e.,
-                                             lora_scaling = alpha / lora_rank */
+                                                lora_alpha - alpha for LoRA scaling
+                                                lora_qat - enable per-block Q4_0 fake-quant
+                                                lora_weight_q4 - Q4_0 tensors for inference */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   std::array<unsigned int, 4> lora_idx;   /**< indices of the lora weights */
   std::unique_ptr<nntrainer::Quantizer> quantizer;
   bool skip_prefill = false;
+
+  float momentum;          /**< EMA momentum for per-block scale update */
+  std::string layer_name_; // captured in finalize(), keys s_qat_registry
+
+  // QAT: per-block EMA scales for loraA and loraB (one float per 32-elem
+  // block). Lazy-initialized on first forward pass when tensor sizes are known.
+  std::vector<float> lora_a_block_d;
+  std::vector<float> lora_b_block_d;
+
+  // QAT: cached fake-quantized adapters from last forward pass (used in STE
+  // backward)
+  Tensor a_fq, b_fq;
+
+  /**
+   * @brief Per-block Q4_0 fake-quantization with EMA block scales.
+   *        Training: updates EMA for each block, quantizes with EMA scale.
+   *        Validation: uses current EMA scales without updating them.
+   *        Backward is STE: gradient passes through unchanged.
+   */
+  Tensor fakeQuantizeQ4_0(const Tensor &x, std::vector<float> &block_d,
+                          bool training);
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -16,6 +16,8 @@
  * @brief	This is Layer classes of Neural Network
  * @see		https://github.com/nntrainer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Anirudh <b.saianirud@samsung.com>
+ * @author	Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug		No known bugs except for NYI items
  *
  */
@@ -194,7 +196,7 @@ public:
   /**
    * @brief    Initialize the layer
    */
-  virtual void initialize(RunLayerContext &context){};
+  virtual void initialize(RunLayerContext &context) {};
 
   /**
    * @brief     Forward Propagation of a layer
@@ -434,6 +436,31 @@ public:
               nntrainer::quant_qs4cx_f32(N, K, weight_t.getData(), data, scale,
                                          true);
               file.write((const char *)data, q_size + scale_size);
+            } else if (dtype == TensorDim::DataType::Q6_K) {
+              NNTR_THROW_IF(weight.getDataType() != TensorDim::DataType::FP32,
+                            std::runtime_error)
+                << "Save with quantization only supports for FP32 weight.";
+              TensorDim dim = weight.getDim();
+              unsigned int K = dim.height();
+              unsigned int N = dim.width();
+
+              // Skip quantization for bias-like tensors (1D with height == 1)
+              if (K == 1) {
+                weight.save(file);
+              } else {
+                NNTR_THROW_IF(K % 256 != 0, std::invalid_argument)
+                  << "Q6_K quantization requires height to be divisible by "
+                     "256, but got height="
+                  << K;
+
+                Tensor weight_t = weight.transpose("0:2:1");
+                Tensor quant_weight(dim.batch(), dim.channel(), K, N,
+                                    {Tformat::NCHW, dtype});
+
+                quantize_q6_K(weight_t.getData<float>(),
+                              quant_weight.getData<uint8_t>(), N, K, nullptr);
+                quant_weight.save(file);
+              }
             } else {
               NNTR_THROW_IF(true, std::runtime_error)
                 << "This dtype is not supported in save with quantization";

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -7,6 +7,8 @@
  * @brief  This file contains common properties for model
  * @see    https://github.com/nntrainer/nntrainer
  * @author Jihoon Lee <jhoon.it.lee@samsung.com>
+ * @author Anirudh <b.saianirud@samsung.com>
+ * @author Pranjal Thapliyal <p.thapliyal@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
@@ -203,6 +205,7 @@ struct ModelTensorDataTypeInfo {
     WQ40A32,
     WQ40A16,
     WQS4CXA32,
+    WQ6KA32,
   };
   static constexpr std::initializer_list<Enum> EnumList = {
     Enum::W3A32,   Enum::W4A16,    Enum::W4A32,    Enum::W8A16,
@@ -210,6 +213,7 @@ struct ModelTensorDataTypeInfo {
     Enum::W32A32,  Enum::WQ16AQ16, Enum::WU16AU16, Enum::W8AU16,
     Enum::WU4AU8,  Enum::WU4AU16,  Enum::WU8AU8,   Enum::WU8AU16,
     Enum::WQ4KA32, Enum::WQ40A32,  Enum::WQ40A16,  Enum::WQS4CXA32,
+    Enum::WQ6KA32,
   };
 
   static constexpr const char *EnumStr[] = {
@@ -217,7 +221,8 @@ struct ModelTensorDataTypeInfo {
     "QINT8-FP32",  "FP16-FP16",     "FP16-FP32",     "FP32-FP16",
     "FP32-FP32",   "QINT16-QINT16", "UINT16-UINT16", "QINT8-UINT16",
     "UINT4-UINT8", "UINT4-UINT16",  "UINT8-UINT8",   "UINT8-UINT16",
-    "Q4_K-FP32",   "Q4_0-FP32",     "Q4_0-FP16",     "QS4CX-FP32"};
+    "Q4_K-FP32",   "Q4_0-FP32",     "Q4_0-FP16",     "QS4CX-FP32",
+    "Q6_K-FP32"};
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds quantization-aware training (QAT) and quantized deployment paths for LoRA adapters trained with the pipeline introduced in the preceding PRs. Enables W4A8 (Q4_0 fake-quant) training and Q6_K / Q4_0 serialization of adapter weights for memory-efficient edge inference.

- **`fc_layer.cpp/.h`**: Introduces `fakeQuantizeQ4_0` for per-block symmetric Q4_0 fake-quantization of LoRA adapter weights during the forward pass. Maintains per-block EMA of scale statistics (`LoRAQATStats`) in a thread-safe registry. Adds `LoraQAT` and `LoraWeightQ4` props that opt a layer into QAT training or Q4_0 quantized inference mode respectively.
- **`common_properties.h`**: Adds `LoraQAT` (bool) and `LoraWeightQ4` (bool) property classes consumed by `fc_layer` to select the quantization path via the layer property string.
- **`layer_devel.h`**: Adds `saveWeightQ6K` virtual method so LoRA-enabled layers can export trained adapter weights in Q6_K format for edge deployment.
- **`model_common_properties.h`**: Adds `WQ6KA32` enum value and string constant for the weight-Q6K / activation-FP32 mixed-precision mode.
- **`transformer.cpp/.h`**: Extends `Transformer` with `save_weight_lora_q6k`, `load_weight_lora_q6k`, `save_weight_lora_q4`, `load_weight_lora_q4`, `printLoRAQATStats`, and `dequantize_q6k`. Boolean members `LORA_QAT` and `LORA_Q4` control which quantization path is active at runtime.

## Test plan

- [ ] Build with QAT flag enabled and verify fc_layer fake-quant runs without NaN/Inf in scales
- [ ] Train a small LoRA adapter with `--lora_qat` and verify `printLoRAQATStats` output stabilizes over epochs
- [ ] Call `save_weight_lora_q6k` after training and reload with `load_weight_lora_q6k`; confirm weight round-trip
- [ ] Run Q4_0 inference path via `load_weight_lora_q4` and verify generation quality is comparable to FP32
- [ ] Verify that `LoraQAT=false` and `LoraWeightQ4=false` (default) produce the same behavior as before this change

Signed-off-by: Anirudh <b.saianirud@samsung.com>
Signed-off-by: Pranjal Thapliyal <p.thapliyal@samsung.com>