### PR TITLE
causallm: resize graph to actual prompt length via resetInputDimension

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -522,6 +522,15 @@ void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
     weight_decay, "Embedding", true);
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, embedding_props);
   LayerImpl::setProperty(remain_props);

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -149,6 +149,18 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only the output tensor's height (sequence length) is updated;
+   * the input tensor keeps the raw token-id shape produced by InputLayer,
+   * which is intentionally excluded from this broadcast (see
+   * NetworkGraph::resetInputDimension).
+   */
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,

--- a/Applications/CausalLM/layers/embedding_normalize_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.cpp
@@ -62,6 +62,14 @@ void EmbeddingNormalizeLayer::incremental_forwarding(
   forwarding(context, training);
 }
 
+void EmbeddingNormalizeLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  // No-op: this layer always sits after Pooling, so its input/output is
+  // already the fixed [batch, 1, 1, dim] pooled vector and never varies with
+  // sequence length.
+}
+
 void EmbeddingNormalizeLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/embedding_normalize_layer.h
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.h
@@ -62,6 +62,14 @@ public:
                               bool training) override;
 
   /**
+   * @copydoc   Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc   Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(nntrainer::RunLayerContext &context) override;

--- a/Applications/CausalLM/layers/embedding_pooling_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.cpp
@@ -152,6 +152,19 @@ void EmbeddingPoolingLayer::incremental_forwarding(
   }
 }
 
+void EmbeddingPoolingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  // Input height is the current sequence length; output stays fixed at
+  // height 1 (pooled to a single vector per finalize()), so only the input
+  // needs to track the new step size.
+  unsigned int height = input_dimensions[0].height();
+
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+}
+
 void EmbeddingPoolingLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/embedding_pooling_layer.h
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.h
@@ -154,6 +154,14 @@ public:
                               bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(nntrainer::RunLayerContext &context) override;

--- a/Applications/CausalLM/layers/logit_softcapping.cpp
+++ b/Applications/CausalLM/layers/logit_softcapping.cpp
@@ -113,8 +113,16 @@ void LogitSoftCappingLayer::applyOnRange(nntrainer::RunLayerContext &context,
 void LogitSoftCappingLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // This layer sits on lm_head's output, whose height is fixed at 1
+  // regardless of prompt length; propagate that actual height instead of
+  // the broadcast sequence length.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  output_dim.height(input_dim.height());
+
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void LogitSoftCappingLayer::calcDerivative(

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1534,13 +1534,26 @@ void MHACoreLayer::updateTensorsByInputDimensions(
   std::vector<nntrainer::TensorDim> input_dimensions) {
   // cache_key/cache_value keep their fixed MAX_SEQ_LEN-based size from
   // finalize(); resizing them here would break decode-phase from/to windows.
-  ml::train::TensorDim kv_dim = input_dimensions[0];
-  kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
+  // QUERY/KEY/VALUE/OUTPUT widths are also preserved from finalize(), since
+  // hidden_size / (num_heads_Q/num_heads_KV) != head_dim whenever
+  // head_dim != hidden_size / num_heads_Q (e.g. Qwen3). Only height changes.
+  unsigned int height = input_dimensions[0].height();
 
-  context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
-  context.updateInput(INOUT_INDEX::KEY, kv_dim);
-  context.updateInput(INOUT_INDEX::VALUE, kv_dim);
-  context.updateOutput(0, input_dimensions[0]);
+  ml::train::TensorDim query_dim =
+    context.getInput(INOUT_INDEX::QUERY).getDim();
+  query_dim.height(height);
+  ml::train::TensorDim key_dim = context.getInput(INOUT_INDEX::KEY).getDim();
+  key_dim.height(height);
+  ml::train::TensorDim value_dim =
+    context.getInput(INOUT_INDEX::VALUE).getDim();
+  value_dim.height(height);
+  ml::train::TensorDim output_dim = context.getOutput(0).getDim();
+  output_dim.height(height);
+
+  context.updateInput(INOUT_INDEX::QUERY, query_dim);
+  context.updateInput(INOUT_INDEX::KEY, key_dim);
+  context.updateInput(INOUT_INDEX::VALUE, value_dim);
+  context.updateOutput(0, output_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1532,33 +1532,15 @@ void MHACoreLayer::setBatch(nntrainer::RunLayerContext &context,
 void MHACoreLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  unsigned int height = input_dimensions[0].height();
-  unsigned int &max_timestep =
-    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
-  unsigned int &max_new_tokens =
-    std::get<props::MaxNewTokens>(mha_core_props).get();
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
-  max_timestep = height + max_new_tokens;
-
+  // cache_key/cache_value keep their fixed MAX_SEQ_LEN-based size from
+  // finalize(); resizing them here would break decode-phase from/to windows.
   ml::train::TensorDim kv_dim = input_dimensions[0];
   kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
-
-  ml::train::TensorDim kv_cache_dim = kv_dim;
-#ifdef ENABLE_FP16
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-#else
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
-#endif
-  kv_cache_dim.height(max_timestep);
 
   context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
   context.updateInput(INOUT_INDEX::KEY, kv_dim);
   context.updateInput(INOUT_INDEX::VALUE, kv_dim);
   context.updateOutput(0, input_dimensions[0]);
-
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/per_layer_slice.cpp
+++ b/Applications/CausalLM/layers/per_layer_slice.cpp
@@ -100,9 +100,12 @@ void PerLayerSliceLayer::incremental_forwarding(
 void PerLayerSliceLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  auto out_dim = input_dimensions[0];
-  out_dim.width(std::get<props::FeatureSize>(slice_props).get());
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  auto in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  in_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, in_dim);
+
+  auto out_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  out_dim.height(input_dimensions[0].height());
   context.updateOutput(SINGLE_INOUT_IDX, out_dim);
 }
 

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -146,8 +146,17 @@ void ReshapedRMSNormLayer::incremental_forwarding(
 void ReshapedRMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width (num_heads * head_dim) is preserved from
+  // finalize(), since it need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -125,8 +125,17 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 void RMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width is preserved from finalize(), since it
+  // need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/scalar_multiply.cpp
+++ b/Applications/CausalLM/layers/scalar_multiply.cpp
@@ -118,8 +118,17 @@ void ScalarMultiplyLayer::incremental_forwarding(
 void ScalarMultiplyLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width is preserved from finalize(), since it
+  // need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void ScalarMultiplyLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -166,6 +166,19 @@ void SharedFullyConnectedLayer::incremental_forwarding(
   }
 }
 
+void SharedFullyConnectedLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void SharedFullyConnectedLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -129,6 +129,14 @@ public:
   void setProperty(const std::vector<std::string> &values) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override {

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -426,10 +426,12 @@ void TieWordEmbedding::updateTensorsByInputDimensions(
 
   if (mode_ == mode::embedding) {
     in_dim.width(height);
+    out_dim.height(height);
   } else {
+    // lm_head mode: output is always the last-token logits (height == 1,
+    // fixed in finalize_lmhead()); only the input sequence length changes.
     in_dim.height(height);
   }
-  out_dim.height(height);
 
   context.updateInput(SINGLE_INOUT_IDX, in_dim);
   context.updateOutput(SINGLE_INOUT_IDX, out_dim);

--- a/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
+++ b/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
@@ -102,6 +102,31 @@ nntrainer::TensorDim makeInputDim(nntrainer::TensorDim::DataType dtype,
 
 } // namespace
 
+TEST(CausalLmEmbeddingSidecarLut,
+     updateTensorsByInputDimensionsOnlyChangesOutputHeight) {
+  causallm::EmbeddingLayer layer;
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {nntrainer::Var_Grad(
+    makeInputDim(nntrainer::TensorDim::DataType::FP32, 4),
+    nntrainer::Initializer::NONE, true, false, "embedding_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "embedding_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  auto context = makeRunContext(weights, inputs, outputs, tensors);
+
+  std::vector<nntrainer::TensorDim> new_dims = {
+    nntrainer::TensorDim({1, 1, 6, 8})};
+  layer.updateTensorsByInputDimensions(context, new_dims);
+
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 4u);
+  EXPECT_EQ(context.getInput(0).getDim().height(), 1u);
+}
+
 TEST(CausalLmEmbeddingSidecarLut, rawUint16RequiresExactHintedSize) {
   TempDir dir("nntrainer_embedding_sidecar_raw_u16");
   const auto raw_path = dir.path() / "embedding.u16";

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -328,6 +328,7 @@ if get_option('enable-test')
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3_cached_slim_moe.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss_cached_slim.cpp',
+        meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_moe_resetinputdim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2_reference.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3.cpp',

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -329,6 +329,7 @@ if get_option('enable-test')
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss_cached_slim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_moe_resetinputdim.cpp',
+        meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_run_prompt_resetinputdim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2_reference.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3.cpp',

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -493,11 +493,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   };
   input = build_inference_inputs();
 
-  ///@note contains possible bug
-  // std::vector<ml::train::TensorDim> input_dims;
-  // ml::train::TensorDim input_dim(1, 1, input_len, DIM);
-  // input_dims.push_back(input_dim);
-  // model->resetInputDimension(input_dims);
+  std::vector<ml::train::TensorDim> input_dims;
+  input_dims.push_back(
+    ml::train::TensorDim(1, 1, input_len, static_cast<unsigned int>(DIM)));
+  model->resetInputDimension(input_dims);
+  // resetInputDimension() silently rebinds KV cache placeholders back to
+  // internal memory; force allocateAndBindKVCache() to redo external binding.
+  kv_cache_bound = false;
 
   auto start_prefill = std::chrono::high_resolution_clock::now();
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -575,9 +575,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     // post process of model output
     id_list = generate(output[0], do_sample, 1, ids_history, init_len);
-
-    if (init_len < INIT_SEQ_LEN)
-      registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+    registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
   }
   // output should be deallocated after use
   for (auto &out : output) {

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -599,6 +599,12 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
+  std::vector<ml::train::TensorDim> decode_input_dims;
+  decode_input_dims.push_back(
+    ml::train::TensorDim(1, 1, 1, static_cast<unsigned int>(DIM)));
+  model->resetInputDimension(decode_input_dims);
+  kv_cache_bound = false;
+
   for (unsigned int token_generation_idx = input_len + 1;
        token_generation_idx < input_len + 1 + NUM_TO_GENERATE &&
        !stop_requested_.load(std::memory_order_acquire);

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
@@ -597,4 +597,31 @@ void GptOssMoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void GptOssMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
@@ -108,6 +108,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "gpt_oss_moe"; /**< type of the layer */
 
 private:

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -592,4 +592,31 @@ void CachedSlimGptOssMoELayer::exportTo(
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void CachedSlimGptOssMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
@@ -111,6 +111,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type =
     "gpt_oss_moe_slim_cached"; /**< type of the layer */
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -534,14 +534,27 @@ void CachedSlimMoELayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
   ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
   ml::train::TensorDim output_dim =
     context.getOutput(SINGLE_INOUT_IDX).getDim();
-
-  input_dim.height(input_dimensions[0].height());
-  output_dim.height(input_dimensions[0].height());
-
-  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  output_dim.height(new_height);
   context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
 }
 
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
@@ -527,4 +527,31 @@ void MoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void MoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
@@ -113,6 +113,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "qwen_moe"; /**< type of the layer */
 
 private:

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
@@ -521,4 +521,31 @@ void SlimMoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void SlimMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
@@ -113,6 +113,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "moe_slim"; /**< type of the layer */
 
 private:

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -338,13 +338,14 @@ void NetworkGraph::resetInputDimension(std::vector<TensorDim> dims) {
     deallocateTensors();
 
   for (auto iter = cbegin(); iter != cend(); iter++) {
-    if ((*iter)->isFinalized()) {
+    /// @note InputLayer is excluded: its raw input tensor doesn't follow the
+    /// height-based convention `dims` uses for every other layer.
+    if ((*iter)->isFinalized() && (*iter)->getType() != InputLayer::type) {
       (*iter)->updateTensorsByInputDimensions(dims);
     }
   }
 
-  if (allocated)
-    allocateTensors(exec_mode);
+  allocateTensors(exec_mode);
 
   /** update input and label dimensions */
   for (unsigned int idx = 0; idx < input_list.size(); idx++)

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -111,6 +111,17 @@ void ActivationLayer::incremental_forwarding(RunLayerContext &context,
   }
 }
 
+void ActivationLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void ActivationLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -58,6 +58,15 @@ public:
                               unsigned int to, bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only height (sequence length) is resized; width (feature dim)
+   * is preserved from finalize().
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -107,9 +107,14 @@ void AdditionLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
   for (size_t i = 0; i < context.getNumInputs(); ++i) {
-    context.updateInput(i, input_dimensions[0]);
+    TensorDim input_dim = context.getInput(i).getDim();
+    input_dim.height(input_dimensions[0].height());
+    context.updateInput(i, input_dim);
   }
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/addition_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.cpp
@@ -104,4 +104,13 @@ void AdditionLayerCL::setProperty(const std::vector<std::string> &values) {
     throw exception::not_supported(msg);
   }
 }
