### PR TITLE
[nntrainer] rename `Packed` property to `UseGlobalWeightDtype`

### DIFF
--- a/Applications/CausalLM/models/bert/bert_transformer.cpp
+++ b/Applications/CausalLM/models/bert/bert_transformer.cpp
@@ -120,9 +120,10 @@ std::pair<std::vector<Tensor>, Tensor> BertTransformer::constructBertGraph() {
   Tensor h = embedding_sum({word, position, token_type});
 
   LayerHandle embedding_norm(createLayer(
-    "layer_normalization", {withKey("name", "embedding_norm"),
-                            withKey("epsilon", toStringPrecise(NORM_EPS)),
-                            withKey("axis", 3), withKey("packed", "false")}));
+    "layer_normalization",
+    {withKey("name", "embedding_norm"),
+     withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
+     withKey("use_global_weight_dtype", "false")}));
   h = embedding_norm(h);
 
   /** --------- Encoder blocks --------- */
@@ -150,7 +151,7 @@ Tensor BertTransformer::createTransformerDecoderBlock(const int layer_id,
     "layer_normalization",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
      withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor attention_normed = attention_norm(attention_residual);
 
   // Feed-forward sub-block
@@ -167,7 +168,7 @@ Tensor BertTransformer::createTransformerDecoderBlock(const int layer_id,
     "layer_normalization",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
      withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
 
   return ffn_norm(ffn_residual);
 }

--- a/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
+++ b/Applications/CausalLM/models/deberta_v2/deberta_v2.cpp
@@ -151,9 +151,10 @@ std::pair<Tensor, Tensor> DebertaV2::constructTransformerModule() {
   Tensor h = embedding(x);
 
   LayerHandle embedding_norm(createLayer(
-    "layer_normalization", {withKey("name", "embeddings_norm"),
-                            withKey("epsilon", toStringPrecise(NORM_EPS)),
-                            withKey("axis", 3), withKey("packed", "false")}));
+    "layer_normalization",
+    {withKey("name", "embeddings_norm"),
+     withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
+     withKey("use_global_weight_dtype", "false")}));
   h = embedding_norm(h);
 
   const int rel_embed_size =
@@ -175,9 +176,10 @@ std::pair<Tensor, Tensor> DebertaV2::constructTransformerModule() {
 
   if (NORM_REL_EBD) {
     LayerHandle rel_embedding_norm(createLayer(
-      "layer_normalization", {withKey("name", "rel_embeddings_norm"),
-                              withKey("epsilon", toStringPrecise(NORM_EPS)),
-                              withKey("axis", 3), withKey("packed", "false")}));
+      "layer_normalization",
+      {withKey("name", "rel_embeddings_norm"),
+       withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
+       withKey("use_global_weight_dtype", "false")}));
     rel = rel_embedding_norm(rel);
   }
 
@@ -199,9 +201,10 @@ Tensor DebertaV2::createDebertaLayer(const int layer_id, Tensor input,
   Tensor attention_residual = attention_res({input, att_out});
 
   LayerHandle attention_norm(createLayer(
-    "layer_normalization", {withKey("name", prefix + "_attention_norm"),
-                            withKey("epsilon", toStringPrecise(NORM_EPS)),
-                            withKey("axis", 3), withKey("packed", "false")}));
+    "layer_normalization",
+    {withKey("name", prefix + "_attention_norm"),
+     withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
+     withKey("use_global_weight_dtype", "false")}));
   Tensor attention_normed = attention_norm(attention_residual);
 
   LayerHandle intermediate(createLayer(
@@ -222,9 +225,10 @@ Tensor DebertaV2::createDebertaLayer(const int layer_id, Tensor input,
   Tensor output_residual = output_res({attention_normed, output_dense_out});
 
   LayerHandle output_norm(createLayer(
-    "layer_normalization", {withKey("name", prefix + "_output"),
-                            withKey("epsilon", toStringPrecise(NORM_EPS)),
-                            withKey("axis", 3), withKey("packed", "false")}));
+    "layer_normalization",
+    {withKey("name", prefix + "_output"),
+     withKey("epsilon", toStringPrecise(NORM_EPS)), withKey("axis", 3),
+     withKey("use_global_weight_dtype", "false")}));
 
   return output_norm(output_residual);
 }

