### PR TITLE
[nntrainer] Allow leading underscore in layer/tensor names

### DIFF
--- a/nntrainer/layers/common_properties.cpp
+++ b/nntrainer/layers/common_properties.cpp
@@ -42,7 +42,10 @@ void Name::set(const std::string &value) {
 }
 
 bool Name::isValid(const std::string &v) const {
-  static std::regex allowed("[a-zA-Z0-9][-_./a-zA-Z0-9]*");
+  // Leading '_' is allowed: ONNX-exported QNN graphs name tensors like
+  // "_model_embed_tokens_Gather_Gather_output_0" and layer names must match
+  // the graph tensor names exactly for input binding.
+  static std::regex allowed("[_a-zA-Z0-9][-_./a-zA-Z0-9]*");
   return !v.empty() && std::regex_match(v, allowed);
 }
 


### PR DESCRIPTION
## Summary

`Name::isValid` rejected any layer/tensor name whose first character was
`_`, because the allowed pattern required the leading character to be
alphanumeric:

[a-zA-Z0-9][-_./a-zA-Z0-9]*

ONNX-exported QNN graphs commonly name tensors with a leading underscore.
Since nntrainer layer names
must match the graph tensor names exactly for input binding, loading such a
model threw `std::invalid_argument` during name validation.

## Changes

- **`nntrainer/layers/common_properties.cpp`** — widen the leading-character
  class in `Name::isValid` from `[a-zA-Z0-9]` to `[_a-zA-Z0-9]`, so names
  beginning with `_` are accepted. Interior characters are unchanged.
- **`nntrainer/layers/layer_node.cpp`** — comment only (no behavior change).
  Document that `createLayerNode` forwarding `properties` to
  `Engine::createLayerObject` is intentional and is *not* a double-dispatch
  onto the raw layer: `Engine` uses them only for `parseComputeEngine`
  (`engine=...` Context selection) and calls `Context::createLayerObject(type)`
  with no properties.