+
+void AdditionLayerCL::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  for (size_t i = 0; i < context.getNumInputs(); ++i) {
+    context.updateInput(i, input_dimensions[0]);
+  }
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -90,6 +90,13 @@ public:
   void setProperty(const std::vector<std::string> &values) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return AdditionLayerCL::type; };

--- a/nntrainer/layers/cl_layers/fc_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.cpp
@@ -198,4 +198,15 @@ void FullyConnectedLayerCl::calcGradient(RunLayerContext &context) {
     !context.isGradientFirstAccess(weight_idx[FCParams::weight]));
 }
 
+void FullyConnectedLayerCl::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -101,6 +101,13 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static bool registerClKernels([[maybe_unused]] ClContext &cl_context) {
     return true;
   };

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -26,7 +26,8 @@
 #include <util_func.h>
 
 namespace nntrainer {
-ConcatLayer::ConcatLayer() : Layer(), leading_helper_dim(1) {}
+ConcatLayer::ConcatLayer() :
+  Layer(), concat_dimension(1), leading_helper_dim(1) {}
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
@@ -36,8 +37,7 @@ void ConcatLayer::finalize(InitLayerContext &context) {
   /// @todo this is hacky way to force concat dimension to width if channel
   /// dimension is taken, this is because recurrent realizer, return sequence
   /// exploits concat layer but have no control over where to stack/axis
-  unsigned int concat_dimension =
-    context.getInputDimensions().front().channel() > 1 ? 3 : 1;
+  concat_dimension = context.getInputDimensions().front().channel() > 1 ? 3 : 1;
   if (!concat_dimension_prop.empty())
     concat_dimension = concat_dimension_prop.get();
 
@@ -325,6 +325,61 @@ void ConcatLayer::exportTo(Exporter &exporter,
                            const ml::train::ExportMethods &method) const {
   Layer::exportTo(exporter, method);
   exporter.saveResult(concat_props, method, this);
+}
+
+void ConcatLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  /** @todo height-axis concat (concat_dimension == 2) sums heights across
+   * inputs rather than sharing a single sequence length, so the assumption
+   * below (all inputs/outputs simply adopt input_dimensions[0].height())
+   * does not hold for it */
+  NNTR_THROW_IF(concat_dimension == 2, std::invalid_argument)
+    << "[ConcatLayer] updateTensorsByInputDimensions does not support "
+       "concat_dimension == 2 (height-axis concat)";
+
+  unsigned int height = input_dimensions[0].height();
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  std::vector<TensorDim> input_dims(context.getNumInputs());
+  for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
+    TensorDim input_dim = context.getInput(idx).getDim();
+    input_dim.height(height);
+    context.updateInput(idx, input_dim);
+    input_dims[idx] = input_dim;
+  }
+
+  /// Recompute output_reshape_helper for the new height
+  output_reshape_helper.channel(1);
+  output_reshape_helper.height(1);
+  output_reshape_helper.width(1);
+  for (unsigned int axis = concat_dimension;
+       axis < ml::train::TensorDim::getNumDim(); ++axis) {
+    output_reshape_helper.width(output_reshape_helper.width() *
+                                output_dim.getTensorDim(axis));
+  }
+
+  /// Recompute input_reshape_helper for the new height
+  for (unsigned int idx = 0; idx < input_reshape_helper.size(); idx++) {
+    input_reshape_helper[idx].channel(1);
+    input_reshape_helper[idx].height(1);
+    input_reshape_helper[idx].width(1);
+
+    for (unsigned int axis = concat_dimension;
+         axis < ml::train::TensorDim::getNumDim(); ++axis) {
+      input_reshape_helper[idx].width(input_reshape_helper[idx].width() *
+                                      input_dims[idx].getTensorDim(axis));
+    }
+  }
+
+  leading_helper_dim = 1;
+  for (unsigned int idx = 1; idx < concat_dimension; ++idx) {
+    leading_helper_dim *= output_dim.getTensorDim(idx);
+  }
+
+  setBatch(output_dim.batch());
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -100,9 +100,18 @@ public:
     setBatch(batch);
   }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "concat";
 
 private:
