### PR TITLE
feat(embedding): mmap sidecar LUT instead of eager full read

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -50,10 +50,18 @@ namespace {
 std::mutex quant_lut_cache_mutex;
 std::unordered_map<std::string, std::weak_ptr<QuantLut>> quant_lut_cache;
 
+/**
+ * @brief True if the given path has a ".json" extension (i.e. a LUT
+ * manifest rather than a raw UINT16 LUT file).
+ */
 bool hasJsonExtension(const std::string &path) {
   return std::filesystem::path(path).extension() == ".json";
 }
 
+/**
+ * @brief Resolve a LUT path referenced from a JSON manifest, treating it as
+ * relative to the manifest's directory unless it is already absolute.
+ */
 std::filesystem::path resolveLutPath(const std::string &manifest_path,
                                      const std::string &lut_path) {
   std::filesystem::path path(lut_path);
@@ -63,6 +71,10 @@ std::filesystem::path resolveLutPath(const std::string &manifest_path,
   return std::filesystem::path(manifest_path).parent_path() / path;
 }
 
+/**
+ * @brief Fetch an object-typed field from a LUT manifest, throwing
+ * std::runtime_error if it is missing or not an object.
+ */
 const nlohmann::json &requireJsonObjectField(const nlohmann::json &json,
                                              const char *field,
                                              const std::string &path) {
@@ -73,6 +85,10 @@ const nlohmann::json &requireJsonObjectField(const nlohmann::json &json,
   return json.at(field);
 }
 
+/**
+ * @brief Fetch a string-typed field from a LUT manifest, throwing
+ * std::runtime_error if it is missing or not a string.
+ */
 std::string requireJsonStringField(const nlohmann::json &json,
                                    const char *field, const std::string &path) {
   NNTR_THROW_IF(!json.contains(field) || !json.at(field).is_string(),
@@ -82,6 +98,10 @@ std::string requireJsonStringField(const nlohmann::json &json,
   return json.at(field).get<std::string>();
 }
 
+/**
+ * @brief Fetch a numeric field from a LUT manifest as a float, throwing
+ * std::runtime_error if it is missing or not a number.
+ */
 float requireJsonFloatField(const nlohmann::json &json, const char *field,
                             const std::string &path) {
   NNTR_THROW_IF(!json.contains(field) || !json.at(field).is_number(),
@@ -91,6 +111,10 @@ float requireJsonFloatField(const nlohmann::json &json, const char *field,
   return json.at(field).get<float>();
 }
 
+/**
+ * @brief Fetch an integer field from a LUT manifest, throwing
+ * std::runtime_error if it is missing, not an integer, or out of int range.
+ */
 int requireJsonIntField(const nlohmann::json &json, const char *field,
                         const std::string &path) {
   NNTR_THROW_IF(!json.contains(field) || !(json.at(field).is_number_integer() ||
@@ -108,6 +132,10 @@ int requireJsonIntField(const nlohmann::json &json, const char *field,
   return static_cast<int>(value);
 }
 
+/**
+ * @brief Fetch a positive integer field from a LUT manifest as a size_t,
+ * throwing if it is missing, not an integer, or not positive.
+ */
 size_t requireJsonSizeField(const nlohmann::json &json, const char *field,
                             const std::string &path) {
   NNTR_THROW_IF(!json.contains(field) || !(json.at(field).is_number_integer() ||
@@ -123,6 +151,10 @@ size_t requireJsonSizeField(const nlohmann::json &json, const char *field,
   return static_cast<size_t>(value);
 }
 
+/**
+ * @brief Derive lut's in_dim from its packed 4-bit byte buffer size and
+ * out_dim, throwing if the manifest is inconsistent.
+ */
 void derivePacked4BitDimensions(QuantLut &lut,
                                 const std::string &manifest_path) {
   NNTR_THROW_IF(lut.out_dim == 0, std::invalid_argument)
@@ -143,6 +175,10 @@ void derivePacked4BitDimensions(QuantLut &lut,
     << "LUT binary has no rows: " << manifest_path;
 }
 
+/**
+ * @brief Load a "ufixed8" (unsigned, single shared scale/offset) packed
+ * 4-bit LUT described by a JSON manifest.
+ */
 std::shared_ptr<QuantLut> loadUfixed8Manifest(const std::string &manifest_path,
                                               const nlohmann::json &json) {
   const auto lut_path = requireJsonStringField(json, "lut-path", manifest_path);
@@ -162,6 +198,10 @@ std::shared_ptr<QuantLut> loadUfixed8Manifest(const std::string &manifest_path,
   return lut;
 }
 
+/**
+ * @brief Load a "sfixed4" (signed, per-row scale) packed 4-bit LUT
+ * described by a JSON manifest.
+ */
 std::shared_ptr<QuantLut> loadSfixed4Manifest(const std::string &manifest_path,
                                               const nlohmann::json &json) {
   const auto lut_path = requireJsonStringField(json, "lut-path", manifest_path);
@@ -196,6 +236,10 @@ std::shared_ptr<QuantLut> loadSfixed4Manifest(const std::string &manifest_path,
   return lut;
 }
 
+/**
+ * @brief Load a sidecar LUT from a JSON manifest file, dispatching on its
+ * "datatype" field ("ufixed8" by default, or "sfixed4").
+ */
 std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
   std::ifstream file(manifest_path);
   NNTR_THROW_IF(!file.is_open(), std::runtime_error)
@@ -230,6 +274,10 @@ std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
   return nullptr;
 }
 
+/**
+ * @brief Load a headerless raw UINT16 LUT file, validating its size against
+ * the caller-supplied in_dim/out_dim hints.
+ */
 std::shared_ptr<QuantLut> loadRawU16(const std::string &path,
                                      size_t in_dim_hint, size_t out_dim_hint) {
   NNTR_THROW_IF(in_dim_hint == 0 || out_dim_hint == 0, std::invalid_argument)
@@ -254,6 +302,10 @@ std::shared_ptr<QuantLut> loadRawU16(const std::string &path,
   return lut;
 }
 
+/**
+ * @brief Throw std::invalid_argument if lut's in_dim/out_dim differ from
+ * the caller-supplied hints (a hint of 0 skips that check).
+ */
 void validateHintedDimensions(const QuantLut &lut, const std::string &path,
                               size_t in_dim_hint, size_t out_dim_hint) {
   NNTR_THROW_IF(in_dim_hint != 0 && lut.in_dim != in_dim_hint,
@@ -266,12 +318,20 @@ void validateHintedDimensions(const QuantLut &lut, const std::string &path,
     << ", file has " << lut.out_dim;
 }
 
+/**
+ * @brief Decode a 4-bit two's-complement nibble to its signed integer value
+ * in the range [-8, 7].
+ */
 int decodeSigned4(uint8_t nibble) {
   nibble &= 0x0fU;
   return (nibble & 0x08U) ? static_cast<int>(nibble) - 16
                           : static_cast<int>(nibble);
 }
 
+/**
+ * @brief Saturate a float to the UINT16 range, mapping non-finite and
+ * out-of-range values to 0 or UINT16_MAX.
+ */
 uint16_t clampFloatToU16(float value) {
   if (!std::isfinite(value))
     return value > 0.0f ? std::numeric_limits<uint16_t>::max() : 0;
@@ -283,6 +343,10 @@ uint16_t clampFloatToU16(float value) {
   return static_cast<uint16_t>(value);
 }
 
+/**
+ * @brief Saturate an already-rounded double to the UINT16 range, mapping
+ * non-finite and out-of-range values to 0 or UINT16_MAX.
+ */
 uint16_t clampRoundedToU16(double value) {
   if (!std::isfinite(value))
     return value > 0.0 ? std::numeric_limits<uint16_t>::max() : 0;
@@ -294,6 +358,10 @@ uint16_t clampRoundedToU16(double value) {
   return static_cast<uint16_t>(value);
 }
 
+/**
+ * @brief Validate that token_idx is within lut's in_dim and output_len
+ * matches lut's out_dim before decoding a row.
+ */
 void validateDecodeArgs(const QuantLut &lut, size_t token_idx,
                         size_t output_len) {
   NNTR_THROW_IF(token_idx >= lut.in_dim, std::invalid_argument)
@@ -303,6 +371,11 @@ void validateDecodeArgs(const QuantLut &lut, size_t token_idx,
     << lut.out_dim;
 }
 
+/**
+ * @brief Dequantize one 4-bit nibble of token_idx's row to a float, scaled
+ * by layer_scale (per-row scale for sfixed4, shared scale/offset for
+ * ufixed8).
+ */
 float decodePacked4BitValue(const QuantLut &lut, size_t token_idx,
                             uint8_t nibble, float layer_scale) {
   if (lut.is_signed4) {
@@ -316,6 +389,10 @@ float decodePacked4BitValue(const QuantLut &lut, size_t token_idx,
          lut.scale * layer_scale;
 }
 
+/**
+ * @brief Decode one packed 4-bit LUT row into a floating-point output
+ * buffer of type T (float or _FP16).
+ */
 template <typename T>
 void decodePacked4BitRowToFloatType(const QuantLut &lut, size_t token_idx,
                                     float layer_scale, T *output,
@@ -378,7 +455,7 @@ MappedBytes &MappedBytes::operator=(MappedBytes &&other) noexcept {
   return *this;
 }
 
-MappedBytes MappedBytes::fromVector(std::vector<uint8_t> data) {
+MappedBytes MappedBytes::fromVector(std::vector<uint8_t> &&data) {
   MappedBytes m;
   m.owned_ = std::move(data);
   m.ptr_ = m.owned_.data();

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -32,6 +32,13 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
 namespace causallm {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
@@ -54,30 +61,6 @@ std::filesystem::path resolveLutPath(const std::string &manifest_path,
     return path;
 
   return std::filesystem::path(manifest_path).parent_path() / path;
-}
-
-std::vector<uint8_t> readBinaryFile(const std::filesystem::path &path) {
-  std::ifstream file(path, std::ios::binary | std::ios::ate);
-  NNTR_THROW_IF(!file.is_open(), std::runtime_error)
-    << "Failed to open LUT file: " << path.string();
-
-  const auto pos = file.tellg();
-  NNTR_THROW_IF(pos < 0, std::runtime_error)
-    << "Failed to get LUT file size: " << path.string();
-
-  const auto size = static_cast<size_t>(pos);
-  std::vector<uint8_t> bytes(size);
-
-  file.seekg(0, std::ios::beg);
-  if (size > 0) {
-    file.read(reinterpret_cast<char *>(bytes.data()),
-              static_cast<std::streamsize>(size));
-    NNTR_THROW_IF(static_cast<size_t>(file.gcount()) != size,
-                  std::runtime_error)
-      << "Failed to read complete LUT file: " << path.string();
-  }
-
-  return bytes;
 }
 
 const nlohmann::json &requireJsonObjectField(const nlohmann::json &json,
@@ -172,7 +155,8 @@ std::shared_ptr<QuantLut> loadUfixed8Manifest(const std::string &manifest_path,
   lut->offset = requireJsonIntField(quant_param, "offset", manifest_path);
   lut->is_raw_u16 = false;
   lut->is_signed4 = false;
-  lut->bytes = readBinaryFile(resolveLutPath(manifest_path, lut_path));
+  lut->bytes =
+    MappedBytes::mapFile(resolveLutPath(manifest_path, lut_path).string());
 
   derivePacked4BitDimensions(*lut, manifest_path);
   return lut;
@@ -193,7 +177,8 @@ std::shared_ptr<QuantLut> loadSfixed4Manifest(const std::string &manifest_path,
   lut->out_dim = requireJsonSizeField(json, "size", manifest_path);
   lut->is_raw_u16 = false;
   lut->is_signed4 = true;
-  lut->bytes = readBinaryFile(resolveLutPath(manifest_path, lut_path));
+  lut->bytes =
+    MappedBytes::mapFile(resolveLutPath(manifest_path, lut_path).string());
   lut->row_scales.reserve(quant_param.at("scale").size());
 
   for (const auto &scale : quant_param.at("scale")) {
@@ -255,7 +240,7 @@ std::shared_ptr<QuantLut> loadRawU16(const std::string &path,
     << "Raw UINT16 LUT size overflows size_t for " << path;
 
   const size_t expected_size = in_dim_hint * out_dim_hint * sizeof(uint16_t);
-  auto bytes = readBinaryFile(path);
+  auto bytes = MappedBytes::mapFile(path);
   NNTR_THROW_IF(bytes.size() != expected_size, std::runtime_error)
     << "Raw UINT16 LUT file size " << bytes.size()
     << " does not match in_dim*out_dim*2 (" << expected_size << ") for "
@@ -354,6 +339,108 @@ void decodePacked4BitRowToFloatType(const QuantLut &lut, size_t token_idx,
 }
 
 } // namespace
+
+MappedBytes::~MappedBytes() { reset(); }
+
+void MappedBytes::reset() noexcept {
+#ifndef _WIN32
+  if (map_addr_ != nullptr) {
+    ::munmap(map_addr_, size_);
+    map_addr_ = nullptr;
+  }
+#endif
+  ptr_ = nullptr;
+  size_ = 0;
+  owned_.clear();
+}
+
+MappedBytes::MappedBytes(MappedBytes &&other) noexcept :
+  ptr_(other.ptr_),
+  size_(other.size_),
+  map_addr_(other.map_addr_),
+  owned_(std::move(other.owned_)) {
+  other.ptr_ = nullptr;
+  other.size_ = 0;
+  other.map_addr_ = nullptr;
+}
+
+MappedBytes &MappedBytes::operator=(MappedBytes &&other) noexcept {
+  if (this != &other) {
+    reset();
+    ptr_ = other.ptr_;
+    size_ = other.size_;
+    map_addr_ = other.map_addr_;
+    owned_ = std::move(other.owned_);
+    other.ptr_ = nullptr;
+    other.size_ = 0;
+    other.map_addr_ = nullptr;
+  }
+  return *this;
+}
+
+MappedBytes MappedBytes::fromVector(std::vector<uint8_t> data) {
+  MappedBytes m;
+  m.owned_ = std::move(data);
+  m.ptr_ = m.owned_.data();
+  m.size_ = m.owned_.size();
+  return m;
+}
+
+MappedBytes MappedBytes::mapFile(const std::string &path) {
+#ifdef _WIN32
+  // No mmap on Windows: fall back to a full read into a heap buffer.
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  NNTR_THROW_IF(!file.is_open(), std::runtime_error)
+    << "Failed to open LUT file: " << path;
+  const auto pos = file.tellg();
+  NNTR_THROW_IF(pos < 0, std::runtime_error)
+    << "Failed to get LUT file size: " << path;
+  std::vector<uint8_t> bytes(static_cast<size_t>(pos));
+  file.seekg(0, std::ios::beg);
+  if (!bytes.empty()) {
+    file.read(reinterpret_cast<char *>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+    NNTR_THROW_IF(static_cast<size_t>(file.gcount()) != bytes.size(),
+                  std::runtime_error)
+      << "Failed to read complete LUT file: " << path;
+  }
+  return fromVector(std::move(bytes));
+#else
+  int fd = ::open(path.c_str(), O_RDONLY);
+  NNTR_THROW_IF(fd < 0, std::runtime_error)
+    << "Failed to open LUT file: " << path;
+
+  struct stat st {};
+  if (::fstat(fd, &st) != 0) {
+    ::close(fd);
+    NNTR_THROW_IF(true, std::runtime_error)
+      << "Failed to stat LUT file: " << path;
+  }
+
+  MappedBytes m;
+  const size_t len = static_cast<size_t>(st.st_size);
+  if (len == 0) {
+    ::close(fd);
+    return m; // empty mapping
+  }
+
+  void *addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
+  // The mapping keeps the underlying file alive, so the fd can be closed now.
+  ::close(fd);
+  NNTR_THROW_IF(addr == MAP_FAILED, std::runtime_error)
+    << "Failed to mmap LUT file: " << path;
+
+  // Embedding is a random row gather by token id, so touch is sparse. Advise
+  // the kernel to skip readahead — the whole point is to fault in only the
+  // rows the model actually uses rather than eagerly paging the entire LUT.
+  ::madvise(addr, len, MADV_RANDOM);
+
+  m.map_addr_ = addr;
+  m.ptr_ = static_cast<const uint8_t *>(addr);
+  m.size_ = len;
+  return m;
+#endif
+}
 
 std::shared_ptr<QuantLut> get_or_load_quant_lut(const std::string &path,
                                                 size_t in_dim_hint,

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -66,10 +66,50 @@ public:
 } // namespace props
 
 /**
+ * @brief RAII owner of LUT bytes, backed by a read-only mmap of the LUT file
+ * (POSIX) or a heap buffer fallback (Windows / in-memory tests).
+ *
+ * Embedding is a sparse row gather by token id, so the model only ever touches
+ * a small fraction of a large LUT. Memory-mapping lets those rows fault in on
+ * demand during forwarding instead of eagerly reading the whole file during
+ * layer finalize() — which used to dominate QNN model load time.
+ *
+ * Exposes data()/size()/empty() so it is a drop-in for the std::vector<uint8_t>
+ * it replaces. Move-only (a mapping must have a single owner to munmap once).
+ */
+class WIN_EXPORT MappedBytes {
+public:
+  MappedBytes() = default;
+  ~MappedBytes();
+  MappedBytes(MappedBytes &&other) noexcept;
+  MappedBytes &operator=(MappedBytes &&other) noexcept;
+  MappedBytes(const MappedBytes &) = delete;
+  MappedBytes &operator=(const MappedBytes &) = delete;
+
+  /// mmap @a path read-only (falls back to a full read on Windows / empty
+  /// file). Throws std::runtime_error on open/map failure.
+  static MappedBytes mapFile(const std::string &path);
+  /// Take ownership of an already in-memory buffer.
+  static MappedBytes fromVector(std::vector<uint8_t> data);
+
+  const uint8_t *data() const { return ptr_; }
+  size_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
+
+private:
+  void reset() noexcept;
+
+  const uint8_t *ptr_ = nullptr;
+  size_t size_ = 0;
+  void *map_addr_ = nullptr;   ///< non-null only when mmap-backed (to munmap)
+  std::vector<uint8_t> owned_; ///< holds data only when vector-backed
+};
+
+/**
  * @brief Shared sidecar embedding LUT loaded from raw UINT16 or JSON manifest.
  */
 struct QuantLut {
-  std::vector<uint8_t> bytes;
+  MappedBytes bytes;
   std::vector<float> row_scales;
 
   float scale = 1.0f;

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -86,11 +86,11 @@ public:
   MappedBytes(const MappedBytes &) = delete;
   MappedBytes &operator=(const MappedBytes &) = delete;
 
-  /// mmap @a path read-only (falls back to a full read on Windows / empty
-  /// file). Throws std::runtime_error on open/map failure.
+  /// mmap the file at path read-only (falls back to a full read on Windows /
+  /// empty file). Throws std::runtime_error on open/map failure.
   static MappedBytes mapFile(const std::string &path);
   /// Take ownership of an already in-memory buffer.
-  static MappedBytes fromVector(std::vector<uint8_t> data);
+  static MappedBytes fromVector(std::vector<uint8_t> &&data);
 
   const uint8_t *data() const { return ptr_; }
   size_t size() const { return size_; }
@@ -252,6 +252,9 @@ public:
   inline static const std::string type = "embedding_layer";
 
 private:
+  /**
+   * @brief Gather embeddings for tokens [from, to) from the sidecar LUT.
+   */
   void forwardSidecarLut(nntrainer::RunLayerContext &context, unsigned int from,
                          unsigned int to);
 


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>feat(embedding): mmap sidecar LUT instead of eager full read</summary><br />

Back QuantLut bytes with a read-only mmap of the LUT file (new MappedBytes RAII owner) instead of reading the whole file into a std::vector during EmbeddingLayer::finalize(). Embedding is a sparse row gather by token id, so only the rows the model actually uses fault in on demand during forwarding; MADV_RANDOM disables readahead so the entire LUT is never paged in. This removes the eager LUT read that dominated QNN model load time.

MappedBytes exposes data()/size()/empty(), so all decode consumers and the sidecar unit test are unchanged. Windows (no mmap) falls back to a full read.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: haehun.yang <haehun.yang@samsung.com>

</details>

### Summary

- mmap sidecar LUT instead of eager full read

Signed-off-by: haehun.yang <haehun.yang@samsung.com>