--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
@@ -83,7 +83,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor normed = attn_norm(input);
 
   Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
@@ -93,7 +93,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm", {withKey("name", "layer" + std::to_string(layer_id) +
                                    "_post_attention_norm"),
                  withKey("epsilon", std::to_string(NORM_EPS)),
-                 withKey("packed", "false")}));
+                 withKey("use_global_weight_dtype", "false")}));
   Tensor post_normed = post_attn_norm(att_out);
 
   LayerHandle post_attn_add(createLayer(
@@ -105,7 +105,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "pre_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor pre_ffn = pre_ffn_norm(post_attn);
 
   Tensor ffn_out = createMlp(layer_id, DIM, INTERMEDIATE_SIZE, pre_ffn);
@@ -114,7 +114,7 @@ Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "post_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor post_ffn = post_ffn_norm(ffn_out);
 
   LayerHandle decoder_output(createLayer(
@@ -159,7 +159,8 @@ Tensor Gemma3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle q_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_q_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("use_global_weight_dtype", "false"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor q_normed = q_norm(q);
 
@@ -167,7 +168,8 @@ Tensor Gemma3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle k_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_k_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("use_global_weight_dtype", "false"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor k_normed = k_norm(k);
 

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -282,10 +282,11 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
   Tensor per_layer_projected = per_layer_projection(h);
 
   float ple_proj_scale = 1.0f / std::sqrt(static_cast<float>(DIM));
-  LayerHandle model_proj_scale(createLayer(
-    "scalar_multiply",
-    {withKey("name", "per_layer_model_proj_scale"), withKey("packed", "false"),
-     withKey("multiplier", std::to_string(ple_proj_scale))}));
+  LayerHandle model_proj_scale(
+    createLayer("scalar_multiply",
+                {withKey("name", "per_layer_model_proj_scale"),
+                 withKey("use_global_weight_dtype", "false"),
+                 withKey("multiplier", std::to_string(ple_proj_scale))}));
   Tensor scaled_projection = model_proj_scale(per_layer_projected);
 
   LayerHandle projection_norm(createLayer(
@@ -294,7 +295,7 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
       withKey("name", "per_layer_projection_norm"),
       withKey("epsilon", std::to_string(NORM_EPS)),
       withKey("feature_size", std::to_string(HIDDEN_SIZE_PER_LAYER_INPUT)),
-      withKey("packed", "false"),
+      withKey("use_global_weight_dtype", "false"),
     }));
   Tensor normalized_projection = projection_norm(scaled_projection);
 
@@ -311,7 +312,7 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
     createLayer("scalar_multiply",
                 {
                   withKey("name", "per_layer_input_scale"),
-                  withKey("packed", "false"),
+                  withKey("use_global_weight_dtype", "false"),
                   withKey("multiplier", std::to_string(per_layer_input_scale)),
                 }));
   per_layer_input = per_layer_input_scale_layer(per_layer_sum_out);
@@ -324,7 +325,8 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
 
   std::vector<std::string> output_norm_props = {
     withKey("name", "output_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(output_norm_props, true);
   LayerHandle out_norm(createLayer("rms_norm", output_norm_props));
   h = out_norm(h);
@@ -340,7 +342,8 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
   const bool is_kv_shared_layer = isKVSharedLayer(layer_id);
   std::vector<std::string> attn_norm_props = {
     withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(attn_norm_props, is_kv_shared_layer);
   LayerHandle attn_norm(createLayer("rms_norm", attn_norm_props));
   Tensor normed = attn_norm(input);
@@ -376,7 +379,8 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
   std::vector<std::string> post_attn_norm_props = {
     withKey("name",
             "layer" + std::to_string(layer_id) + "_post_attention_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(post_attn_norm_props, is_kv_shared_layer);
   LayerHandle post_attn_norm(createLayer("rms_norm", post_attn_norm_props));
   Tensor post_normed = post_attn_norm(att_out);
@@ -390,7 +394,8 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
 
   std::vector<std::string> pre_ffn_norm_props = {
     withKey("name", "layer" + std::to_string(layer_id) + "_pre_ffn_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(pre_ffn_norm_props, is_kv_shared_layer);
   LayerHandle pre_ffn_norm(createLayer("rms_norm", pre_ffn_norm_props));
   Tensor pre_ffn = pre_ffn_norm(post_attention);
@@ -399,7 +404,8 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
 
   std::vector<std::string> post_ffn_norm_props = {
     withKey("name", "layer" + std::to_string(layer_id) + "_post_ffn_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(post_ffn_norm_props, is_kv_shared_layer);
   LayerHandle post_ffn_norm(createLayer("rms_norm", post_ffn_norm_props));
   Tensor post_ffn = post_ffn_norm(ffn_out);
@@ -467,7 +473,8 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
   std::vector<std::string> post_per_layer_input_norm_props = {
     withKey("name",
             "layer" + std::to_string(layer_id) + "_post_per_layer_input_norm"),
-    withKey("epsilon", std::to_string(NORM_EPS)), withKey("packed", "false")};
+    withKey("epsilon", std::to_string(NORM_EPS)),
+    withKey("use_global_weight_dtype", "false")};
   appendSkipPrefillIfNeeded(post_per_layer_input_norm_props,
                             is_kv_shared_layer);
   LayerHandle post_per_layer_input_norm(
@@ -485,7 +492,7 @@ Tensor Gemma4Transformer::createTransformerDecoderBlock(const int layer_id,
 
   std::vector<std::string> layer_scalar_props = {
     withKey("name", "layer" + std::to_string(layer_id) + "_layer_scalar"),
-    withKey("packed", "false"),
+    withKey("use_global_weight_dtype", "false"),
     withKey("use_weight", "true"),
   };
   appendSkipPrefillIfNeeded(layer_scalar_props, is_kv_shared_layer);
@@ -529,7 +536,7 @@ Tensor Gemma4Transformer::createSharedAttention(const int layer_id,
 
   // q_norm on per-head projection [B, S, Nq*Dh]
   std::vector<std::string> q_norm_params = {
-    withKey("name", Q_norm), withKey("packed", "false"),
+    withKey("name", Q_norm), withKey("use_global_weight_dtype", "false"),
     withKey("epsilon", std::to_string(NORM_EPS)),
     withKey("feature_size", std::to_string(curr_head_dim))};
   appendSkipPrefillIfNeeded(q_norm_params, is_kv_shared_layer);
@@ -543,7 +550,7 @@ Tensor Gemma4Transformer::createSharedAttention(const int layer_id,
   // TODO : fix AVX kernel to not make it divide by 1/sqrt(head_dim) on gemma4
   LayerHandle q_scale(createLayer(
     "scalar_multiply",
-    {withKey("name", Q_scaled), withKey("packed", "false"),
+    {withKey("name", Q_scaled), withKey("use_global_weight_dtype", "false"),
      withKey("multiplier",
              std::to_string(std::sqrt(static_cast<float>(curr_head_dim))))}));
   Tensor q_scaled = q_scale(q_normed);
@@ -648,7 +655,7 @@ Tensor Gemma4Transformer::createAttention(const int layer_id, int seq_len,
 
   // q_norm on per-head projection [B, S, Nq*Dh]
   std::vector<std::string> q_norm_params = {
-    withKey("name", Q_norm), withKey("packed", "false"),
+    withKey("name", Q_norm), withKey("use_global_weight_dtype", "false"),
     withKey("epsilon", std::to_string(NORM_EPS)),
     withKey("feature_size", std::to_string(curr_head_dim))};
   appendSkipPrefillIfNeeded(q_norm_params, is_kv_shared_layer);
@@ -660,14 +667,14 @@ Tensor Gemma4Transformer::createAttention(const int layer_id, int seq_len,
   // sqrt(head_dim) to preserve Gemma4 semantics.
   LayerHandle q_scale(createLayer(
     "scalar_multiply",
-    {withKey("name", Q_scaled), withKey("packed", "false"),
+    {withKey("name", Q_scaled), withKey("use_global_weight_dtype", "false"),
      withKey("multiplier",
              std::to_string(std::sqrt(static_cast<float>(curr_head_dim))))}));
   Tensor q_scaled = q_scale(q_normed);
 
   // k_norm on per-head projection [B, S, Nk*Dh]
   std::vector<std::string> k_norm_params = {
-    withKey("name", K_norm), withKey("packed", "false"),
+    withKey("name", K_norm), withKey("use_global_weight_dtype", "false"),
     withKey("epsilon", std::to_string(NORM_EPS)),
     withKey("feature_size", std::to_string(curr_head_dim))};
   appendSkipPrefillIfNeeded(k_norm_params, is_kv_shared_layer);
@@ -676,7 +683,7 @@ Tensor Gemma4Transformer::createAttention(const int layer_id, int seq_len,
 
   // v_norm on per-head projection [B, S, Nk*Dh] (no learned scale)
   std::vector<std::string> v_norm_params = {
-    withKey("name", V_norm), withKey("packed", "false"),
+    withKey("name", V_norm), withKey("use_global_weight_dtype", "false"),
     withKey("epsilon", std::to_string(NORM_EPS)),
     withKey("feature_size", std::to_string(curr_head_dim))};
   v_norm_params.push_back(withKey("use_gamma", "false"));

--- a/Applications/CausalLM/models/qwen3/qwen3_causallm.cpp
+++ b/Applications/CausalLM/models/qwen3/qwen3_causallm.cpp
@@ -47,7 +47,8 @@ Tensor Qwen3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle q_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_q_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("use_global_weight_dtype", "false"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor q_normed = q_norm(q);
 
@@ -63,7 +64,8 @@ Tensor Qwen3Transformer::createAttention(const int layer_id, int seq_len,
   LayerHandle k_norm(createLayer(
     "reshaped_rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_k_norm"),
-     withKey("packed", "false"), withKey("epsilon", std::to_string(NORM_EPS)),
+     withKey("use_global_weight_dtype", "false"),
+     withKey("epsilon", std::to_string(NORM_EPS)),
      withKey("feature_size", std::to_string(head_dim))}));
   Tensor k_normed = k_norm(k);
 

--- a/Applications/CausalLM/models/timm_vit/timm_vit_transformer.cpp
+++ b/Applications/CausalLM/models/timm_vit/timm_vit_transformer.cpp
@@ -219,7 +219,7 @@ Tensor TimmViTTransformer::createAttention(const int layer_id, Tensor input) {
                                {withKey("name", prefix + "attention_norm"),
                                 withKey("axis", "3"),
                                 withKey("epsilon", std::to_string(NORM_EPS)),
-                                withKey("packed", "false")}));
+                                withKey("use_global_weight_dtype", "false")}));
   Tensor normed = norm(input);
 
   auto q = prefix + "qkv_q", k = prefix + "qkv_k", v = prefix + "qkv_v",
@@ -268,7 +268,7 @@ Tensor TimmViTTransformer::createMlp(const int layer_id, Tensor input) {
     createLayer("layer_normalization",
                 {withKey("name", prefix + "ffn_norm"), withKey("axis", "3"),
                  withKey("epsilon", std::to_string(NORM_EPS)),
-                 withKey("packed", "false")}));
+                 withKey("use_global_weight_dtype", "false")}));
   Tensor h = norm(input);
 
   LayerHandle fc_up(createLayer(
@@ -322,7 +322,7 @@ std::pair<Tensor, Tensor> TimmViTTransformer::constructModel() {
     createLayer("layer_normalization",
                 {withKey("name", "output_norm"), withKey("axis", "3"),
                  withKey("epsilon", std::to_string(NORM_EPS)),
-                 withKey("packed", "false")}));
+                 withKey("use_global_weight_dtype", "false")}));
   h = output_norm(h);
 
   return {input, h};

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -261,7 +261,7 @@ std::pair<Tensor, Tensor> Transformer::constructModel() {
   LayerHandle out_norm(
     createLayer("rms_norm", {withKey("name", "output_norm"),
                              withKey("epsilon", std::to_string(NORM_EPS)),
-                             withKey("packed", "false")}));
+                             withKey("use_global_weight_dtype", "false")}));
   h = out_norm(h);
 
   return {x, h};
@@ -399,7 +399,7 @@ Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor normed = attn_norm(input);
 
   Tensor att_out = createAttention(layer_id, INIT_SEQ_LEN, NUM_HEADS, HEAD_DIM,
@@ -414,7 +414,7 @@ Tensor Transformer::createTransformerDecoderBlock(const int layer_id,
     "rms_norm",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_norm"),
      withKey("epsilon", std::to_string(NORM_EPS)),
-     withKey("packed", "false")}));
+     withKey("use_global_weight_dtype", "false")}));
   Tensor ffn_normed = ffn_norm(residual);
 
   Tensor ffn_out = createMlp(layer_id, DIM, INTERMEDIATE_SIZE, ffn_normed);

--- a/Applications/LLaMA/jni/main.cpp
+++ b/Applications/LLaMA/jni/main.cpp
@@ -402,7 +402,7 @@ Tensor createTransformerDecoder(const int layer_id, Tensor input) {
     "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_attention_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("use_global_weight_dtype", "false")}));
   auto normed = att_norm(input);
 
   auto att_out = createAttentionLayer(layer_id, INIT_SEQ_LEN, NUM_HEADS,
@@ -418,7 +418,7 @@ Tensor createTransformerDecoder(const int layer_id, Tensor input) {
     "rms_norm", {nntrainer::withKey("name", "layer" + std::to_string(layer_id) +
                                               "_ffn_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("use_global_weight_dtype", "false")}));
   auto ffn_normed = ffn_norm(residual);
 
   auto ffn_out =
@@ -439,8 +439,8 @@ std::pair<Tensor, Tensor> buildLLaMAGraph() {
   auto x = Tensor({1, 1, 1, static_cast<unsigned int>(INIT_SEQ_LEN)}, "input0");
 
   LayerHandle embedding(ml::train::layer::Embedding(
-    {"name=embedding0", "in_dim=" + std::to_string(NUM_VOCAB), "packed=false",
-     "out_dim=" + std::to_string(DIM)}));
+    {"name=embedding0", "in_dim=" + std::to_string(NUM_VOCAB),
+     "use_global_weight_dtype=false", "out_dim=" + std::to_string(DIM)}));
   auto h = embedding(x);
 
   for (int i = 0; i < NUM_LAYERS; i++) {
@@ -450,14 +450,15 @@ std::pair<Tensor, Tensor> buildLLaMAGraph() {
   LayerHandle out_norm(createLayer(
     "rms_norm", {nntrainer::withKey("name", "output_norm"),
                  nntrainer::withKey("epsilon", std::to_string(NORM_EPS)),
-                 nntrainer::withKey("packed", "false")}));
+                 nntrainer::withKey("use_global_weight_dtype", "false")}));
   h = out_norm(h);
 
-  LayerHandle out_fc(createLayer("fully_connected",
-                                 {nntrainer::withKey("name", "output_of_llama"),
-                                  nntrainer::withKey("unit", NUM_VOCAB),
-                                  nntrainer::withKey("disable_bias", "true"),
-                                  nntrainer::withKey("packed", "false")}));
+  LayerHandle out_fc(
+    createLayer("fully_connected",
+                {nntrainer::withKey("name", "output_of_llama"),
+                 nntrainer::withKey("unit", NUM_VOCAB),
+                 nntrainer::withKey("disable_bias", "true"),
+                 nntrainer::withKey("use_global_weight_dtype", "false")}));
   auto y = out_fc(h);
 
   return {x, y};

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -162,20 +162,17 @@ public:
 };
 
 /**
- * @brief trainable property, use this to set and check how if certain layer is
- * trainable
+ * @brief UseGlobalWeightDtype property to determine weight dtype source
  *
  */
-class Packed : public nntrainer::Property<bool> {
+class UseGlobalWeightDtype : public nntrainer::Property<bool> {
 public:
   /**
-   * @brief Construct a new Trainable object
-   * if it is true, then weight type always follows tensor_type[1]( Global
-   * Weight Type ). if it is false, the weight type follows tensor_type[2]
-   * (Global Activation Type)
+   * @brief Construct a new UseGlobalWeightDtype object
+   * true (default): use global weight type, false: use activation type
    */
-  Packed(bool val = true) : nntrainer::Property<bool>(val) {}
-  static constexpr const char *key = "packed";
+  UseGlobalWeightDtype(bool val = true) : nntrainer::Property<bool>(val) {}
+  static constexpr const char *key = "use_global_weight_dtype";
   using prop_tag = bool_prop_tag;
 };
 

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -199,11 +199,11 @@ LayerNode::LayerNode(std::unique_ptr<nntrainer::Layer> &&l) :
 
   output_connections(),
   run_context(nullptr),
-  layer_node_props(
-    new PropsType(props::Name(), props::Distribute(), props::Trainable(), {},
-                  {}, props::SharedFrom(), props::ClipGradByGlobalNorm(),
-                  props::Packed(), props::WeightDtype(), props::InputDtype(),
-                  props::LossScaleForMixed(), props::ComputeEngine())),
+  layer_node_props(new PropsType(
+    props::Name(), props::Distribute(), props::Trainable(), {}, {},
+    props::SharedFrom(), props::ClipGradByGlobalNorm(),
+    props::UseGlobalWeightDtype(), props::WeightDtype(), props::InputDtype(),
+    props::LossScaleForMixed(), props::ComputeEngine())),
   layer_node_props_realization(
     new RealizationPropsType(props::Flatten(), props::Activation())),
   loss(new props::Loss()),
@@ -638,10 +638,11 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
     compute_engine = std::get<props::ComputeEngine>(*layer_node_props).get();
   }
 
-  if (!std::get<props::Packed>(*layer_node_props).empty()) {
-    bool isPacked = std::get<props::Packed>(*layer_node_props);
-    if (!isPacked) {
-      // set weight type = activation type
+  if (!std::get<props::UseGlobalWeightDtype>(*layer_node_props).empty()) {
+    bool useGlobalWeightDtype =
+      std::get<props::UseGlobalWeightDtype>(*layer_node_props);
+    if (!useGlobalWeightDtype) {
+      // if not using global weight dtype, use activation type instead
       tensor_type[1] = tensor_type[2];
     }
   }

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -52,7 +52,7 @@ class Activation;
 class SharedFrom;
 class InputConnection;
 class ClipGradByGlobalNorm;
-class Packed;
+class UseGlobalWeightDtype;
 class LossScaleForMixed;
 class ComputeEngine;
 } // namespace props
@@ -1055,8 +1055,8 @@ properties in the context/graph unless intended. */
     std::tuple<props::Name, props::Distribute, props::Trainable,
                std::vector<props::InputConnection>,
                std::vector<props::InputShape>, props::SharedFrom,
-               props::ClipGradByGlobalNorm, props::Packed, props::WeightDtype,
-               props::InputDtype, props::LossScaleForMixed,
+               props::ClipGradByGlobalNorm, props::UseGlobalWeightDtype,
+               props::WeightDtype, props::InputDtype, props::LossScaleForMixed,
                props::ComputeEngine>;
 
   using RealizationPropsType = std::tuple<props::Flatten, props::Activation>;

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -91,7 +91,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm, props::Packed,
+                   props::ClipGradByGlobalNorm, props::UseGlobalWeightDtype,
                    props::WeightDtype, props::InputDtype,
                    props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self) {

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -233,7 +233,7 @@ class ClipGradByGlobalNorm;
 class DisableBias;
 class Activation;
 class BatchNormalization;
-class Packed;
+class UseGlobalWeightDtype;
 class LossScaleForMixed;
 class InPlaceProp;
 class InPlaceDirectionProp;
@@ -252,7 +252,7 @@ void Exporter::saveTflResult(
   const std::tuple<props::Name, props::Distribute, props::Trainable,
                    std::vector<props::InputConnection>,
                    std::vector<props::InputShape>, props::SharedFrom,
-                   props::ClipGradByGlobalNorm, props::Packed,
+                   props::ClipGradByGlobalNorm, props::UseGlobalWeightDtype,
                    props::WeightDtype, props::InputDtype,
                    props::LossScaleForMixed, props::ComputeEngine> &props,
   const LayerNode *self);


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[nntrainer] rename Packed property to UseGlobalWeightDtype</summary><br />

This commit renames ambigious property to better reflect its behavior:
whether to use global(config) weight dtype or fall back to activation dtype.
This change will avoid name conflict with the repacked weights.
It's natural to set property such as MirrorActivationDtype whether to use activation dtype if true.
But to keep the backward compatibility, the name has finalized.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

This PR renames the property to avoid ambiguity with repacked weight.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