+  unsigned int concat_dimension;   /**< axis along which inputs are
+                                      concatenated */
   unsigned int leading_helper_dim; /**< batch dimension of helper dimension not
                                 containing the actual batch */
   std::vector<TensorDim>

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -228,4 +228,11 @@ void EmbeddingLayer::exportTo(Exporter &exporter,
   exporter.saveResult(embedding_props, method, this);
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 } // namespace nntrainer

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -101,6 +101,13 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "embedding";
 
 private:

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -251,6 +251,17 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
   }
 }
 
+void FullyConnectedLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
                                                  unsigned int from,
                                                  unsigned int to,

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -59,6 +59,15 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only height (sequence length) is resized; width (feature dim)
+   * is preserved from finalize().
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
 ￼   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
 ￼   * int from, unsigned int to, bool training)
 ￼   */

--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -332,4 +332,52 @@ void LayerNormalizationLayer::setBatch(RunLayerContext &context,
   context.updateTensor(wt_idx[LNParams::temp_normalized_size], batch);
 }
 
+void LayerNormalizationLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  // @todo: consider NHWC format
+  bool is_height_normalize =
+    std::find(normalize_axes.begin(), normalize_axes.end(), 1) !=
+    normalize_axes.end();
+
+  unsigned int height = input_dimensions[0].height();
+
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  TensorDim deviation_dim =
+    context.getTensor(wt_idx[LNParams::deviation]).getDim();
+  deviation_dim.height(height);
+  context.updateTensor(wt_idx[LNParams::deviation], deviation_dim);
+
+  TensorDim temp_origin_dim =
+    context.getTensor(wt_idx[LNParams::temp_origin_size]).getDim();
+  temp_origin_dim.height(height);
+  context.updateTensor(wt_idx[LNParams::temp_origin_size], temp_origin_dim);
+
+  /** variance/inv_std_dev/temp_normalized_size only carry sequence length in
+   * their height when height is not one of the normalize axes */
+  if (!is_height_normalize) {
+    TensorDim variance_dim =
+      context.getTensor(wt_idx[LNParams::variance]).getDim();
+    variance_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::variance], variance_dim);
+
+    TensorDim inv_std_dev_dim =
+      context.getTensor(wt_idx[LNParams::inv_std_dev]).getDim();
+    inv_std_dev_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::inv_std_dev], inv_std_dev_dim);
+
+    TensorDim temp_normalized_dim =
+      context.getTensor(wt_idx[LNParams::temp_normalized_size]).getDim();
+    temp_normalized_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::temp_normalized_size],
+                         temp_normalized_dim);
+  }
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_normalization_layer.h
+++ b/nntrainer/layers/layer_normalization_layer.h
@@ -120,6 +120,13 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "layer_normalization";
 
 private:

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -91,10 +91,14 @@ void MultiOutLayer::setProperty(const std::vector<std::string> &values) {
 void MultiOutLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
 
   for (size_t i = 0; i < context.getNumOutputs(); ++i) {
-    context.updateOutput(i, input_dimensions[0]);
+    TensorDim output_dim = context.getOutput(i).getDim();
+    output_dim.height(input_dimensions[0].height());
+    context.updateOutput(i, output_dim);
   }
 }
 

