### PR TITLE
feat(qnn): thread-safe context map for async load + init timing

### DIFF
--- a/nntrainer/qnn/jni/QNNGraph.cpp
+++ b/nntrainer/qnn/jni/QNNGraph.cpp
@@ -172,10 +172,21 @@ void QNNGraph::forwarding(RunLayerContext &context, bool training) {
   auto qc_var = getQNNVar(context);
   unsigned int graphIdx = 0;
 
+  // Measure how long the first forward blocks acquiring the QNN context. With
+  // the async preload this should be ~0 ms (already loaded); without it, this
+  // is the full contextCreateFromBinary cost on the critical path.
+  const bool log_ctx_wait = !context_wait_logged_;
+  const auto _qnn_t_ctx = std::chrono::steady_clock::now();
   if (!qc_var->findContext(bin_path)) {
     ml_logw("Context is not created. Create Now");
 
     qc_var->makeContext(bin_path);
+  }
+  if (log_ctx_wait) {
+    context_wait_logged_ = true;
+    QNN_TIMING_LOG("first forward: context acquire wait (graph=%s): %lld ms",
+                   context.getName().c_str(),
+                   ::nntrainer::qnn_ms_since(_qnn_t_ctx));
   }
 
   auto graphInfo = qc_var->graphRetrieve(bin_path, context.getName());

--- a/nntrainer/qnn/jni/QNNGraph.cpp
+++ b/nntrainer/qnn/jni/QNNGraph.cpp
@@ -38,6 +38,10 @@ std::chrono::duration<double> exec_seconds;
 
 namespace nntrainer {
 
+/**
+ * @brief Fetch the shared QNN backend state (device/context/profiling
+ * handles) from a layer's run context.
+ */
 std::shared_ptr<QNNVar> getQNNVar(RunLayerContext &context) {
   std::shared_ptr<QNNVar> qc_var =
     (std::static_pointer_cast<QNNBackendVar>(context.getContextData()))

--- a/nntrainer/qnn/jni/QNNGraph.h
+++ b/nntrainer/qnn/jni/QNNGraph.h
@@ -26,10 +26,20 @@ namespace nntrainer {
  */
 class QNNGraph : public LayerImpl {
 public:
+  /** @brief Variant over the raw tensor buffer pointer types QNNGraph can
+   * bind as QNN graph input/output. */
   using BufferTypePtr =
     std::variant<std::monostate, uint8_t *, uint16_t *, float *>;
 
+  /**
+   * @brief     Constructor of QNNGraph
+   */
   QNNGraph();
+
+  /**
+   * @brief     Destructor of QNNGraph. Frees the QNN graph context and, if
+   * this was the last user, the cached context entry for its binary path.
+   */
   ~QNNGraph();
 
   inline static const std::string type = "qnn_graph";
@@ -65,18 +75,36 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @brief Deserialize (or reuse the cached) QNN context binary for this
+   * graph's bin_path.
+   */
   StatusCode makeContext(RunLayerContext &context);
 
+  /**
+   * @brief Free the QNN graph context created by makeContext().
+   */
   StatusCode freeContext(RunLayerContext &context);
 
+  /**
+   * @copydoc Layer::read()
+   */
   void read(std::ifstream &file, RunLayerContext &run_context, bool opt_var,
             ml::train::ExecutionMode mode, bool trainable,
             TensorDim::DataType defineWeightDataType, bool fsu = false,
             size_t start_offset = 0, bool read_from_offset = false,
             int file_fd = -1) override;
 
+  /**
+   * @brief Append a BufferTypePtr for T to buffers, tagged by T's data type
+   * (UINT4/UINT8, UINT16, or FP32) so it can be bound to a QNN tensor.
+   */
   void updateBufferType(std::vector<BufferTypePtr> &buffers, Tensor &T);
 
+  /**
+   * @brief Populate and register QNN tensor T with the given buffer,
+   * dispatching on the buffer's held pointer type.
+   */
   void populateTensor(std::shared_ptr<QNNVar> qc_var,
                       Qnn_Context_Graph_t &context_i, BufferTypePtr buffer,
                       Qnn_Tensor_t *T);

--- a/nntrainer/qnn/jni/QNNGraph.h
+++ b/nntrainer/qnn/jni/QNNGraph.h
@@ -107,6 +107,11 @@ private:
   sample_app::QnnFunctionPointers m_qnnFunctionPointers;
 
   int counter;
+
+  // One-shot guard: log how long the very first forward waits to acquire the
+  // QNN context (i.e. how much of the background preload it had to block on).
+  // ~0 ms means the async preload fully hid the deserialization.
+  bool context_wait_logged_ = false;
 };
 
 } // namespace nntrainer

--- a/nntrainer/qnn/jni/iotensor_wrapper.hpp
+++ b/nntrainer/qnn/jni/iotensor_wrapper.hpp
@@ -24,6 +24,10 @@ using namespace qnn::tools::iotensor;
 /** @brief Wraps QNN IO tensor allocation and teardown without copying data. */
 class IOTensorWrapper {
 public:
+  /**
+   * @brief Allocate and deep-copy QNN input/output tensor descriptors from
+   * graphInfo, tearing down whatever was already allocated on failure.
+   */
   StatusCode
   setupInputAndOutputTensors(Qnn_Tensor_t **inputs, Qnn_Tensor_t **outputs,
                              qnn_wrapper_api::GraphInfo_t graphInfo) {
@@ -58,6 +62,11 @@ public:
     return returnStatus;
   }
 
+  /**
+   * @brief Copy a uint8_t source buffer into QNN input tensor input,
+   * quantizing from float first if inputDataType is FLOAT but input expects
+   * a non-float native type.
+   */
   StatusCode populateInputTensor(uint8_t *buffer, Qnn_Tensor_t *input,
                                  InputDataType inputDataType) {
     if (nullptr == input) {
@@ -90,6 +99,11 @@ public:
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Copy a uint16_t source buffer into QNN input tensor input,
+   * quantizing from float first if inputDataType is FLOAT but input expects
+   * a non-float native type.
+   */
   StatusCode populateInputTensor(uint16_t *buffer, Qnn_Tensor_t *input,
                                  InputDataType inputDataType) {
     if (nullptr == input) {
@@ -125,6 +139,11 @@ public:
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Copy a float source buffer into QNN input tensor input,
+   * quantizing it first if inputDataType is FLOAT but input expects a
+   * non-float native type.
+   */
   StatusCode populateInputTensor(float *buffer, Qnn_Tensor_t *input,
                                  InputDataType inputDataType) {
     if (nullptr == input) {
@@ -158,6 +177,10 @@ public:
   }
 
 private:
+  /**
+   * @brief Allocate tensors and deep-copy tensorWrappers' descriptors into
+   * it, without copying any tensor data.
+   */
   StatusCode setupTensorsNoCopy(Qnn_Tensor_t **tensors, uint32_t tensorCount,
                                 Qnn_Tensor_t *tensorWrappers) {
     if (nullptr == tensorWrappers) {
@@ -199,7 +222,10 @@ private:
     return returnStatus;
   }
 
-  // Clean up all tensors related data after execution.
+  /**
+   * @brief Free the dimensions and client buffer owned by each tensor, then
+   * free the tensors array itself.
+   */
   StatusCode tearDownTensors(Qnn_Tensor_t *tensors, uint32_t tensorCount) {
     for (size_t tensorIdx = 0; tensorIdx < tensorCount; tensorIdx++) {
       QNN_DEBUG("freeing resources for tensor: %d", tensorIdx);
@@ -216,6 +242,9 @@ private:
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Copy the first rank entries of inDimensions into dims.
+   */
   StatusCode fillDims(std::vector<size_t> &dims, uint32_t *inDimensions,
                       uint32_t rank) {
     if (nullptr == inDimensions) {
@@ -228,8 +257,10 @@ private:
     return StatusCode::SUCCESS;
   }
 
-  // Helper method to copy a float buffer, quantize it, and copy
-  // it to a tensor (Qnn_Tensor_t) buffer.
+  /**
+   * @brief Quantize/cast floatBuffer into tensor's native client buffer type,
+   * dispatching on tensor's QNN data type.
+   */
   StatusCode copyFromFloatToNative(float *floatBuffer, Qnn_Tensor_t *tensor) {
     if (nullptr == floatBuffer || nullptr == tensor) {
       QNN_ERROR("copyFromFloatToNative(): received a nullptr");

--- a/nntrainer/qnn/jni/qnn_context_var.h
+++ b/nntrainer/qnn/jni/qnn_context_var.h
@@ -58,6 +58,10 @@ enum class StatusCode {
   QNN_FEATURE_UNSUPPORTED
 };
 
+/**
+ * @brief Per-binary QNN context state: the backend context handle plus the
+ * graphs deserialized from it, indexed by graph name.
+ */
 struct Qnn_Context_Graph_t {
   Qnn_ContextHandle_t m_context;
   qnn_wrapper_api::GraphInfo_t **m_graphsInfo;
@@ -70,6 +74,10 @@ struct Qnn_Context_Graph_t {
 
   QnnContext_Config_t **m_contextConfig = nullptr;
 
+  /**
+   * @brief Populate graph_map from m_graphsInfo/m_graphsCount after the
+   * binary has been deserialized.
+   */
   void setGraphInfoMap() {
     for (uint32_t i = 0; i < m_graphsCount; ++i) {
       std::string n((m_graphsInfo)[i]->graphName);
@@ -77,6 +85,10 @@ struct Qnn_Context_Graph_t {
     }
   }
 
+  /**
+   * @brief Look up a graph by name, falling back to a case-insensitive
+   * match against the binary's real graph names.
+   */
   qnn_wrapper_api::GraphInfo_t *getGraphPtr(const std::string &graph_name) {
     auto mapIt = graph_map.find(graph_name);
     if (mapIt != graph_map.end()) {
@@ -105,6 +117,9 @@ struct Qnn_Context_Graph_t {
     return nullptr;
   }
 
+  /**
+   * @brief Look up a graph's index within this context by name.
+   */
   int getGraphIdx(std::string graph_name) {
     auto mapIt = graph_idx.find(graph_name);
     if (mapIt != graph_idx.end()) {
@@ -116,6 +131,11 @@ struct Qnn_Context_Graph_t {
   }
 };
 
+/**
+ * @brief Per-backend-instance QNN state shared by a QNNContext and every
+ * QNNGraph layer that uses it: backend/device handles, function pointers,
+ * and the cache of context binaries already deserialized (ct_map).
+ */
 struct QNNVar {
   QnnBackend_Config_t **m_backendConfig = nullptr;
   Qnn_BackendHandle_t m_backendHandle = nullptr;
@@ -146,6 +166,10 @@ struct QNNVar {
    */
   std::mutex ct_mutex;
 
+  /**
+   * @brief Look up the deserialized context/graphs for bin_path, if it has
+   * already been created.
+   */
   std::optional<std::reference_wrapper<Qnn_Context_Graph_t>>
   findContext(std::string bin_path) {
     std::lock_guard<std::mutex> lock(ct_mutex);
@@ -156,6 +180,10 @@ struct QNNVar {
     return std::nullopt;
   }
 
+  /**
+   * @brief Free the QNN context handle, graphs info, and context config
+   * owned by ct_map[bin_path], then erase the entry.
+   */
   StatusCode freeContext(const std::string &bin_path) {
     std::lock_guard<std::mutex> lock(ct_mutex);
     auto it = ct_map.find(bin_path);
@@ -210,6 +238,9 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Free every context currently tracked in ct_map.
+   */
   StatusCode freeAllContexts() {
     // 반복 중 erase하면 안 되므로 키를 먼저 복사
     std::vector<std::string> keys;
@@ -223,6 +254,10 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Deserialize a QNN context binary (mmap + contextCreateFromBinary)
+   * and cache it in ct_map, or return immediately if bin is already cached.
+   */
   StatusCode makeContext(props::FilePath bin) {
     // Hold ct_mutex for the entire load so the background context preload and a
     // racing first forward create the binary exactly once; the loser blocks
@@ -365,6 +400,10 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Retrieve the QNN graph handle for graphName from the context
+   * already loaded from bin_path.
+   */
   qnn_wrapper_api::GraphInfo_t *graphRetrieve(std::string bin_path,
                                               std::string graphName) {
 
@@ -406,6 +445,10 @@ struct QNNVar {
     return graphInfo;
   }
 
+  /**
+   * @brief Dump every profiling event (and its sub-events) recorded on the
+   * backend profile handle.
+   */
   StatusCode extractBackendProfilingInfo() {
     Qnn_ProfileHandle_t profileHandle = m_profileBackendHandle;
 
@@ -429,6 +472,9 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Recursively dump the sub-events of a profiling event.
+   */
   StatusCode extractProfilingSubEvents(QnnProfile_EventId_t profileEventId) {
     const QnnProfile_EventId_t *profileSubEvents{nullptr};
     uint32_t numSubEvents{0};
@@ -447,6 +493,9 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Log a single profiling event's type/value/identifier/unit.
+   */
   StatusCode extractProfilingEvent(QnnProfile_EventId_t profileEventId) {
     QnnProfile_EventData_t eventData;
     if (QNN_PROFILE_NO_ERROR !=
@@ -462,6 +511,9 @@ struct QNNVar {
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief mmap a QNN context binary file read-only into buffer.
+   */
   bool mmapBinaryFile(std::string filePath, void **buffer, size_t bufferSize) {
     int fd = open(filePath.c_str(), O_RDONLY);
     int OFFSET = 0;
@@ -476,9 +528,20 @@ struct QNNVar {
   }
 };
 
+/**
+ * @brief ContextData wrapper that owns the QNNVar shared by a QNNContext
+ * instance and every QNNGraph layer created under it.
+ */
 class QNNBackendVar : public ContextData {
 public:
+  /**
+   * @brief     Default constructor
+   */
   QNNBackendVar() : data(std::make_shared<QNNVar>()) {}
+
+  /**
+   * @brief     Access the shared QNNVar.
+   */
   std::shared_ptr<QNNVar> &getVar() { return data; }
 
 private:

--- a/nntrainer/qnn/jni/qnn_context_var.h
+++ b/nntrainer/qnn/jni/qnn_context_var.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -40,6 +41,8 @@
 #include <layer_devel.h>
 
 #include <nntrainer_log.h>
+
+#include "qnn_timing.h"
 
 using namespace qnn;
 using namespace qnn::tools;
@@ -132,8 +135,20 @@ struct QNNVar {
   std::map<std::string, Qnn_Context_Graph_t>
     ct_map; /** bin file name - Context map **/
 
+  /**
+   * Guards ct_map. The QNN context binary can be deserialized either eagerly on
+   * a background thread (see Quick_Dot_AI_QNN context preload) or lazily on the
+   * first forward; this serializes those paths so a binary is created exactly
+   * once. Held for the whole makeContext() body, so a first forward that races
+   * an in-flight preload simply blocks until the load finishes. ct_map is a
+   * std::map, so references returned by findContext() stay valid across other
+   * inserts; entries are only erased at teardown (after the preload is joined).
+   */
+  std::mutex ct_mutex;
+
   std::optional<std::reference_wrapper<Qnn_Context_Graph_t>>
   findContext(std::string bin_path) {
+    std::lock_guard<std::mutex> lock(ct_mutex);
     auto mapIt = ct_map.find(bin_path);
     if (mapIt != ct_map.end()) {
       return mapIt->second;
@@ -142,6 +157,7 @@ struct QNNVar {
   }
 
   StatusCode freeContext(const std::string &bin_path) {
+    std::lock_guard<std::mutex> lock(ct_mutex);
     auto it = ct_map.find(bin_path);
     if (it == ct_map.end()) {
       ml_logw("Context not found for: %s", bin_path.c_str());
@@ -208,11 +224,18 @@ struct QNNVar {
   }
 
   StatusCode makeContext(props::FilePath bin) {
+    // Hold ct_mutex for the entire load so the background context preload and a
+    // racing first forward create the binary exactly once; the loser blocks
+    // here until the winner finishes. Look up ct_map directly rather than via
+    // findContext(), which would re-lock the same (non-recursive) mutex.
+    std::lock_guard<std::mutex> lock(ct_mutex);
 
-    if (findContext(bin.get())) {
+    if (ct_map.find(bin.get()) != ct_map.end()) {
       ml_logw("context is already exists");
       return StatusCode::SUCCESS;
     };
+
+    QNN_TIME_SCOPE("makeContext (context binary load, total): " + bin.get());
 
     // Let backendExtensions populate configs
     QnnContext_Config_t **customConfigs{nullptr};
@@ -239,10 +262,12 @@ struct QNNVar {
     std::shared_ptr<uint8_t> buffer{nullptr};
 
     void *mappedBuffer = nullptr;
+    auto _qnn_t = std::chrono::steady_clock::now();
     if (true != mmapBinaryFile(bin.get(), &mappedBuffer, bufferSize)) {
       ml_loge("Failed to read binary data");
       return StatusCode::FAILURE;
     }
+    QNN_TIME_SINCE("makeContext: mmapBinaryFile", _qnn_t);
 
     buffer = std::shared_ptr<uint8_t>(static_cast<uint8_t *>(mappedBuffer),
                                       [&bufferSize](uint8_t *ptr) {
@@ -254,6 +279,7 @@ struct QNNVar {
     auto returnStatus = StatusCode::SUCCESS;
     Qnn_Context_Graph_t context_i;
 
+    _qnn_t = std::chrono::steady_clock::now();
     QnnSystemContext_Handle_t sysCtxHandle{nullptr};
     if (QNN_SUCCESS !=
         m_qnnFunctionPointers.qnnSystemInterface.systemContextCreate(
@@ -281,6 +307,7 @@ struct QNNVar {
 
     m_qnnFunctionPointers.qnnSystemInterface.systemContextFree(sysCtxHandle);
     sysCtxHandle = nullptr;
+    QNN_TIME_SINCE("makeContext: systemContext metadata parse", _qnn_t);
 
     if (StatusCode::SUCCESS == returnStatus &&
         nullptr == m_qnnFunctionPointers.qnnInterface.contextCreateFromBinary) {
@@ -309,6 +336,7 @@ struct QNNVar {
       context_i.m_contextConfig[i + 1] = customConfigs[i];
     context_i.m_contextConfig[customConfigCount + 1] = nullptr;
 
+    _qnn_t = std::chrono::steady_clock::now();
     if (StatusCode::SUCCESS == returnStatus &&
         m_qnnFunctionPointers.qnnInterface.contextCreateFromBinary(
           m_backendHandle, m_deviceHandle,
@@ -318,6 +346,8 @@ struct QNNVar {
       ml_loge("Could not create context from binary.");
       returnStatus = StatusCode::FAILURE;
     }
+    QNN_TIME_SINCE("makeContext: contextCreateFromBinary (HTP deserialize)",
+                   _qnn_t);
 
     if (nullptr != m_backendExtensions && m_backendExtensions->interface()) {
       if (!m_backendExtensions->interface()->afterCreateFromBinary()) {

--- a/nntrainer/qnn/jni/qnn_properties.h
+++ b/nntrainer/qnn/jni/qnn_properties.h
@@ -51,11 +51,17 @@ public:
 
 } // namespace props
 
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
 template <>
 std::string str_converter<props::quant_param_prop_tag,
                           std::pair<std::string, std::pair<float, int>>>::
   to_string(const std::pair<std::string, std::pair<float, int>> &quant_param);
 
+/**
+ * @copydoc template <typename Tag, typename DataType> struct str_converter
+ */
 template <>
 std::pair<std::string, std::pair<float, int>>
 str_converter<props::quant_param_prop_tag,

--- a/nntrainer/qnn/jni/qnn_rpc_manager.cpp
+++ b/nntrainer/qnn/jni/qnn_rpc_manager.cpp
@@ -23,6 +23,10 @@
 
 namespace nntrainer {
 
+/**
+ * @brief Resolve symbol sym from libHandle as function pointer type T,
+ * logging (but not throwing) if it cannot be found.
+ */
 template <class T>
 static inline T resolveSymbol(void *libHandle, const char *sym) {
   T ptr = (T)pal::dynamicloading::dlSym(libHandle, sym);

--- a/nntrainer/qnn/jni/qnn_rpc_manager.h
+++ b/nntrainer/qnn/jni/qnn_rpc_manager.h
@@ -31,20 +31,55 @@ typedef Qnn_ErrorHandle_t (*QnnInterfaceGetProvidersFn_t)(
 /** @brief Manages QNN RPC shared memory allocation via libcdsprpc. */
 class QNNRpcManager : public MemAllocator {
 public:
+  /**
+   * @brief     Constructor. Resolves libQnnHtp.so's QNN interface providers
+   * and validates that the shared RpcMem (libcdsprpc.so) loader succeeded.
+   */
   QNNRpcManager();
+
+  /**
+   * @brief     Destructor. Deregisters and frees every RPC buffer still
+   * tracked in ptrToFdAndMemHandleMap_.
+   */
   ~QNNRpcManager();
 
+  /**
+   * @copydoc MemAllocator::alloc(void **ptr, size_t size, size_t alignment)
+   */
   void alloc(void **ptr, size_t size, size_t alignment) override;
+
+  /**
+   * @copydoc MemAllocator::free(void *ptr)
+   */
   void free(void *ptr) override;
 
+  /**
+   * @copydoc MemAllocator::getName()
+   */
   std::string getName() override { return "qnn"; }
 
+  /**
+   * @brief Set the QNN interface/context to use for subsequent tensor
+   * registration calls.
+   */
   void setQnnInterfaceAndContext(void *context);
 
+  /**
+   * @brief Register ptr as shared RPC memory for a QNN tensor under the
+   * given context, mapping it to an ION fd and QNN mem handle.
+   */
   void registerQnnTensor(void *ptr, Qnn_Tensor_t &qnnTensor,
                          Qnn_ContextHandle_t &context);
+
+  /**
+   * @brief Deregister every RPC tensor mapping currently tracked.
+   */
   void deRegisterQnnTensor();
 
+  /**
+   * @brief If ptr was already registered under context, fill qnnTensor's mem
+   * handle from the cached mapping and return true.
+   */
   bool findMatchingPtr(void *ptr, Qnn_ContextHandle_t &context,
                        Qnn_Tensor_t &qnnTensor);
 

--- a/nntrainer/qnn/jni/qnn_timing.h
+++ b/nntrainer/qnn/jni/qnn_timing.h
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
+ * Copyright (C) 2026 Haehun Yang <haehun.yang@samsung.com>
+ *
  * @file    qnn_timing.h
+ * @date    10 Jul 2026
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Haehun Yang <haehun.yang@samsung.com>
+ * @bug     No known bugs except for NYI items
  * @brief   Lightweight wall-clock timing helpers for QNN initialization
  *          profiling. All elapsed times are logged in milliseconds under the
  *          "QNN-INIT" tag so they can be filtered with `logcat | grep QNN-INIT`
@@ -36,7 +42,8 @@
 namespace nntrainer {
 
 /**
- * @brief Elapsed milliseconds since @a since, as a long long for %lld logging.
+ * @brief Milliseconds elapsed since the given time point, as a long long for
+ * %lld logging.
  */
 inline long long
 qnn_ms_since(const std::chrono::steady_clock::time_point &since) {

--- a/nntrainer/qnn/jni/qnn_timing.h
+++ b/nntrainer/qnn/jni/qnn_timing.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file    qnn_timing.h
+ * @brief   Lightweight wall-clock timing helpers for QNN initialization
+ *          profiling. All elapsed times are logged in milliseconds under the
+ *          "QNN-INIT" tag so they can be filtered with `logcat | grep QNN-INIT`
+ *          (Android) or a grep on stderr (host).
+ *
+ *          Two ways to use it:
+ *            - QNN_TIME_SCOPE("label")      : RAII timer, logs on scope exit.
+ *            - QNN_TIME_SINCE("label", tp)  : logs (now - tp); use for calls
+ *                                             embedded in an if-condition where
+ *                                             a scope block is awkward.
+ *
+ *          steady_clock is used deliberately: it is monotonic and unaffected by
+ *          wall-clock adjustments, so it is the correct source for measuring
+ *          durations. Define QNN_TIMING_DISABLE to compile the timers out.
+ */
+#ifndef __QNN_TIMING_H__
+#define __QNN_TIMING_H__
+
+#include <chrono>
+#include <string>
+#include <utility>
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#define QNN_TIMING_LOG(...)                                                    \
+  __android_log_print(ANDROID_LOG_INFO, "QNN-INIT", __VA_ARGS__)
+#else
+#include <cstdio>
+#define QNN_TIMING_LOG(fmt, ...)                                               \
+  fprintf(stderr, "[QNN-INIT] " fmt "\n", ##__VA_ARGS__)
+#endif
+
+namespace nntrainer {
+
+/**
+ * @brief Elapsed milliseconds since @a since, as a long long for %lld logging.
+ */
+inline long long
+qnn_ms_since(const std::chrono::steady_clock::time_point &since) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+           std::chrono::steady_clock::now() - since)
+    .count();
+}
+
+/**
+ * @brief RAII timer: captures the current time on construction and logs the
+ * elapsed duration under the "QNN-INIT" tag when it goes out of scope.
+ */
+class QnnScopedTimer {
+public:
+  explicit QnnScopedTimer(std::string label) :
+    label_(std::move(label)), start_(std::chrono::steady_clock::now()) {}
+  ~QnnScopedTimer() {
+    QNN_TIMING_LOG("%s: %lld ms", label_.c_str(), qnn_ms_since(start_));
+  }
+  QnnScopedTimer(const QnnScopedTimer &) = delete;
+  QnnScopedTimer &operator=(const QnnScopedTimer &) = delete;
+
+private:
+  std::string label_;
+  std::chrono::steady_clock::time_point start_;
+};
+
+} // namespace nntrainer
+
+#define QNN_TIMER_CONCAT_(a, b) a##b
+#define QNN_TIMER_CONCAT(a, b) QNN_TIMER_CONCAT_(a, b)
+
+#ifndef QNN_TIMING_DISABLE
+#define QNN_TIME_SCOPE(label)                                                  \
+  ::nntrainer::QnnScopedTimer QNN_TIMER_CONCAT(_qnn_scoped_timer_,             \
+                                               __LINE__)(label)
+#define QNN_TIME_SINCE(label, since)                                           \
+  QNN_TIMING_LOG("%s: %lld ms", label, ::nntrainer::qnn_ms_since(since))
+#else
+#define QNN_TIME_SCOPE(label) ((void)0)
+#define QNN_TIME_SINCE(label, since) ((void)0)
+#endif
+
+#endif /* __QNN_TIMING_H__ */

--- a/nntrainer/qnn/qnn_context.cpp
+++ b/nntrainer/qnn/qnn_context.cpp
@@ -48,6 +48,9 @@ namespace nntrainer {
 
 static std::string g_default_backend_ext_config_path;
 
+/**
+ * @brief Strip trailing '/' characters from a path, keeping a lone "/".
+ */
 static std::string trim_trailing_slashes(std::string path) {
   while (path.size() > 1 && path.back() == '/') {
     path.pop_back();
@@ -55,10 +58,18 @@ static std::string trim_trailing_slashes(std::string path) {
   return path;
 }
 
+/**
+ * @brief True if path is a POSIX absolute path (starts with '/').
+ */
 static bool is_absolute_path(const std::string &path) {
   return !path.empty() && path[0] == '/';
 }
 
+/**
+ * @brief Resolve the QuickDotAI base directory: the QUICK_DOT_AI_BASE_DIR
+ * env override if set, else the current working directory, else a hardcoded
+ * fallback path.
+ */
 static std::string resolve_quick_dot_ai_base_dir() {
   const char *override_base_dir = std::getenv("QUICK_DOT_AI_BASE_DIR");
   if (override_base_dir != nullptr && override_base_dir[0] != '\0') {
@@ -82,6 +93,10 @@ static std::string resolve_quick_dot_ai_base_dir() {
   return fallback;
 }
 
+/**
+ * @brief Resolve a possibly-relative backend extension config path against
+ * the QuickDotAI base directory; absolute or empty paths are returned as-is.
+ */
 static std::string
 resolve_backend_extensions_config_value(const std::string &path) {
   if (path.empty() || is_absolute_path(path)) {
@@ -90,6 +105,11 @@ resolve_backend_extensions_config_value(const std::string &path) {
   return resolve_quick_dot_ai_base_dir() + "/" + path;
 }
 
+/**
+ * @brief Resolve the backend extensions config file path: the
+ * QUICK_DOT_AI_QNN_BACKEND_EXT_CONFIG_PATH env override if set, else the
+ * default file name under the QuickDotAI base directory.
+ */
 static std::string resolve_backend_extensions_config_path() {
   const char *override_config_path =
     std::getenv("QUICK_DOT_AI_QNN_BACKEND_EXT_CONFIG_PATH");

--- a/nntrainer/qnn/qnn_context.cpp
+++ b/nntrainer/qnn/qnn_context.cpp
@@ -23,6 +23,7 @@
 #include "BackendExtensions.hpp"
 
 #include "qnn_context.h"
+#include "qnn_timing.h"
 #include <QNNGraph.h>
 #include <cstdlib>
 #include <iostream>
@@ -145,6 +146,7 @@ void QNNContext::initialize() noexcept {
 
 int QNNContext::init() {
   LOGD("init: START");
+  QNN_TIME_SCOPE("QNNContext::init (backend bring-up, total)");
   std::cout << "qnncontext::init called" << std::endl;
   if (!log::initializeLogging()) {
     LOGE("init: Unable to initialize logging!");
@@ -180,9 +182,11 @@ int QNNContext::init() {
   }
   LOGD("init: calling dynamicloadutil::getQnnFunctionPointers");
 
+  auto _qnn_t = std::chrono::steady_clock::now();
   auto statusCode = dynamicloadutil::getQnnFunctionPointers(
     backEndPath, "", &qnn_data->m_qnnFunctionPointers,
     &qnn_data->m_backendLibraryHandle, false, nullptr);
+  QNN_TIME_SINCE("init: getQnnFunctionPointers (dlopen libQnnHtp.so)", _qnn_t);
   LOGD("init: getQnnFunctionPointers returned status=%d", (int)statusCode);
   if (dynamicloadutil::StatusCode::SUCCESS != statusCode) {
     if (dynamicloadutil::StatusCode::FAIL_LOAD_BACKEND == statusCode) {
@@ -199,8 +203,11 @@ int QNNContext::init() {
   }
 
   LOGD("init: calling getQnnSystemFunctionPointers");
+  _qnn_t = std::chrono::steady_clock::now();
   statusCode = qnn::tools::dynamicloadutil::getQnnSystemFunctionPointers(
     systemLibraryPath, &qnn_data->m_qnnFunctionPointers);
+  QNN_TIME_SINCE("init: getQnnSystemFunctionPointers (dlopen libQnnSystem.so)",
+                 _qnn_t);
   LOGD("init: getQnnSystemFunctionPointers returned status=%d",
        (int)statusCode);
   if (qnn::tools::dynamicloadutil::StatusCode::SUCCESS != statusCode) {
@@ -238,9 +245,12 @@ int QNNContext::init() {
   backend_extensions_config.configFilePath = config_path;
   backend_extensions_config.sharedLibraryPath = "libQnnHtpNetRunExtensions.so";
 
+  _qnn_t = std::chrono::steady_clock::now();
   BackendExtensions *backend_extensions = new BackendExtensions(
     backend_extensions_config, qnn_data->m_backendLibraryHandle, false, nullptr,
     QNN_LOG_LEVEL_ERROR);
+  QNN_TIME_SINCE("init: BackendExtensions ctor (config + dlopen extensions)",
+                 _qnn_t);
   qnn_data->m_backendExtensions = backend_extensions;
   LOGD("init: Backend extensions created");
 
@@ -270,10 +280,12 @@ int QNNContext::init() {
   }
 
   LOGD("init: Calling backendCreate");
+  _qnn_t = std::chrono::steady_clock::now();
   auto qnnStatus = qnn_data->m_qnnFunctionPointers.qnnInterface.backendCreate(
     qnn_data->m_logHandle,
     (const QnnBackend_Config_t **)qnn_data->m_backendConfig,
     &qnn_data->m_backendHandle);
+  QNN_TIME_SINCE("init: backendCreate", _qnn_t);
   LOGD("init: backendCreate returned status=%lu", qnnStatus);
   if (QNN_BACKEND_NO_ERROR != qnnStatus) {
     LOGE("init: Could not initialize backend, error=%d",
@@ -307,7 +319,9 @@ int QNNContext::init() {
   LOGD("init: isDevicePropertySupported returned %d",
        (int)devicePropertySupportStatus);
   if (StatusCode::FAILURE != devicePropertySupportStatus) {
+    _qnn_t = std::chrono::steady_clock::now();
     auto createDeviceStatus = this->createDevice();
+    QNN_TIME_SINCE("init: createDevice (HTP device power-up)", _qnn_t);
     LOGD("init: createDevice returned %d", (int)createDeviceStatus);
     if (StatusCode::SUCCESS != createDeviceStatus) {
       LOGE("init: Device Creation failure");
@@ -324,11 +338,13 @@ int QNNContext::init() {
   }
 
   LOGD("init: Registering Op Packages");
+  _qnn_t = std::chrono::steady_clock::now();
   if (StatusCode::SUCCESS != this->registerOpPackages()) {
     LOGE("init: Register Op Packages failure");
     ml_loge("Register Op Packages failure");
     return -1;
   }
+  QNN_TIME_SINCE("init: registerOpPackages", _qnn_t);
 
   LOGD("init: END (returning 0)");
   return 0;

--- a/nntrainer/qnn/qnn_context.h
+++ b/nntrainer/qnn/qnn_context.h
@@ -83,6 +83,10 @@ public:
    */
   QNNContext() : Context(std::make_shared<QNNBackendVar>()) {}
 
+  /**
+   * @brief   Destructor. Frees all cached QNN contexts, tears down the QNN
+   * backend, and closes the backend library handle.
+   */
   ~QNNContext() {
     auto qnn_data = getQnnData();
     // Free all remaining QNN contexts in ct_map before releasing backend
@@ -103,6 +107,9 @@ public:
     }
   }
 
+  /**
+   * @copydoc Context::init()
+   */
   int init() override;
 
   /**
@@ -239,20 +246,37 @@ public:
    */
   static void setDefaultBackendExtConfigPath(const std::string &path);
 
+  /**
+   * @brief   Set the backend extension config path for this instance,
+   * overriding the process-wide default set via
+   * setDefaultBackendExtConfigPath().
+   */
   void setBackendExtConfigPath(const std::string &path) {
     m_backendExtConfigPath = path;
   }
 
+  /**
+   * @brief   Set the Mem Allocator object
+   *
+   * @param mem Memory allocator object
+   */
   void setMemAllocator(std::shared_ptr<QNNRpcManager> mem) {
     getContextData()->setMemAllocator(mem);
   }
 
+  /**
+   * @brief   Get the shared QNN backend state (device/context/profiling
+   * handles) associated with this context.
+   */
   std::shared_ptr<QNNVar> getQnnData() {
     std::shared_ptr<QNNBackendVar> d =
       std::static_pointer_cast<QNNBackendVar>(this->getContextData());
     return d->getVar();
   }
 
+  /**
+   * @copydoc Context::load(const std::string &file_path)
+   */
   int load(const std::string &file_path) override {
 
     StatusCode ret = getQnnData()->makeContext(file_path);
@@ -260,6 +284,9 @@ public:
   }
 
 private:
+  /**
+   * @brief   Overriden initialization function
+   */
   void initialize() noexcept override;
 
   // flag to check predefined qnn context is resistered
@@ -290,6 +317,10 @@ private:
 
   bool m_isContextCreated;
 
+  /**
+   * @brief Free a graphs-info array and everything it owns (graph names,
+   * input/output tensors), then null out the caller's pointer.
+   */
   static StatusCode
   QnnModel_freeGraphsInfo(qnn_wrapper_api::GraphInfoPtr_t **graphsInfo,
                           uint32_t numGraphsInfo) {
@@ -313,18 +344,39 @@ private:
     return StatusCode::SUCCESS;
   }
 
+  /**
+   * @brief Check whether the backend supports the device property group.
+   */
   StatusCode isDevicePropertySupported();
 
+  /**
+   * @brief Create the QNN device handle used for backend execution.
+   */
   StatusCode createDevice();
 
+  /**
+   * @brief Map a QNN error code to the corresponding StatusCode.
+   */
   StatusCode verifyFailReturnStatus(Qnn_ErrorHandle_t errCode);
 
+  /**
+   * @brief Create the QNN profile handle if profiling is enabled.
+   */
   StatusCode initializeProfiling();
 
+  /**
+   * @brief Register each configured custom op package with the backend.
+   */
   StatusCode registerOpPackages();
 
+  /**
+   * @brief Release device resources acquired during init().
+   */
   void release();
 
+  /**
+   * @brief Free the QNN device handle created by createDevice().
+   */
   StatusCode freeDevice();
 };
 


### PR DESCRIPTION
## Dependency of the PR
Not a depencdency, but the results were tested with #4062 applied.

## Commits to be reviewed in this PR


<details><summary>feat(qnn): thread-safe context map for async load + init timing</summary><br />

Guard QNNVar's context map with ct_mutex across findContext/makeContext/ freeContext so the QNN context binary can be deserialized on a background thread without racing the first forward. makeContext holds the lock for the whole load and is keyed by bin path, so a racing forward blocks until the load finishes instead of double-loading; ct_map is a std::map, so references stay valid across other inserts.

Add lightweight steady_clock timing (qnn_timing.h; compile out with QNN_TIMING_DISABLE) under the "QNN-INIT" log tag around backend bring-up (qnn_context.cpp), the context binary load (qnn_context_var.h), and the first forward's context-acquire wait (QNNGraph) to profile QNN init cost.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: haehun.yang <haehun.yang@samsung.com>

</details>

<details><summary>docs(qnn): add doxygen comments to nntrainer/qnn</summary><br />

Document previously-undocumented classes, methods, and helper functions
across qnn_context.{h,cpp}, jni/QNNGraph.{h,cpp}, jni/qnn_properties.h,
jni/qnn_rpc_manager.{h,cpp}, jni/qnn_context_var.h, jni/qnn_timing.h, and
jni/iotensor_wrapper.hpp

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: haehun.yang <haehun.yang@samsung.com>

</details>

### Summary

- feat(qnn): thread-safe context map for async load + init timing
- docs(qnn): add doxygen comments to nntrainer/qnn

Signed-off-by: haehun.yang <haehun.yang@samsung.com>