--- a/nntrainer/layers/multiply_layer.cpp
+++ b/nntrainer/layers/multiply_layer.cpp
@@ -60,4 +60,13 @@ void MultiplyLayer::setProperty(const std::vector<std::string> &values) {
     throw exception::not_supported(msg);
   }
 }
+
+void MultiplyLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  for (size_t i = 0; i < context.getNumInputs(); ++i) {
+    context.updateInput(i, input_dimensions[0]);
+  }
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
 } /* namespace nntrainer */

--- a/nntrainer/layers/multiply_layer.cpp
+++ b/nntrainer/layers/multiply_layer.cpp
@@ -65,8 +65,13 @@ void MultiplyLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
   for (size_t i = 0; i < context.getNumInputs(); ++i) {
-    context.updateInput(i, input_dimensions[0]);
+    TensorDim input_dim = context.getInput(i).getDim();
+    input_dim.height(input_dimensions[0].height());
+    context.updateInput(i, input_dim);
   }
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 } /* namespace nntrainer */

--- a/nntrainer/layers/multiply_layer.h
+++ b/nntrainer/layers/multiply_layer.h
@@ -139,6 +139,14 @@ public:
    */
   const std::string getType() const final { return MultiplyLayer::type; };
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) final;
+
   std::tuple<props::Print, props::InPlaceProp, props::InPlaceDirectionProp,
              props::SkipPrefill>
     multiply_props;

--- a/nntrainer/layers/operation_layer.h
+++ b/nntrainer/layers/operation_layer.h
@@ -79,6 +79,23 @@ public:
     }
   }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   *
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context,
+    std::vector<TensorDim> input_dimensions) override {
+    TensorDim input_dim = context.getInput(0).getDim();
+    input_dim.height(input_dimensions[0].height());
+    context.updateInput(0, input_dim);
+
+    TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+    output_dim.height(input_dimensions[0].height());
+    context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+  }
+
   static constexpr size_t SINGLE_INOUT_IDX = 0;
 };
 
@@ -154,6 +171,27 @@ public:
 
       forwarding_operation(input0_step, input1_step, hidden_step);
     }
+  }
+
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   *
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context,
+    std::vector<TensorDim> input_dimensions) override {
+    TensorDim input0_dim = context.getInput(0).getDim();
+    input0_dim.height(input_dimensions[0].height());
+    context.updateInput(0, input0_dim);
+
+    TensorDim input1_dim = context.getInput(1).getDim();
+    input1_dim.height(input_dimensions[0].height());
+    context.updateInput(1, input1_dim);
+
+    TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+    output_dim.height(input_dimensions[0].height());
+    context.updateOutput(SINGLE_INOUT_IDX, output_dim);
   }
 
   static constexpr size_t SINGLE_INOUT_IDX = 0;

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <activation_layer.h>
+#include <layer_context.h>
 #include <layers_common_tests.h>
 
 auto semantic_activation_relu = LayerSemanticsParamType(
@@ -57,3 +58,34 @@ GTEST_PARAMETER_TEST(
                     semantic_activation_gelu, semantic_activation_sigmoid,
                     semantic_activation_softmax, semantic_activation_tanh,
                     semantic_activation_none));
+
+TEST(ActivationUpdateTensorsByInputDimensions,
+     updates_input_output_height_only) {
+  nntrainer::ActivationLayer acti;
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "activation_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "activation_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  std::vector<nntrainer::Weight *> weights_view;
+  std::vector<nntrainer::Var_Grad *> inputs_view = {&inputs[0]};
+  std::vector<nntrainer::Var_Grad *> outputs_view = {&outputs[0]};
+  std::vector<nntrainer::Var_Grad *> tensors_view;
+
+  nntrainer::RunLayerContext context("activation_update_dims_test", true, 0.0f,
+                                     false, 1.0f, nullptr, false, weights_view,
+                                     inputs_view, outputs_view, tensors_view);
+
+  std::vector<nntrainer::TensorDim> dims = {nntrainer::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(acti.updateTensorsByInputDimensions(context, dims));
+
+  EXPECT_EQ(context.getInput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 8u);
+}

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <fc_layer.h>
+#include <layer_context.h>
 #include <layers_common_tests.h>
 
 auto semantic_fc = LayerSemanticsParamType(
@@ -89,3 +90,34 @@ GTEST_PARAMETER_TEST(FullyConnected16, LayerGoldenTest,
                                        fc_basic_single_batch_w16a16,
                                        fc_basic_no_decay_w16a16));
 #endif
+
+TEST(FullyConnectedUpdateTensorsByInputDimensions,
+     updates_input_output_height_only) {
+  nntrainer::FullyConnectedLayer fc;
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {
+    nntrainer::Var_Grad(nntrainer::TensorDim({1, 1, 4, 8}),
+                        nntrainer::Initializer::NONE, true, false, "fc_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 16}), nntrainer::Initializer::NONE, true,
+    false, "fc_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  std::vector<nntrainer::Weight *> weights_view;
+  std::vector<nntrainer::Var_Grad *> inputs_view = {&inputs[0]};
+  std::vector<nntrainer::Var_Grad *> outputs_view = {&outputs[0]};
+  std::vector<nntrainer::Var_Grad *> tensors_view;
+
+  nntrainer::RunLayerContext context("fc_update_dims_test", true, 0.0f, false,
+                                     1.0f, nullptr, false, weights_view,
+                                     inputs_view, outputs_view, tensors_view);
+
+  std::vector<nntrainer::TensorDim> dims = {nntrainer::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(fc.updateTensorsByInputDimensions(context, dims));
+
+  EXPECT_EQ(context.getInput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 16u);
+}

--- a/test/unittest/models/causallm_test_utils.h
+++ b/test/unittest/models/causallm_test_utils.h
@@ -14,6 +14,7 @@
 #define __CAUSALLM_TEST_UTILS_H__
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <functional>
 #include <map>
@@ -22,6 +23,10 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#ifdef ENABLE_FP16
+#include <fp16.h>
+#endif
 
 #include <causal_lm.h>
 #include <layer.h>
@@ -130,6 +135,13 @@ public:
    * @return true if run() completed
    */
   virtual bool hasRun() const = 0;
+
+  /**
+   * @brief Check whether the final logits tensor (output_of_causallm) is
+   * entirely finite (no NaN/Inf) after the most recent run()/runPrompt()
+   * @return true if every element of the output tensor is finite
+   */
+  virtual bool lastOutputIsFinite() const = 0;
 
   /**
    * @brief Read one token from the model input/output history
@@ -363,6 +375,50 @@ public:
   bool hasRun() const override { return causallm::CausalLM::hasRun(); }
 
   /**
+   * @brief Check the final logits tensor (output_of_causallm) is finite
+   *
+   * Reads the raw output tensor directly, independent of dtype, so it
+   * catches dtype-reinterpretation corruption (e.g. an FP16 buffer viewed
+   * through a stale FP32 dimension) that a text-decoding check would miss.
+   */
+  bool lastOutputIsFinite() const override {
+    bool found = false;
+    bool finite = true;
+
+    this->model->forEachLayer([&](ml::train::Layer &layer,
+                                  nntrainer::RunLayerContext &context, void *) {
+      if (found || layer.getName() != "output_of_causallm")
+        return;
+      found = true;
+
+      nntrainer::Tensor &out = context.getOutput(0);
+      for (unsigned int i = 0; i < out.size(); ++i) {
+        float v = 0.0f;
+#ifdef ENABLE_FP16
+        if (out.getDataType() == ml::train::TensorDim::DataType::FP16)
+          v = static_cast<float>(out.template getData<_FP16>()[i]);
+        else
+#endif
+          if (out.getDataType() == ml::train::TensorDim::DataType::FP32)
+          v = out.template getData<float>()[i];
+        else
+          throw std::logic_error(
+            "lastOutputIsFinite: unsupported output tensor dtype");
+
+        if (!std::isfinite(v)) {
+          finite = false;
+          break;
+        }
+      }
+    });
+
+    if (!found)
+      throw std::logic_error(
+        "lastOutputIsFinite: output_of_causallm layer not found");
+    return finite;
+  }
+
+  /**
    * @brief Read one token from the model input/output history
    */
   unsigned int tokenAt(size_t idx) const override {
@@ -504,6 +560,10 @@ public:
     throw std::logic_error("getOutputText not supported for embedding models");
   }
   bool hasRun() const override { return false; }
+  bool lastOutputIsFinite() const override {
+    throw std::logic_error(
+      "lastOutputIsFinite not supported for embedding models");
+  }
   unsigned int tokenAt(size_t) const override {
     throw std::logic_error("tokenAt not supported for embedding models");
   }

--- a/test/unittest/models/unittest_causallm_moe_resetinputdim.cpp
+++ b/test/unittest/models/unittest_causallm_moe_resetinputdim.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_causallm_moe_resetinputdim.cpp
+ * @date   08 July 2026
+ * @brief  End-to-end verification that MoE layers survive
+ *         CausalLM::run()'s resetInputDimension() call. Exercises the real
+ *         run()/resetInputDimension path, unlike the golden
+ *         prefillLogits()-based tests elsewhere in this suite which bypass
+ *         it entirely.
+ * @author Jungwon Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * @note Only Qwen3MoE (qwen_moe) is exercised here.
+ *       - GptOss (gpt_oss_moe) is intentionally NOT covered: once its MoE
+ *         layer's updateTensorsByInputDimensions() override stops throwing,
+ *         a separate pre-existing bug in GptOss's MHACoreLayer/sliding-window
+ *         attention path segfaults on resetInputDimension(). That is a
+ *         distinct, deeper issue outside the scope of the MoE tensor-resize
+ *         fix and is tracked separately.
+ *       - SlimMoE (moe_slim), Qwen3CachedSlimMoE (qwen_moe_cached), and
+ *         GptOssCachedSlim (gpt_oss_moe_slim_cached) call
+ *         Tensor::activate()/deactivate() unconditionally in forwarding() for
+ *         lazy mmap-based expert weight loading; in this in-process
+ *         tiny-test harness their weights are plain in-memory tensors, so
+ *         activate() hangs (see the pre-existing comment in
+ *         unittest_causallm_qwen3_slim_moe.cpp). Running them here would
+ *         risk hanging the test binary, so they are intentionally not
+ *         covered by this file; their fix was verified by structural code
+ *         inspection (identical requestTensor/updateTensor pattern to the
+ *         one covered here).
+ */
+
+#include <causallm_test_utils.h>
+
+#include <gtest/gtest.h>
+
+#include <layer.h>
+#include <layer_context.h>
+#include <qwen3_moe_causallm.h>
+
+namespace {
+
+using TinyQwen3MoECausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen3MoECausalLM>;
+
+causallm::json makeTinyQwen3MoEConfig() {
+  return {
+    {"architectures", {"Qwen3MoeForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"moe_intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"num_experts", 4},
+    {"num_experts_per_tok", 2},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+/**
+ * @brief Zero all FP32 weights, but set MoE gate weights to non-uniform
+ * values so routing is deterministic. No correctness assertions are made
+ * here -- this only needs to run forward without crashing/OOB.
+ */
+template <typename Model>
+void zeroWeightsWithMoEGate(Model &model, const std::string &moe_layer_type) {
+  model.forEachLayer(
+    [&](ml::train::Layer &layer, nntrainer::RunLayerContext &context, void *) {
+      if (layer.getName() == "output_of_causallm")
+        return;
+
+      if (layer.getType() == moe_layer_type) {
+        auto &gate = context.getWeight(0);
+        const auto dim = gate.getDim();
+        const unsigned hidden = dim.height();
+        const unsigned num_exp = dim.width();
+        for (unsigned h = 0; h < hidden; ++h)
+          for (unsigned e = 0; e < num_exp; ++e)
+            gate.setValue(0, 0, h, e, 1.0f / (e + 1));
+
+        for (unsigned int i = 1; i < context.getNumWeights(); ++i) {
+          auto &w = context.getWeight(i);
+          if (w.getDataType() == ml::train::TensorDim::DataType::FP32)
+            w.setValue(0.0f);
+        }
+        return;
+      }
+
+      for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+        auto &weight = context.getWeight(i);
+        if (weight.getDataType() != ml::train::TensorDim::DataType::FP32)
+          continue;
+
+        weight.setValue(0.0f);
+        if (layer.getType() == "rms_norm") {
+          weight.setValue(1.0f);
+        } else if (layer.getName() == "embedding0") {
+          weight.setValue(0, 0, 1, 0, 1.0f);
+          weight.setValue(0, 0, 4, 0, 2.0f);
+        }
+      }
+    });
+}
+
+TEST(MoEResetInputDimensionEndToEnd, Qwen3MoERunPromptDoesNotCrash) {
+  auto files = causallm_test::makeTinyCausalLMFiles(
+    "MoEResetInputDimensionEndToEnd", "Qwen3MoERunPromptDoesNotCrash",
+    "Qwen3MoE_FP32");
+
+  auto model_cfg = makeTinyQwen3MoEConfig();
+  auto gen_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyNntrainerConfig(
+    files.tokenizer_path, causallm_test::makeTinyFp32DataType());
+
+  auto model =
+    std::make_unique<TinyQwen3MoECausalLM>(model_cfg, gen_cfg, nntr_cfg);
+  model->initializeModel();
+  zeroWeightsWithMoEGate(*model, "qwen_moe");
+
+  // Longer than a single token so resetInputDimension() actually resizes the
+  // sequence length away from whatever finalize() originally allocated.
+  ASSERT_NO_THROW(model->runPrompt("hello tok4 tok5 tok6 tok7"));
+  EXPECT_TRUE(model->hasRun());
+
+  // Run a second, shorter prompt through the same model instance:
+  // resetInputDimension() is called on every run(), so this exercises
+  // shrinking the router_logits/expert_mask tensors back down too.
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_TRUE(model->hasRun());
+}
+
+} // namespace

--- a/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
+++ b/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_causallm_run_prompt_resetinputdim.cpp
+ * @date   08 July 2026
+ * @brief  End-to-end verification that Qwen2, Qwen3, Gemma3 and Gemma4
+ *         survive CausalLM::run()'s resetInputDimension() call when the
+ *         same model instance is reused across prompts of different
+ *         lengths. Exercises the real run()/resetInputDimension() path,
+ *         unlike the golden prefillLogits()-based tests elsewhere in this
+ *         suite which call NeuralNetwork::incremental_inference() directly
+ *         and therefore never reach resetInputDimension() at all.
+ * @author Jungwon Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * @note See unittest_causallm_moe_resetinputdim.cpp for the equivalent
+ *       Qwen3MoE coverage, and for why GptOss / SlimMoE / CachedSlimMoE
+ *       variants are intentionally not covered by an analogous test here.
+ */
+
+#include <causallm_test_utils.h>
+
+#include <gtest/gtest.h>
+
+#include <gemma3_causallm.h>
+#include <gemma4_causallm.h>
+#include <layer.h>
+#include <layer_context.h>
+#include <qwen2_causallm.h>
+#include <qwen3_causallm.h>
+
+namespace {
+
+/**
+ * @brief Zero every FP32 weight, leaving rms_norm at 1 and a couple of
+ * embedding rows non-zero so the forward pass is deterministic. No
+ * correctness assertions are made on the produced logits here -- these
+ * tests only need the resetInputDimension()-driven forward pass to run
+ * without crashing/OOB across multiple prompt lengths on the same
+ * instance.
+ */
+template <typename Model> void zeroWeights(Model &model) {
+  model.forEachLayer(
+    [&](ml::train::Layer &layer, nntrainer::RunLayerContext &context, void *) {
+      if (layer.getName() == "output_of_causallm")
+        return;
+
+      for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+        auto &weight = context.getWeight(i);
+        if (weight.getDataType() != ml::train::TensorDim::DataType::FP32)
+          continue;
+
+        weight.setValue(0.0f);
+        if (layer.getType() == "rms_norm" ||
+            layer.getType() == "reshaped_rms_norm") {
+          weight.setValue(1.0f);
+        } else if (layer.getName() == "embedding0") {
+          weight.setValue(0, 0, 1, 0, 1.0f);
+          weight.setValue(0, 0, 4, 0, 2.0f);
+        } else if (layer.getName().find("_layer_scalar") != std::string::npos) {
+          weight.setValue(1.0f);
+        }
+      }
+    });
+}
+
+using TinyQwen2CausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen2CausalLM>;
+using TinyQwen3CausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen3CausalLM>;
+
+/**
+ * @brief Tiny Gemma3 CausalLM adapter (needs sanitizeConfig() before the
+ * virtual Transformer base is constructed, see unittest_causallm_gemma3.cpp)
+ */
+class TinyGemma3CausalLM final
+  : public causallm_test::CausalLMTestAdapter<causallm::Gemma3CausalLM> {
+public:
+  TinyGemma3CausalLM(causallm::json &cfg, causallm::json &generation_cfg,
+                     causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm_test::CausalLMTestAdapter<causallm::Gemma3CausalLM>(
+      cfg, generation_cfg, nntr_cfg) {}
+};
+
+/**
+ * @brief Tiny Gemma4 CausalLM adapter (needs sanitizeConfig() to flatten
+ * text_config before the virtual Transformer base is constructed, see
+ * unittest_causallm_gemma4.cpp)
+ */
+class TinyGemma4CausalLM final
+  : public causallm_test::CausalLMTestAdapter<causallm::Gemma4CausalLM> {
+public:
+  TinyGemma4CausalLM(causallm::json &cfg, causallm::json &generation_cfg,
+                     causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm_test::CausalLMTestAdapter<causallm::Gemma4CausalLM>(
+      cfg, generation_cfg, nntr_cfg) {}
+};
+
+causallm::json makeTinyQwen2Config() {
+  return {
+    {"architectures", {"Qwen2ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyQwen3Config() {
+  return {
+    {"architectures", {"Qwen3ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyGemma3Config() {
+  return {
+    {"architectures", {"Gemma3ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 2},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-6},
+    {"rope_theta", 1000000},
+    {"sliding_window", 4},
+    {"sliding_window_pattern", 2},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyGemma4Config() {
+  return {
+    {"architectures", {"Gemma4ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"text_config",
+     {
+       {"head_dim", 8},
+       {"hidden_size", 64},
+       {"hidden_size_per_layer_input", 32},
+       {"intermediate_size", 64},
+       {"layer_types", {"sliding_attention", "full_attention"}},
+       {"max_position_embeddings", 8},
+       {"num_attention_heads", 8},
+       {"num_hidden_layers", 2},
+       {"num_key_value_heads", 4},
+       {"rms_norm_eps", 1e-6},
+       {"rope_theta", 1000000},
+       {"sliding_window", 4},
+       {"tie_word_embeddings", true},
+       {"vocab_size", 32},
+       {"vocab_size_per_layer_input", 32},
+     }},
+  };
+}
+
+/**
+ * @brief Build, initialize and zero-weight a tiny model of the given type,
+ * then run two prompts of different lengths through the same instance.
+ */
+template <typename Model>
+void runResetInputDimensionRegression(const std::string &suite,
+                                      const std::string &test,
+                                      const std::string &fixture_name,
+                                      causallm::json model_cfg) {
+  auto files = causallm_test::makeTinyCausalLMFiles(suite, test, fixture_name);
+
+  auto gen_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyNntrainerConfig(
+    files.tokenizer_path, causallm_test::makeTinyFp32DataType());
+
+  auto model = std::make_unique<Model>(model_cfg, gen_cfg, nntr_cfg);
+  model->initializeModel();
+  zeroWeights(*model);
+
+  // Longer than a single token so resetInputDimension() actually resizes
+  // the sequence length away from whatever finalize() originally allocated.
+  ASSERT_NO_THROW(model->runPrompt("hello tok4 tok5 tok6 tok7"));
+  EXPECT_TRUE(model->hasRun());
+
+  // Run a second, shorter prompt through the same model instance:
+  // resetInputDimension() is called on every run(), so this exercises
+  // shrinking tensors back down too.
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_TRUE(model->hasRun());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen2RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyQwen2CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen2RunPromptDoesNotCrash",
+    "Qwen2_FP32", makeTinyQwen2Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen3RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyQwen3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen3RunPromptDoesNotCrash",
+    "Qwen3_FP32", makeTinyQwen3Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma3RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyGemma3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma3RunPromptDoesNotCrash",
+    "Gemma3_FP32", makeTinyGemma3Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma4RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyGemma4CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma4RunPromptDoesNotCrash",
+    "Gemma4_FP32", makeTinyGemma4Config());
+}
+
+} // namespace

--- a/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
+++ b/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
@@ -193,17 +193,24 @@ causallm::json makeTinyGemma4Config() {
 /**
  * @brief Build, initialize and zero-weight a tiny model of the given type,
  * then run two prompts of different lengths through the same instance.
+ *
+ * Asserts the final logits tensor is finite after each run: dtype-clobbering
+ * bugs in a layer's updateTensorsByInputDimensions() (e.g. a residual add
+ * whose input view gets reinterpreted at the wrong dtype) corrupt the
+ * activation stream with NaN/Inf without necessarily throwing, so a plain
+ * ASSERT_NO_THROW is not sufficient to catch them.
  */
 template <typename Model>
-void runResetInputDimensionRegression(const std::string &suite,
-                                      const std::string &test,
-                                      const std::string &fixture_name,
-                                      causallm::json model_cfg) {
+void runResetInputDimensionRegression(
+  const std::string &suite, const std::string &test,
+  const std::string &fixture_name, causallm::json model_cfg,
+  const causallm_test::TinyCausalLMDataType &data_type =
+    causallm_test::makeTinyFp32DataType()) {
   auto files = causallm_test::makeTinyCausalLMFiles(suite, test, fixture_name);
 
   auto gen_cfg = causallm_test::makeTinyGenerationConfig();
-  auto nntr_cfg = causallm_test::makeTinyNntrainerConfig(
-    files.tokenizer_path, causallm_test::makeTinyFp32DataType());
+  auto nntr_cfg =
+    causallm_test::makeTinyNntrainerConfig(files.tokenizer_path, data_type);
 
   auto model = std::make_unique<Model>(model_cfg, gen_cfg, nntr_cfg);
   model->initializeModel();
@@ -213,12 +220,14 @@ void runResetInputDimensionRegression(const std::string &suite,
   // the sequence length away from whatever finalize() originally allocated.
   ASSERT_NO_THROW(model->runPrompt("hello tok4 tok5 tok6 tok7"));
   EXPECT_TRUE(model->hasRun());
+  EXPECT_TRUE(model->lastOutputIsFinite());
 
   // Run a second, shorter prompt through the same model instance:
   // resetInputDimension() is called on every run(), so this exercises
   // shrinking tensors back down too.
   ASSERT_NO_THROW(model->runPrompt("hello"));
   EXPECT_TRUE(model->hasRun());
+  EXPECT_TRUE(model->lastOutputIsFinite());
 }
 
 TEST(RunPromptResetInputDimensionEndToEnd, Qwen2RunPromptDoesNotCrash) {
@@ -244,5 +253,57 @@ TEST(RunPromptResetInputDimensionEndToEnd, Gemma4RunPromptDoesNotCrash) {
     "RunPromptResetInputDimensionEndToEnd", "Gemma4RunPromptDoesNotCrash",
     "Gemma4_FP32", makeTinyGemma4Config());
 }
+
+#ifdef ENABLE_FP16
+/**
+ * @brief FP16-activation coverage for the same resetInputDimension() path.
+ *
+ * Regression test for a bug where AdditionLayer/MultiplyLayer/MultiOutLayer/
+ * PerLayerSliceLayer's updateTensorsByInputDimensions() overwrote a tensor's
+ * entire TensorDim (including dtype) with the caller-supplied dimension --
+ * which defaults to FP32 -- instead of only updating height. On an FP16
+ * activation build this silently reinterpreted FP16 buffers as FP32 at the
+ * first decoder block's residual add, corrupting the activation stream with
+ * NaN/Inf from layer 0 onward. Only reproduces with FP16 activations:
+ * FP32 models never hit the dtype mismatch, and this file is excluded from
+ * the FP32-only host meson suite (see enable_causallm_model_unittest in
+ * Applications/CausalLM/meson.build), so this only runs in the Android
+ * FP16 unittest_causallm_models build.
+ *
+ * Uses the Q4_0-FP16 (weight+activation) data type -- the actual combination
+ * shipped on Android -- since plain FP32 weights are not supported with
+ * FP16 activations: FC/lm_head layers compute `input_.dot(weight_, ...)`,
+ * so with FP16 activations the dot is dispatched through HalfTensor::dot(),
+ * which only accepts an FP16, Q4_0, or Q6_K weight operand and throws
+ * "unsupported datatype" for a plain FP32 weight.
+ */
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen2RunPromptFp16IsFinite) {
+  runResetInputDimensionRegression<TinyQwen2CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen2RunPromptFp16IsFinite",
+    "Qwen2_FP16", makeTinyQwen2Config(),
+    causallm_test::makeTinyQ40Fp16DataType());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen3RunPromptFp16IsFinite) {
+  runResetInputDimensionRegression<TinyQwen3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen3RunPromptFp16IsFinite",
+    "Qwen3_FP16", makeTinyQwen3Config(),
+    causallm_test::makeTinyQ40Fp16DataType());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma3RunPromptFp16IsFinite) {
+  runResetInputDimensionRegression<TinyGemma3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma3RunPromptFp16IsFinite",
+    "Gemma3_FP16", makeTinyGemma3Config(),
+    causallm_test::makeTinyQ40Fp16DataType());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma4RunPromptFp16IsFinite) {
+  runResetInputDimensionRegression<TinyGemma4CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma4RunPromptFp16IsFinite",
+    "Gemma4_FP16", makeTinyGemma4Config(),
+    causallm_test::makeTinyQ40Fp16DataType());
+}
+#endif // ENABLE_FP16
 
 } // namespace

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -403,6 +403,36 @@ TEST(nntrainerGraphUnitTest, NoLossLayerWhenInferenceMode) {
   ans.clear();
 }
 
+TEST(nntrainerGraphUnitTest, ResetInputDimensionSkipsInputLayer) {
+  std::unique_ptr<ml::train::Model> model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  model->addLayer(ml::train::createLayer(
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "1:1:4")}));
+  model->addLayer(ml::train::createLayer(
+    "fully_connected",
+    {nntrainer::withKey("unit", 8),
+     nntrainer::withKey("weight_initializer", "xavier_uniform"),
+     nntrainer::withKey("bias_initializer", "zeros")}));
+
+  model->setProperty({nntrainer::withKey("batch_size", 1),
+                      nntrainer::withKey("model_tensor_type", "FP32-FP32")});
+
+  ASSERT_EQ(model->compile(ml::train::ExecutionMode::INFERENCE), ML_ERROR_NONE);
+  ASSERT_EQ(model->initialize(ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
+
+  std::vector<ml::train::TensorDim> new_dims = {
+    ml::train::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(model->resetInputDimension(new_dims));
+
+  // input0's own dim (raw width-based shape) must stay untouched.
+  EXPECT_EQ(model->getInputDimension()[0].width(), 4u);
+  EXPECT_EQ(model->getInputDimension()[0].height(), 1u);
+}
+
 void check_sorted_graph(nntrainer::GraphCore graph,
                         std::vector<std::string> expected_layer_names) {
   int expected_graph_size = expected_layer_names.size();


### PR DESCRIPTION
https://github.com/nntrainer/nntrainer/pull/3881

## Summary
- Wire up `NetworkGraph::resetInputDimension()` so `CausalLM::run()` resizes the graph to the real prompt length during prefill and to a single token before the decode loop, instead of keeping a graph sized for a fixed `INIT_SEQ_LEN` for the whole session.
- Add/fix `updateTensorsByInputDimensions()` overrides across the layers used in CausalLM graphs (fc, embedding, mha_core, activation, rms_norm variants, scalar_multiply, tie_word_embedding, logit_softcapping, and all 5 MoE layer variants) so each correctly resizes its own tensors instead of falling back to the base class's unconditional throw, or naively overwriting tensor width with the broadcast hidden_size-based dimension when its true width differs (per-head tensors, GQA KV width, lm_head's fixed height-1 output, etc).
- Fix a pre-existing bug where prompts `>= INIT_SEQ_LEN` silently dropped the first generated token.
- `network_graph`: exclude `InputLayer` from the `resetInputDimension` broadcast, since its raw token-id tensor convention differs from every other layer's height-based one.

## Commits
Ordered so every commit up to "wire up resetInputDimension" only adds inert per-layer support (the call site isn't wired up yet), and the switch is flipped last, once every layer type used by a CausalLM graph can handle it:
1. `fc_layer`: add height-only `updateTensorsByInputDimensions`
2. `causallm/embedding_layer`: add height-only `updateTensorsByInputDimensions`
3. `causallm/mha_core`: stop resizing the KV cache in `updateTensorsByInputDimensions`
4. `network_graph`: exclude `InputLayer` from the broadcast, always allocate
5. `activation_layer`: add height-only `updateTensorsByInputDimensions`
6. `causallm/moe`: add `updateTensorsByInputDimensions` across all 5 MoE layer variants (router_logits/expert_mask resize)
7. `causallm`: wire up `resetInputDimension()` before prefill, force KV cache rebind — the actual switch
8. `test/causallm`: end-to-end `runPrompt()` regression coverage for Qwen2/Qwen3/Gemma3/Gemma4
9. `causallm`: stop dropping the first prefill token for long prompts
10. `causallm`: resize graph to a single token before the decode loop
11. `causallm`: preserve tensor width in `updateTensorsByInputDimensions` overrides (fc/activation/rms_norm variants/scalar_multiply/mha_core/tie_word_embedding/logit_softcapping)

## Test plan
- [x] `unittest_nntrainer_graph.cpp`: `InputLayer` exclusion from the broadcast
- [x] `unittest_layers_fully_connected.cpp` / `unittest_layers_activation.cpp`: height-only resize
- [x] `unittest_causallm_moe_resetinputdim.cpp`: end-to-end `runPrompt()` grow/shrink for Qwen3MoE
- [x] `unittest_causallm_run_prompt_resetinputdim.cpp`: end-to-end `runPrompt()` grow/shrink for Qwen2/Qwen3/Gemma3/Gemma4
- [x] Full `unittest_causallm_models` suite passes

Known follow-ups noted in commit messages (out of scope here):
- `GptOssMoELayer`: allowing `resetInputDimension` past the MoE layer exposes a pre-existing SIGSEGV in GptOss's sliding-window attention path; not covered by the new tests.
- `SlimMoELayer` / `CachedSlimGptOssMoELayer`: not covered by the new end-to-end test because their lazy mmap-based expert loading hangs in the in-process tiny-test harness; verified instead by code inspection against the identical `MoELayer` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
