### PR TITLE
causallm: remove incremental_forwarding, manage KV cache position via cache_index/KVCacheManager

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -522,6 +522,15 @@ void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
     weight_decay, "Embedding", true);
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, embedding_props);
   LayerImpl::setProperty(remain_props);

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -149,6 +149,18 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only the output tensor's height (sequence length) is updated;
+   * the input tensor keeps the raw token-id shape produced by InputLayer,
+   * which is intentionally excluded from this broadcast (see
+   * NetworkGraph::resetInputDimension).
+   */
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,

--- a/Applications/CausalLM/layers/embedding_normalize_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.cpp
@@ -62,6 +62,14 @@ void EmbeddingNormalizeLayer::incremental_forwarding(
   forwarding(context, training);
 }
 
+void EmbeddingNormalizeLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  // No-op: this layer always sits after Pooling, so its input/output is
+  // already the fixed [batch, 1, 1, dim] pooled vector and never varies with
+  // sequence length.
+}
+
 void EmbeddingNormalizeLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/embedding_normalize_layer.h
+++ b/Applications/CausalLM/layers/embedding_normalize_layer.h
@@ -62,6 +62,14 @@ public:
                               bool training) override;
 
   /**
+   * @copydoc   Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc   Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(nntrainer::RunLayerContext &context) override;

--- a/Applications/CausalLM/layers/embedding_pooling_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.cpp
@@ -152,6 +152,19 @@ void EmbeddingPoolingLayer::incremental_forwarding(
   }
 }
 
+void EmbeddingPoolingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  // Input height is the current sequence length; output stays fixed at
+  // height 1 (pooled to a single vector per finalize()), so only the input
+  // needs to track the new step size.
+  unsigned int height = input_dimensions[0].height();
+
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+}
+
 void EmbeddingPoolingLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/embedding_pooling_layer.h
+++ b/Applications/CausalLM/layers/embedding_pooling_layer.h
@@ -154,6 +154,14 @@ public:
                               bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(nntrainer::RunLayerContext &context) override;

--- a/Applications/CausalLM/layers/logit_softcapping.cpp
+++ b/Applications/CausalLM/layers/logit_softcapping.cpp
@@ -113,8 +113,16 @@ void LogitSoftCappingLayer::applyOnRange(nntrainer::RunLayerContext &context,
 void LogitSoftCappingLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // This layer sits on lm_head's output, whose height is fixed at 1
+  // regardless of prompt length; propagate that actual height instead of
+  // the broadcast sequence length.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  output_dim.height(input_dim.height());
+
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void LogitSoftCappingLayer::calcDerivative(

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -1,5 +1,6 @@
 causallm_layer_inc_abs = [meson.current_source_dir()]
-causallm_layer_inc = [include_directories('.')]
+# '..' pulls in Applications/CausalLM/kv_cache_manager.h, needed by mha_core.h
+causallm_layer_inc = [include_directories('.', '..')]
 
 causallm_rms_norm_src_abs = [meson.current_source_dir() / 'rms_norm.cpp']
 causallm_swiglu_src_abs = [meson.current_source_dir() / 'swiglu.cpp']

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -307,8 +307,14 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
   unsigned int step_size = (incremental_step_size > 0)
                              ? incremental_step_size
                              : (unsigned int)query.height();
-  unsigned int from = cache_index;
-  unsigned int to = cache_index + step_size;
+  unsigned int from =
+    kv_cache_manager_ ? kv_cache_manager_->getPosition() : cache_index;
+  unsigned int to = from + step_size;
+  // one_batch_incremental_forwarding() below indexes the cache through the
+  // cache_index member; keep it in sync with the resolved absolute position
+  // for this call, whether it came from the bound manager or the local
+  // fallback.
+  cache_index = from;
 
   auto get_step_dim = [step_size](const ml::train::TensorDim &dim) {
     auto step_dim = dim;
@@ -395,7 +401,14 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
     }
   }
 
-  cache_index += step_size;
+  // When a KVCacheManager is bound, it owns the write position: the host
+  // advances it exactly once per step after the full graph forward pass
+  // completes (see CausalLM::advanceKVCachePosition), since multiple
+  // mha_core layers (one per attention block) all forward within a single
+  // step. Self-advancing here would over-advance the shared position.
+  if (!kv_cache_manager_) {
+    cache_index += step_size;
+  }
 }
 
 /**
@@ -406,12 +419,22 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
 void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                           unsigned int _from, unsigned int _to,
                                           bool training) {
-  // External KV cache path: from/to are interpreted as the absolute write
-  // position; route through forwarding() which reads cache_key/cache_value
-  // from input slots 3/4. forwarding() advances cache_index internally.
+  // External KV cache path: route through forwarding(), which reads
+  // cache_key/cache_value from input slots 3/4. The step size (width of this
+  // call) still comes from _to - _from: some callers (e.g. test harnesses)
+  // invoke incremental_forwarding() without resizing the input tensors via
+  // resetInputDimension() first, so query.height() alone isn't a reliable
+  // stand-in for the step width. The *absolute* write position is what moves
+  // to the KVCacheManager: when bound, it is the single source of truth
+  // instead of the _from plumbed through here, since multiple mha_core
+  // layers (one per attention block) must agree on one shared position.
+  // Without a bound manager (back-compat / no host wiring), fall back to the
+  // legacy contract of taking the absolute position from _from directly.
   if (use_external_cache) {
-    cache_index = _from;
     incremental_step_size = _to - _from;
+    if (!kv_cache_manager_) {
+      cache_index = _from;
+    }
     forwarding(context, training);
     incremental_step_size = 0;
     return;
@@ -1575,6 +1598,17 @@ void MHACoreLayer::setProperty(const std::vector<std::string> &values) {
     if (nntrainer::getKeyValue(value, key, parsed_value) == ML_ERROR_NONE &&
         key == "cache_index") {
       setCacheIndex(static_cast<unsigned int>(std::stoul(parsed_value)));
+    } else if (nntrainer::getKeyValue(value, key, parsed_value) ==
+                 ML_ERROR_NONE &&
+               key == "kv_cache_manager_addr") {
+      // ml::train::Layer only exposes setProperty()/getProperty() to the
+      // host, so the host binds this layer to its shared KVCacheManager by
+      // passing the manager's address once (see
+      // CausalLM::allocateAndBindKVCache()) rather than through a typed
+      // setter, which isn't reachable from outside this layer's own type.
+      auto addr =
+        static_cast<uintptr_t>(std::stoull(parsed_value, nullptr, 16));
+      setKVCacheManager(reinterpret_cast<KVCacheManager *>(addr));
     } else {
       props.push_back(value);
     }

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1534,13 +1534,26 @@ void MHACoreLayer::updateTensorsByInputDimensions(
   std::vector<nntrainer::TensorDim> input_dimensions) {
   // cache_key/cache_value keep their fixed MAX_SEQ_LEN-based size from
   // finalize(); resizing them here would break decode-phase from/to windows.
-  ml::train::TensorDim kv_dim = input_dimensions[0];
-  kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
+  // QUERY/KEY/VALUE/OUTPUT widths are also preserved from finalize(), since
+  // hidden_size / (num_heads_Q/num_heads_KV) != head_dim whenever
+  // head_dim != hidden_size / num_heads_Q (e.g. Qwen3). Only height changes.
+  unsigned int height = input_dimensions[0].height();
 
-  context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
-  context.updateInput(INOUT_INDEX::KEY, kv_dim);
-  context.updateInput(INOUT_INDEX::VALUE, kv_dim);
-  context.updateOutput(0, input_dimensions[0]);
+  ml::train::TensorDim query_dim =
+    context.getInput(INOUT_INDEX::QUERY).getDim();
+  query_dim.height(height);
+  ml::train::TensorDim key_dim = context.getInput(INOUT_INDEX::KEY).getDim();
+  key_dim.height(height);
+  ml::train::TensorDim value_dim =
+    context.getInput(INOUT_INDEX::VALUE).getDim();
+  value_dim.height(height);
+  ml::train::TensorDim output_dim = context.getOutput(0).getDim();
+  output_dim.height(height);
+
+  context.updateInput(INOUT_INDEX::QUERY, query_dim);
+  context.updateInput(INOUT_INDEX::KEY, key_dim);
+  context.updateInput(INOUT_INDEX::VALUE, value_dim);
+  context.updateOutput(0, output_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -269,14 +269,17 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
 /**
  * @note In external KV cache mode (use_external_cache == true), this
  *       implements the inference forward pass using cache tensors supplied
- *       as input[3] (cache_key) and input[4] (cache_value). The host (e.g.
- *       KVCacheManager via setExternalTensors) is responsible for owning
- *       these buffers and for calling setCacheIndex() before each step to
- *       set the write position. After this call cache_index is advanced by
- *       input.height().
+ *       as input[3] (cache_key) and input[4] (cache_value). The step width
+ *       comes from the query tensor's own height, and the absolute write
+ *       position from the bound KVCacheManager (see setKVCacheManager()) when
+ *       present, or the local cache_index fallback otherwise. Callers must
+ *       keep the query/key/value tensors' height in sync with the true token
+ *       count via resetInputDimension() / updateTensorsByInputDimensions()
+ *       before each prefill/decode phase change.
  *
- *       In legacy 3/4-input mode (use_external_cache == false) training is
- *       NYI and incremental_forwarding() is the inference path.
+ *       In legacy 3/4-input mode (use_external_cache == false), this is a
+ *       single-shot, non-autoregressive path (e.g. BERT/TimmViT-style
+ *       encoders) that always starts at position 0; training is NYI.
  *
  *       Input layout for external cache mode:
  *         input[0] = Q   (B, 1, step_size, num_heads_Q  * head_dim)
@@ -287,33 +290,57 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
  */
 void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
                               bool training) {
-  if (!use_external_cache) {
-    return;
-  }
-
   nntrainer::Tensor &query = context.getInput(INOUT_INDEX::QUERY);
   nntrainer::Tensor &key = context.getInput(INOUT_INDEX::KEY);
   nntrainer::Tensor &value = context.getInput(INOUT_INDEX::VALUE);
   nntrainer::Tensor &output = context.getOutput(INOUT_INDEX::OUTPUT);
-
-  nntrainer::Tensor &cache_key = context.getInput(3);
-  nntrainer::Tensor &cache_value = context.getInput(4);
 
   nntrainer::Tensor sink;
   if (use_sink) {
     sink = context.getWeight(sink_idx);
   }
 
-  unsigned int step_size = (incremental_step_size > 0)
-                             ? incremental_step_size
-                             : (unsigned int)query.height();
-  unsigned int from =
-    kv_cache_manager_ ? kv_cache_manager_->getPosition() : cache_index;
-  unsigned int to = from + step_size;
+  // Step width always comes from the query tensor's own height. Callers are
+  // responsible for keeping it accurate via resetInputDimension() /
+  // updateTensorsByInputDimensions() before each prefill/decode phase change
+  // (see CausalLM::run() and the CausalLM test harness).
+  unsigned int step_size = (unsigned int)query.height();
+  unsigned int from;
+  unsigned int to;
+  nntrainer::Tensor *cache_key_ptr;
+  nntrainer::Tensor *cache_value_ptr;
+
+  if (use_external_cache) {
+    // Absolute write position: when a KVCacheManager is bound, it is the
+    // single source of truth (multiple mha_core layers, one per attention
+    // block, must agree on one shared position); otherwise fall back to the
+    // locally-tracked cache_index (back-compat / no host wiring, e.g.
+    // SentenceTransformer's single-shot use at position 0).
+    from = kv_cache_manager_ ? kv_cache_manager_->getPosition() : cache_index;
+    to = from + step_size;
+    cache_key_ptr = &context.getInput(3);
+    cache_value_ptr = &context.getInput(4);
+  } else {
+    // Legacy internal-cache path: single-shot, non-autoregressive attention
+    // (e.g. BERT/TimmViT-style encoders) that always processes the full
+    // input sequence starting at position 0 in one call.
+    unsigned int max_timestep =
+      std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+    from = 0;
+    to = step_size;
+    if (to >= max_timestep) {
+      throw std::invalid_argument(
+        "to shouldn't greater than max_timestep for initial forwarding");
+    }
+    cache_key_ptr = &context.getTensor(tensor_idx[AttentionParams::cache_key]);
+    cache_value_ptr =
+      &context.getTensor(tensor_idx[AttentionParams::cache_value]);
+  }
+  nntrainer::Tensor &cache_key = *cache_key_ptr;
+  nntrainer::Tensor &cache_value = *cache_value_ptr;
   // one_batch_incremental_forwarding() below indexes the cache through the
   // cache_index member; keep it in sync with the resolved absolute position
-  // for this call, whether it came from the bound manager or the local
-  // fallback.
+  // for this call.
   cache_index = from;
 
   auto get_step_dim = [step_size](const ml::train::TensorDim &dim) {
@@ -406,184 +433,11 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
   // completes (see CausalLM::advanceKVCachePosition), since multiple
   // mha_core layers (one per attention block) all forward within a single
   // step. Self-advancing here would over-advance the shared position.
-  if (!kv_cache_manager_) {
+  // The internal-cache path is single-shot (always starts back at position 0
+  // on the next call), so it never advances either.
+  if (use_external_cache && !kv_cache_manager_) {
     cache_index += step_size;
   }
-}
-
-/**
- * @note This incremental_forwarding method is invoked for inference mode.
- *       Please note that Transformer Decoder's MHA takes only one sequence at a
- * step. Incremental forwarding function is used for this.
- */
-void MHACoreLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
-                                          unsigned int _from, unsigned int _to,
-                                          bool training) {
-  // External KV cache path: route through forwarding(), which reads
-  // cache_key/cache_value from input slots 3/4. The step size (width of this
-  // call) still comes from _to - _from: some callers (e.g. test harnesses)
-  // invoke incremental_forwarding() without resizing the input tensors via
-  // resetInputDimension() first, so query.height() alone isn't a reliable
-  // stand-in for the step width. The *absolute* write position is what moves
-  // to the KVCacheManager: when bound, it is the single source of truth
-  // instead of the _from plumbed through here, since multiple mha_core
-  // layers (one per attention block) must agree on one shared position.
-  // Without a bound manager (back-compat / no host wiring), fall back to the
-  // legacy contract of taking the absolute position from _from directly.
-  if (use_external_cache) {
-    incremental_step_size = _to - _from;
-    if (!kv_cache_manager_) {
-      cache_index = _from;
-    }
-    forwarding(context, training);
-    incremental_step_size = 0;
-    return;
-  }
-
-  /// @todo replace step_size into input height
-  unsigned int step_size = _to - _from;
-
-  unsigned int max_timestep =
-    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
-
-  unsigned int from = _from;
-  unsigned int to = _to;
-
-  if (to >= max_timestep) {
-    // initial forwarding
-    if (!_from) {
-      throw std::invalid_argument(
-        "to shouldn't greater than max_timestep for initial forwarding");
-    } else {
-      throw std::runtime_error("NYI: cache shift is not available");
-      // exceeds the kv_cache size
-      // KV_cache is shifted!
-      cache_shift = true;
-      from = max_timestep - 1;
-      to = max_timestep;
-    }
-  }
-
-  // util fn to compute tensor dimension for one step.
-  auto get_step_dim = [step_size](const ml::train::TensorDim &dim) {
-    auto step_dim = dim;
-    step_dim.batch(1);
-    step_dim.height(step_size);
-    return step_dim;
-  };
-
-  /** incremental forwarding for each batch */
-  nntrainer::Tensor &query =
-    context.getInput(INOUT_INDEX::QUERY); // projected query
-  nntrainer::Tensor &key = context.getInput(INOUT_INDEX::KEY); // projected key
-  nntrainer::Tensor &value =
-    context.getInput(INOUT_INDEX::VALUE); // projected value
-  nntrainer::Tensor &output =
-    context.getOutput(INOUT_INDEX::OUTPUT); // output to be projected
-
-  nntrainer::Tensor &cache_key =
-    context.getTensor(tensor_idx[AttentionParams::cache_key]);
-  nntrainer::Tensor &cache_value =
-    context.getTensor(tensor_idx[AttentionParams::cache_value]);
-
-  nntrainer::Tensor sink;
-  if (use_sink) {
-    sink = context.getWeight(sink_idx);
-  }
-
-  ml::train::TensorDim query_dim =
-    query.getDim(); // (B, 1, seq_len, n_heads_Q * head_dim)
-  ml::train::TensorDim key_dim =
-    key.getDim(); // (B, 1, seq_len, n_heads_KV * head_dim)
-  ml::train::TensorDim value_dim =
-    value.getDim(); // (B, 1, seq_len, n_heads_KV * head_dim)
-  ml::train::TensorDim output_dim =
-    output.getDim(); // (B, 1, seq_len, n_heads_Q * head_dim)
-  ml::train::TensorDim cache_key_dim =
-    cache_key.getDim(); // (B, 1, max_timestep, n_heads_KV * head_dim)
-  ml::train::TensorDim cache_value_dim =
-    cache_value.getDim(); // (B, 1, max_timestep, n_heads_KV * head_dim)
-
-  ml::train::TensorDim query_step_dim =
-    get_step_dim(query_dim); // (1, 1, step_size, n_heads_Q * head_dim)
-  ml::train::TensorDim key_step_dim = get_step_dim(key_dim);
-  ml::train::TensorDim value_step_dim = get_step_dim(value_dim);
-  ml::train::TensorDim output_step_dim =
-    get_step_dim(output_dim); // (1, 1, step_size, n_heads_Q * head_dim)
-  ml::train::TensorDim cache_key_step_dim =
-    get_step_dim(cache_key_dim); // (1, 1, step_size, n_heads_KV * head_dim)
-
-  ml::train::TensorDim cache_value_step_dim =
-    get_step_dim(cache_value_dim); // (1, 1, step_size, n_heads_KV * head_dim)
-
-  unsigned int batch_size = query_dim.batch();
-  // do the incremental forwarding
-  for (unsigned int batch = 0; batch < batch_size; ++batch) {
-
-    // preparing step tensors
-    nntrainer::Tensor query_step = query.getSharedDataTensor(
-      query_step_dim, batch * query_dim.getFeatureLen(), true);
-    nntrainer::Tensor key_step = key.getSharedDataTensor(
-      key_step_dim, batch * key_dim.getFeatureLen(), true);
-    nntrainer::Tensor value_step = value.getSharedDataTensor(
-      value_step_dim, batch * value_dim.getFeatureLen(), true);
-    nntrainer::Tensor output_step = output.getSharedDataTensor(
-      output_step_dim, batch * output_dim.getFeatureLen(), true);
-
-    if (query_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
-#if ENABLE_FP16 && defined(__ANDROID__)
-      nntrainer::TensorDim Q_step_dim = query_step_dim;
-      nntrainer::TensorDim K_step_dim = key_step_dim;
-      nntrainer::TensorDim V_step_dim = value_step_dim;
-      nntrainer::TensorDim O_step_dim = output_step_dim;
-      Q_step_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-      K_step_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-      V_step_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-      O_step_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-
-      nntrainer::Tensor Q_step = nntrainer::Tensor(Q_step_dim, true);
-      nntrainer::Tensor K_step = nntrainer::Tensor(K_step_dim, true);
-      nntrainer::Tensor V_step = nntrainer::Tensor(V_step_dim, true);
-      nntrainer::Tensor O_step = nntrainer::Tensor(O_step_dim, true);
-
-      Q_step.copyData(query_step);
-      K_step.copyData(key_step);
-      V_step.copyData(value_step);
-      if (use_sink) {
-        one_batch_incremental_forwarding(
-          batch, _from, from, to, Q_step, K_step, V_step, O_step, cache_key,
-          cache_value, cache_key_dim, cache_key_step_dim, cache_value_dim,
-          cache_value_step_dim, sink);
-      } else {
-        one_batch_incremental_forwarding(batch, _from, from, to, Q_step, K_step,
-                                         V_step, O_step, cache_key, cache_value,
-                                         cache_key_dim, cache_key_step_dim,
-                                         cache_value_dim, cache_value_step_dim);
-      }
-      output_step.copyData(O_step);
-#else
-      if (use_sink) {
-        one_batch_incremental_forwarding(
-          batch, _from, from, to, query_step, key_step, value_step, output_step,
-          cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-          cache_value_dim, cache_value_step_dim, sink);
-      } else {
-        one_batch_incremental_forwarding(
-          batch, _from, from, to, query_step, key_step, value_step, output_step,
-          cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-          cache_value_dim, cache_value_step_dim);
-      }
-#endif
-    } else {
-      one_batch_incremental_forwarding(
-        batch, _from, from, to, query_step, key_step, value_step, output_step,
-        cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-        cache_value_dim, cache_value_step_dim);
-    }
-  }
-
-  // increase cache size
-  cache_index += step_size;
 }
 
 /**

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -396,35 +396,35 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
       V_step.copyData(value_step);
 
       if (use_sink) {
-        one_batch_incremental_forwarding(
-          batch, from, from, to, Q_step, K_step, V_step, O_step, cache_key,
-          cache_value, cache_key_dim, cache_key_step_dim, cache_value_dim,
-          cache_value_step_dim, sink);
+        one_batch_incremental_forwarding(batch, Q_step, K_step, V_step, O_step,
+                                         cache_key, cache_value, cache_key_dim,
+                                         cache_key_step_dim, cache_value_dim,
+                                         cache_value_step_dim, sink);
       } else {
-        one_batch_incremental_forwarding(batch, from, from, to, Q_step, K_step,
-                                         V_step, O_step, cache_key, cache_value,
-                                         cache_key_dim, cache_key_step_dim,
-                                         cache_value_dim, cache_value_step_dim);
+        one_batch_incremental_forwarding(batch, Q_step, K_step, V_step, O_step,
+                                         cache_key, cache_value, cache_key_dim,
+                                         cache_key_step_dim, cache_value_dim,
+                                         cache_value_step_dim);
       }
       output_step.copyData(O_step);
 #else
       if (use_sink) {
         one_batch_incremental_forwarding(
-          batch, from, from, to, query_step, key_step, value_step, output_step,
-          cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-          cache_value_dim, cache_value_step_dim, sink);
+          batch, query_step, key_step, value_step, output_step, cache_key,
+          cache_value, cache_key_dim, cache_key_step_dim, cache_value_dim,
+          cache_value_step_dim, sink);
       } else {
         one_batch_incremental_forwarding(
-          batch, from, from, to, query_step, key_step, value_step, output_step,
-          cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-          cache_value_dim, cache_value_step_dim);
+          batch, query_step, key_step, value_step, output_step, cache_key,
+          cache_value, cache_key_dim, cache_key_step_dim, cache_value_dim,
+          cache_value_step_dim);
       }
 #endif
     } else {
-      one_batch_incremental_forwarding(
-        batch, from, from, to, query_step, key_step, value_step, output_step,
-        cache_key, cache_value, cache_key_dim, cache_key_step_dim,
-        cache_value_dim, cache_value_step_dim);
+      one_batch_incremental_forwarding(batch, query_step, key_step, value_step,
+                                       output_step, cache_key, cache_value,
+                                       cache_key_dim, cache_key_step_dim,
+                                       cache_value_dim, cache_value_step_dim);
     }
   }
 
@@ -453,10 +453,11 @@ void MHACoreLayer::forwarding(nntrainer::RunLayerContext &context,
  */
 void MHACoreLayer::compute_kcaches(nntrainer::Tensor &in,
                                    nntrainer::Tensor &cache,
-                                   nntrainer::Tensor &out, unsigned int from,
-                                   size_t sequence_len, unsigned int num_head,
+                                   nntrainer::Tensor &out, size_t sequence_len,
+                                   unsigned int num_head,
                                    unsigned int group_size,
                                    unsigned int head_dim) {
+  unsigned int from = cache_index;
 
   // Dispatch based on data type (FP32 or FP16)
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
@@ -568,8 +569,7 @@ void MHACoreLayer::compute_kcaches(nntrainer::Tensor &in,
 }
 
 void MHACoreLayer::one_batch_incremental_forwarding(
-  const unsigned int batch, const unsigned int _from, const unsigned int from,
-  const unsigned int to, nntrainer::Tensor &query_step,
+  const unsigned int batch, nntrainer::Tensor &query_step,
   nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
   nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
   nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
@@ -614,8 +614,8 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 #endif
   }
 
-  unsigned int step_size = to - from;
-  bool is_prefill = !from || step_size > 1;
+  unsigned int step_size = (unsigned int)query_step.height();
+  bool is_prefill = !cache_index || step_size > 1;
   if (skip_prefill && is_prefill)
     return;
 
@@ -648,60 +648,64 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 
   unsigned int gqa_size = num_heads_Q / num_heads_KV;
 
-  compute_kcaches(query_step, b_cached_key, out_, cache_from,
-                  cache_to - cache_from, num_heads_Q, gqa_size, head_dim);
+  compute_kcaches(query_step, b_cached_key, out_, cache_to - cache_from,
+                  num_heads_Q, gqa_size, head_dim);
 
-  softmax_triangle(out_, step_size, num_heads_Q, cache_from);
+  softmax_triangle(out_, step_size, num_heads_Q);
 
   compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
-                                cache_from, num_heads_KV, gqa_size, head_dim,
-                                cache_to);
+                                num_heads_KV, gqa_size, head_dim, step_size);
 }
 
 void MHACoreLayer::one_batch_incremental_forwarding(
-  const unsigned int batch, const unsigned int _from, const unsigned int from,
-  const unsigned int to, nntrainer::Tensor &query_step,
+  const unsigned int batch, nntrainer::Tensor &query_step,
   nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
   nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
   nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
   ml::train::TensorDim &cache_key_step_dim,
   ml::train::TensorDim &cache_value_dim,
   ml::train::TensorDim &cache_value_step_dim, nntrainer::Tensor &sink_step) {
-  /// @todo replace from, to into cache_index, input height
   /// @note currently, only gpt-oss uses this method
 
   /**
    *  cache_key
-   *  +--------+                        ->
-   *  |        |                        ->
-   *  |        |                        ->
-   *  |........| from                   ->
-   *  |........| to -> b_cache_key_step -> b_cached_key
+   *  +--------+                              ->
+   *  |        |                              ->
+   *  |        |                              ->
+   *  |........| cache_from                   ->
+   *  |........| cache_to -> b_cache_key_step -> b_cached_key
    *  |        |
    *  +--------+
    *
    */
 
+  unsigned int step_size = (unsigned int)query_step.height();
+  unsigned int cache_from = cache_index;
+  unsigned int cache_to = cache_from + step_size;
+
   /** 1. Load Input Tensors of this batch : b_ denotes a Tensor for this batch
    * **/
   nntrainer::Tensor b_cache_key_step = cache_key.getSharedDataTensor(
     cache_key_step_dim,
-    batch * cache_key_dim.getFeatureLen() + from * cache_key_dim.width(), true);
-  nntrainer::Tensor b_cache_value_step = cache_value.getSharedDataTensor(
-    cache_value_step_dim,
-    batch * cache_value_dim.getFeatureLen() + from * cache_value_dim.width(),
+    batch * cache_key_dim.getFeatureLen() + cache_from * cache_key_dim.width(),
     true);
+  nntrainer::Tensor b_cache_value_step =
+    cache_value.getSharedDataTensor(cache_value_step_dim,
+                                    batch * cache_value_dim.getFeatureLen() +
+                                      cache_from * cache_value_dim.width(),
+                                    true);
 
   if (use_rope) {
-    apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, _from, false);
+    apply_rotary_emb_tensor_v2(query_step, query_step, head_dim, cache_from,
+                               false);
   }
 
-  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, _from,
+  apply_rotary_emb_tensor_v2(key_step, b_cache_key_step, head_dim, cache_from,
                              !use_rope);
 
   if (query_step.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    apply_rotary_emb_tensor_v2(value_step, b_cache_value_step, head_dim, _from,
-                               true);
+    apply_rotary_emb_tensor_v2(value_step, b_cache_value_step, head_dim,
+                               cache_from, true);
   } else if (query_step.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
     b_cache_value_step.copyData(value_step);
@@ -712,31 +716,31 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 
   ml::train::TensorDim cached_key_dim = cache_key_dim;
   ml::train::TensorDim cached_value_dim = cache_value_dim;
-  cached_key_dim.height(to);
-  cached_value_dim.height(to);
+  cached_key_dim.height(cache_to);
+  cached_value_dim.height(cache_to);
 
   nntrainer::Tensor b_cached_key = cache_key.getSharedDataTensor(
     cached_key_dim, batch * cache_key_dim.getFeatureLen(), true);
   nntrainer::Tensor b_cached_value = cache_value.getSharedDataTensor(
     cached_value_dim, batch * cache_value_dim.getFeatureLen(), true);
 
-  nntrainer::Tensor out_(1, 1,
-                         is_causal ? (((to - from) == 1)
-                                        ? to
-                                        : calc_windowed_attn_index(to) -
-                                            calc_windowed_attn_index(from))
-                                   : ((to - from) * to),
-                         num_heads_Q, query_step.getTensorType());
+  nntrainer::Tensor out_(
+    1, 1,
+    is_causal ? ((step_size == 1) ? cache_to
+                                  : calc_windowed_attn_index(cache_to) -
+                                      calc_windowed_attn_index(cache_from))
+              : (step_size * cache_to),
+    num_heads_Q, query_step.getTensorType());
 
   unsigned int gqa_size = num_heads_Q / num_heads_KV;
 
-  compute_kcaches(query_step, b_cached_key, out_, _from, to - from, num_heads_Q,
+  compute_kcaches(query_step, b_cached_key, out_, step_size, num_heads_Q,
                   gqa_size, head_dim);
 
-  softmax_triangle(out_, to - from, num_heads_Q, from, sink_step);
+  softmax_triangle(out_, step_size, num_heads_Q, sink_step);
 
   compute_fp16vcache_transposed(out_, b_cached_value, attention_output_step,
-                                from, num_heads_KV, gqa_size, head_dim, to);
+                                num_heads_KV, gqa_size, head_dim, step_size);
 }
 
 /************************************************************** */
@@ -1073,7 +1077,8 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
 }
 
 void MHACoreLayer::softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
-                                    size_t num_head, unsigned int from) {
+                                    size_t num_head) {
+  unsigned int from = cache_index;
   if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP32) {
     float *qk_out_ = qk_out.getData<float>();
 
@@ -1172,8 +1177,9 @@ void MHACoreLayer::softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
 }
 
 void MHACoreLayer::softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
-                                    size_t num_head, unsigned int from,
+                                    size_t num_head,
                                     nntrainer::Tensor &sink_step) {
+  unsigned int from = cache_index;
   if (qk_out.getDataType() == ml::train::TensorDim::DataType::FP32) {
     float *qk_out_ = qk_out.getData<float>();
 
@@ -1279,7 +1285,9 @@ void MHACoreLayer::softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
 
 void MHACoreLayer::compute_fp16vcache_transposed(
   nntrainer::Tensor &in, nntrainer::Tensor &vcache, nntrainer::Tensor &output,
-  int from, int num_cache_head, int gqa_size, int head_dim, int to) {
+  int num_cache_head, int gqa_size, int head_dim, int step_size) {
+  int from = (int)cache_index;
+  int to = from + step_size;
 
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
     if ((to - from) != 1) {

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1532,33 +1532,15 @@ void MHACoreLayer::setBatch(nntrainer::RunLayerContext &context,
 void MHACoreLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  unsigned int height = input_dimensions[0].height();
-  unsigned int &max_timestep =
-    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
-  unsigned int &max_new_tokens =
-    std::get<props::MaxNewTokens>(mha_core_props).get();
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
-  max_timestep = height + max_new_tokens;
-
+  // cache_key/cache_value keep their fixed MAX_SEQ_LEN-based size from
+  // finalize(); resizing them here would break decode-phase from/to windows.
   ml::train::TensorDim kv_dim = input_dimensions[0];
   kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
-
-  ml::train::TensorDim kv_cache_dim = kv_dim;
-#ifdef ENABLE_FP16
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-#else
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
-#endif
-  kv_cache_dim.height(max_timestep);
 
   context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
   context.updateInput(INOUT_INDEX::KEY, kv_dim);
   context.updateInput(INOUT_INDEX::VALUE, kv_dim);
   context.updateOutput(0, input_dimensions[0]);
-
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -251,8 +251,7 @@ public:
                              bool training) override;
 
   void one_batch_incremental_forwarding(
-    const unsigned int batch, const unsigned int _from, const unsigned int from,
-    const unsigned int to, nntrainer::Tensor &query_step,
+    const unsigned int batch, nntrainer::Tensor &query_step,
     nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
     nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
     nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
@@ -261,8 +260,7 @@ public:
     ml::train::TensorDim &cache_value_step_dim);
 
   void one_batch_incremental_forwarding(
-    const unsigned int batch, const unsigned int _from, const unsigned int from,
-    const unsigned int to, nntrainer::Tensor &query_step,
+    const unsigned int batch, nntrainer::Tensor &query_step,
     nntrainer::Tensor &key_step, nntrainer::Tensor &value_step,
     nntrainer::Tensor &attention_output_step, nntrainer::Tensor &cache_key,
     nntrainer::Tensor &cache_value, ml::train::TensorDim &cache_key_dim,
@@ -504,15 +502,15 @@ private:
                bool process_all);
 
   void compute_kcaches(nntrainer::Tensor &in, nntrainer::Tensor &cache,
-                       nntrainer::Tensor &out, unsigned int from,
-                       size_t sequence_len, unsigned int num_heads,
-                       unsigned int group_size, unsigned int head_dim);
+                       nntrainer::Tensor &out, size_t sequence_len,
+                       unsigned int num_heads, unsigned int group_size,
+                       unsigned int head_dim);
+
+  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row,
+                        size_t num_heads);
 
   void softmax_triangle(nntrainer::Tensor &qk_out, size_t row, size_t num_heads,
-                        unsigned int from);
-
-  void softmax_triangle(nntrainer::Tensor &qk_out, size_t row, size_t num_heads,
-                        unsigned int from, nntrainer::Tensor &sink_step);
+                        nntrainer::Tensor &sink_step);
 
   void compute_vcaches(nntrainer::Tensor &in, nntrainer::Tensor &vcache,
                        nntrainer::Tensor &out, unsigned int from,
@@ -521,9 +519,9 @@ private:
 
   void compute_fp16vcache_transposed(nntrainer::Tensor &in,
                                      nntrainer::Tensor &vcache,
-                                     nntrainer::Tensor &output, int from,
+                                     nntrainer::Tensor &output,
                                      int num_cache_head, int gqa_size,
-                                     int head_dim, int to);
+                                     int head_dim, int step_size);
 
   /************** END OF  ROTARY EMBEDDING *************/
 

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -46,6 +46,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <kv_cache_manager.h>
+
 namespace causallm {
 
 namespace props {
@@ -322,15 +324,33 @@ public:
 
   /**
    * @brief Set the cache index for external cache mode.
-   *        Must be called before forwarding() when use_external_cache is true.
+   *        Only used as a fallback when no KVCacheManager is bound (see
+   *        setKVCacheManager()); ignored otherwise since the manager becomes
+   *        the single source of truth for the write position.
    * @param[in] idx current write position in the KV cache
    */
   WIN_EXPORT void setCacheIndex(unsigned int idx) { cache_index = idx; }
 
   /**
-   * @brief Get the current cache index
+   * @brief Get the current cache index (delegates to the bound
+   *        KVCacheManager when present).
    */
-  WIN_EXPORT unsigned int getCacheIndex() const { return cache_index; }
+  WIN_EXPORT unsigned int getCacheIndex() const {
+    return kv_cache_manager_ ? kv_cache_manager_->getPosition() : cache_index;
+  }
+
+  /**
+   * @brief Bind the shared KVCacheManager that owns the absolute write
+   *        position for this (and every other) mha_core layer. Once bound,
+   *        this layer reads its write position from the manager instead of
+   *        tracking it locally, and no longer self-advances; the host is
+   *        responsible for advancing the manager's position exactly once per
+   *        step after the full graph forward pass completes.
+   * @param[in] manager pointer to the host-owned KVCacheManager (not owned)
+   */
+  WIN_EXPORT void setKVCacheManager(KVCacheManager *manager) {
+    kv_cache_manager_ = manager;
+  }
 
   inline static const std::string type = "mha_core";
 
@@ -352,7 +372,16 @@ private:
   nntrainer::ActiFunc sm;
 
   float epsilon;            /** to avoid overflow */
-  unsigned int cache_index; /** idx of kv cache */
+  unsigned int cache_index; /** idx of kv cache; fallback when
+                                kv_cache_manager_ is not bound */
+
+  /**
+   * @brief Shared KV cache manager owning the absolute write position across
+   *        all mha_core layers. Not owned by this layer. When bound, this
+   *        layer treats it as the single source of truth for the current
+   *        cache position instead of tracking cache_index itself.
+   */
+  KVCacheManager *kv_cache_manager_ = nullptr;
 
   /**
    * @brief Whether to use externally provided cache tensors

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -15,10 +15,10 @@
  *         in a layer, this layer is attached after Q / K / V
  *         fully connected layer to post-process them
  *         including KV-Cache.
- *         For inference, incremental_forwarding is called,
- *         which takes inputs of seq_len = 1 via `from` / `to` param.
- *         For training, forwarding is called,
- *         which takes all input seqences at once.
+ *         forwarding() handles both inference (external KV cache,
+ *         incrementally stepping over the query tensor's own height) and the
+ *         legacy internal-cache path (single-shot, non-autoregressive
+ *         encoder attention).
  */
 
 #ifndef __MHA_CORE_H__
@@ -269,12 +269,6 @@ public:
     ml::train::TensorDim &cache_key_step_dim,
     ml::train::TensorDim &cache_value_dim,
     ml::train::TensorDim &cache_value_step_dim, nntrainer::Tensor &sink_step);
-  /**
-   * @copydoc Layer::calcDerivative(RunLayerContext &context)
-   */
-  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
-                                         unsigned int from, unsigned int to,
-                                         bool training) override;
 
   /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
@@ -442,9 +436,6 @@ private:
   float scale = 1.0f;
   float rope_partial_rotary_factor = 1.0f;
   unsigned int original_max_position_embeddings = 4096;
-
-  /** set by incremental_forwarding, used by forwarding */
-  unsigned int incremental_step_size = 0;
 
   /****************** ROTARY EMBEDDING *****************/
   /**

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -146,8 +146,17 @@ void ReshapedRMSNormLayer::incremental_forwarding(
 void ReshapedRMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width (num_heads * head_dim) is preserved from
+  // finalize(), since it need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -125,8 +125,17 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 void RMSNormLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width is preserved from finalize(), since it
+  // need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/scalar_multiply.cpp
+++ b/Applications/CausalLM/layers/scalar_multiply.cpp
@@ -118,8 +118,17 @@ void ScalarMultiplyLayer::incremental_forwarding(
 void ScalarMultiplyLayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  // Only height is updated; width is preserved from finalize(), since it
+  // need not match the broadcast hidden_size width.
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+
+  input_dim.height(input_dimensions[0].height());
+  output_dim.height(input_dimensions[0].height());
+
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
 }
 
 void ScalarMultiplyLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -166,6 +166,19 @@ void SharedFullyConnectedLayer::incremental_forwarding(
   }
 }
 
+void SharedFullyConnectedLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  nntrainer::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void SharedFullyConnectedLayer::calcDerivative(
   nntrainer::RunLayerContext &context) {
   throw nntrainer::exception::not_supported(

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -129,6 +129,14 @@ public:
   void setProperty(const std::vector<std::string> &values) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override {

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -426,10 +426,12 @@ void TieWordEmbedding::updateTensorsByInputDimensions(
 
   if (mode_ == mode::embedding) {
     in_dim.width(height);
+    out_dim.height(height);
   } else {
+    // lm_head mode: output is always the last-token logits (height == 1,
+    // fixed in finalize_lmhead()); only the input sequence length changes.
     in_dim.height(height);
   }
-  out_dim.height(height);
 
   context.updateInput(SINGLE_INOUT_IDX, in_dim);
   context.updateOutput(SINGLE_INOUT_IDX, out_dim);

--- a/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
+++ b/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
@@ -102,6 +102,31 @@ nntrainer::TensorDim makeInputDim(nntrainer::TensorDim::DataType dtype,
 
 } // namespace
 
+TEST(CausalLmEmbeddingSidecarLut,
+     updateTensorsByInputDimensionsOnlyChangesOutputHeight) {
+  causallm::EmbeddingLayer layer;
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {nntrainer::Var_Grad(
+    makeInputDim(nntrainer::TensorDim::DataType::FP32, 4),
+    nntrainer::Initializer::NONE, true, false, "embedding_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "embedding_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  auto context = makeRunContext(weights, inputs, outputs, tensors);
+
+  std::vector<nntrainer::TensorDim> new_dims = {
+    nntrainer::TensorDim({1, 1, 6, 8})};
+  layer.updateTensorsByInputDimensions(context, new_dims);
+
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 4u);
+  EXPECT_EQ(context.getInput(0).getDim().height(), 1u);
+}
+
 TEST(CausalLmEmbeddingSidecarLut, rawUint16RequiresExactHintedSize) {
   TempDir dir("nntrainer_embedding_sidecar_raw_u16");
   const auto raw_path = dir.path() / "embedding.u16";

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -328,6 +328,7 @@ if get_option('enable-test')
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3_cached_slim_moe.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss_cached_slim.cpp',
+        meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_moe_resetinputdim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2_reference.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3.cpp',

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -329,6 +329,7 @@ if get_option('enable-test')
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_gpt_oss_cached_slim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_moe_resetinputdim.cpp',
+        meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_run_prompt_resetinputdim.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen2_reference.cpp',
         meson.source_root() / 'test' / 'unittest' / 'models' / 'unittest_causallm_qwen3.cpp',

--- a/Applications/CausalLM/models/bert/multilingual_tinybert_16mb.cpp
+++ b/Applications/CausalLM/models/bert/multilingual_tinybert_16mb.cpp
@@ -71,6 +71,13 @@ std::vector<float *> MultilingualTinyBert::encode(const WSTR prompt,
   std::vector<float *> input = {input_sample, position_ids, token_type_ids};
   std::vector<float *> label;
 
+  // mha_core (internal-cache path) derives its step width from the query
+  // tensor's own height rather than an explicit incremental_forwarding
+  // from/to, so keep it in sync via resetInputDimension() whenever the
+  // actual token count is shorter than the compiled INIT_SEQ_LEN.
+  model->resetInputDimension(
+    {ml::train::TensorDim(1, 1, input_len, static_cast<unsigned int>(DIM))});
+
   auto start_prefill = std::chrono::high_resolution_clock::now();
   auto output = model->incremental_inference(BATCH_SIZE, input, label,
                                              input_len, 0, input_len, false);

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <app_context.h>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <engine.h>
 #include <filesystem>
@@ -30,6 +31,7 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -195,22 +197,30 @@ void CausalLM::allocateAndBindKVCache() {
     vp->setData(vc.getMemoryData(), vc.getOffset(), false);
   }
 
+  // Bind every mha_core layer to the shared KVCacheManager so they read the
+  // absolute write position directly from it, instead of the host having to
+  // push it into each layer via setProperty("cache_index=...") before every
+  // step. All attention layers share the same position since they all
+  // advance in lockstep with the token stream.
+  std::ostringstream kv_cache_addr;
+  kv_cache_addr << std::hex << reinterpret_cast<uintptr_t>(&kv_cache);
+  std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
+    bind_kv_cache_manager = [&kv_cache_addr](ml::train::Layer &l,
+                                             nntrainer::RunLayerContext &,
+                                             void *) {
+      if (l.getType() == causallm::MHACoreLayer::type)
+        l.setProperty({"kv_cache_manager_addr=" + kv_cache_addr.str()});
+    };
+  model->forEachLayer(bind_kv_cache_manager, nullptr);
+
   kv_cache_bound = true;
 }
 
 void CausalLM::setKVCachePosition(unsigned int pos) {
   kv_cache.setPosition(pos);
-  std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
-    fn = [pos](ml::train::Layer &l, nntrainer::RunLayerContext &, void *) {
-      if (l.getType() == causallm::MHACoreLayer::type)
-        l.setProperty({"cache_index=" + std::to_string(pos)});
-    };
-  model->forEachLayer(fn, nullptr);
 }
 
 void CausalLM::advanceKVCachePosition(unsigned int step_size) {
-  // mha_core advances its own cache_index inside forwarding(), so the host
-  // only has to keep KVCacheManager's tracked position in sync.
   kv_cache.advance(step_size);
 }
 
@@ -523,6 +533,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     setKVCachePosition(0);
     output = model->incremental_inference(BATCH_SIZE, input, label, input_len,
                                           0, input_len, false);
+    advanceKVCachePosition(input_len);
 
     SYS_PROMP_LEN = input_len;
     save_kvcache(PRE_COMPUTED_CACHE_PATH, SYS_PROMP_LEN);
@@ -559,6 +570,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     setKVCachePosition(prefill_from);
     output = model->incremental_inference(
       BATCH_SIZE, input, label, init_len - 1, prefill_from, prefill_to, false);
+    advanceKVCachePosition(prefill_to - prefill_from);
 
     for (unsigned int b = 0; b < BATCH_SIZE; ++b)
       id_list.push_back(skipped_token);
@@ -572,6 +584,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     setKVCachePosition(prefill_from);
     output = model->incremental_inference(BATCH_SIZE, input, label, init_len,
                                           prefill_from, prefill_to, false);
+    advanceKVCachePosition(prefill_to - prefill_from);
 
     // post process of model output
     id_list = generate(output[0], do_sample, 1, ids_history, init_len);
@@ -615,6 +628,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       model->incremental_inference(BATCH_SIZE, input, label, input_len,
                                    token_generation_idx - 1 + global_token_len,
                                    token_generation_idx + global_token_len);
+    // mha_core no longer self-advances once bound to kv_cache; advance the
+    // shared position by the single decoded token processed this step.
+    advanceKVCachePosition(1);
     std::vector<unsigned int> ids_list(generate(output_interval[0], do_sample));
 
     // Feed the newly generated token back as the next input token.

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -493,11 +493,13 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   };
   input = build_inference_inputs();
 
-  ///@note contains possible bug
-  // std::vector<ml::train::TensorDim> input_dims;
-  // ml::train::TensorDim input_dim(1, 1, input_len, DIM);
-  // input_dims.push_back(input_dim);
-  // model->resetInputDimension(input_dims);
+  std::vector<ml::train::TensorDim> input_dims;
+  input_dims.push_back(
+    ml::train::TensorDim(1, 1, input_len, static_cast<unsigned int>(DIM)));
+  model->resetInputDimension(input_dims);
+  // resetInputDimension() silently rebinds KV cache placeholders back to
+  // internal memory; force allocateAndBindKVCache() to redo external binding.
+  kv_cache_bound = false;
 
   auto start_prefill = std::chrono::high_resolution_clock::now();
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -575,9 +575,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     // post process of model output
     id_list = generate(output[0], do_sample, 1, ids_history, init_len);
-
-    if (init_len < INIT_SEQ_LEN)
-      registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+    registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
   }
   // output should be deallocated after use
   for (auto &out : output) {

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -599,6 +599,12 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
+  std::vector<ml::train::TensorDim> decode_input_dims;
+  decode_input_dims.push_back(
+    ml::train::TensorDim(1, 1, 1, static_cast<unsigned int>(DIM)));
+  model->resetInputDimension(decode_input_dims);
+  kv_cache_bound = false;
+
   for (unsigned int token_generation_idx = input_len + 1;
        token_generation_idx < input_len + 1 + NUM_TO_GENERATE &&
        !stop_requested_.load(std::memory_order_acquire);

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -14,11 +14,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
+#include <sstream>
 
 #include <app_context.h>
 #include <engine.h>
 #include <llm_util.hpp>
 #include <logit_softcapping.h>
+#include <mha_core.h>
 #include <model.h>
 #include <per_layer_slice.h>
 #include <reshaped_rms_norm.h>
@@ -904,6 +907,20 @@ void Gemma4CausalLM::allocateAndBindKVCache() {
     kp->setData(kc.getMemoryData(), kc.getOffset(), false);
     vp->setData(vc.getMemoryData(), vc.getOffset(), false);
   }
+
+  // Bind every mha_core layer to the shared KVCacheManager so they read the
+  // absolute write position directly from it, instead of falling back to
+  // their own per-layer cache_index (see CausalLM::allocateAndBindKVCache()).
+  std::ostringstream kv_cache_addr;
+  kv_cache_addr << std::hex << reinterpret_cast<uintptr_t>(&kv_cache);
+  std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
+    bind_kv_cache_manager = [&kv_cache_addr](ml::train::Layer &l,
+                                             nntrainer::RunLayerContext &,
+                                             void *) {
+      if (l.getType() == causallm::MHACoreLayer::type)
+        l.setProperty({"kv_cache_manager_addr=" + kv_cache_addr.str()});
+    };
+  model->forEachLayer(bind_kv_cache_manager, nullptr);
 
   kv_cache_bound = true;
 }

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.cpp
@@ -597,4 +597,31 @@ void GptOssMoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void GptOssMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
+++ b/Applications/CausalLM/models/gpt_oss/gpt_oss_moe_layer.h
@@ -108,6 +108,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "gpt_oss_moe"; /**< type of the layer */
 
 private:

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -592,4 +592,31 @@ void CachedSlimGptOssMoELayer::exportTo(
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void CachedSlimGptOssMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
@@ -111,6 +111,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type =
     "gpt_oss_moe_slim_cached"; /**< type of the layer */
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -534,14 +534,27 @@ void CachedSlimMoELayer::updateTensorsByInputDimensions(
   nntrainer::RunLayerContext &context,
   std::vector<nntrainer::TensorDim> input_dimensions) {
   ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
   ml::train::TensorDim output_dim =
     context.getOutput(SINGLE_INOUT_IDX).getDim();
-
-  input_dim.height(input_dimensions[0].height());
-  output_dim.height(input_dimensions[0].height());
-
-  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  output_dim.height(new_height);
   context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
 }
 
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.cpp
@@ -527,4 +527,31 @@ void MoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void MoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
+++ b/Applications/CausalLM/models/qwen3_moe/qwen_moe_layer.h
@@ -113,6 +113,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "qwen_moe"; /**< type of the layer */
 
 private:

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.cpp
@@ -521,4 +521,31 @@ void SlimMoELayer::exportTo(nntrainer::Exporter &exporter,
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+void SlimMoELayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  const unsigned int batch_size = input_dim.batch();
+  const unsigned int new_height = input_dimensions[0].height();
+  const unsigned int total_tokens = batch_size * new_height;
+
+  input_dim.height(new_height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  ml::train::TensorDim output_dim =
+    context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(new_height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  ml::train::TensorDim router_logits_dim =
+    context.getTensor(router_logits_idx).getDim();
+  router_logits_dim.batch(total_tokens);
+  context.updateTensor(router_logits_idx, router_logits_dim);
+
+  ml::train::TensorDim expert_mask_dim =
+    context.getTensor(expert_mask_idx).getDim();
+  expert_mask_dim.width(total_tokens);
+  context.updateTensor(expert_mask_idx, expert_mask_dim);
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
+++ b/Applications/CausalLM/models/qwen3_slim_moe/qwen_moe_layer_fsu.h
@@ -113,6 +113,16 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Resizes input/output height plus the router_logits/expert_mask
+   * tensors (sized by total_tokens = batch * seq_len) to match.
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "moe_slim"; /**< type of the layer */
 
 private:

--- a/Applications/CausalLM/models/sentence_transformer.cpp
+++ b/Applications/CausalLM/models/sentence_transformer.cpp
@@ -334,6 +334,15 @@ std::vector<float *> SentenceTransformer::encode(const WSTR prompt,
 
   std::vector<float *> label; // Empty label for inference
 
+  // mha_core derives its step width from the query tensor's own height
+  // rather than an explicit incremental_forwarding from/to, so keep it in
+  // sync via resetInputDimension() whenever the actual token count is
+  // shorter than the compiled INIT_SEQ_LEN. Must happen before
+  // allocateAndBindKVCache(), since resetInputDimension() silently rebinds
+  // the KV cache placeholders back to internal memory.
+  model->resetInputDimension(
+    {ml::train::TensorDim(1, 1, input_len, static_cast<unsigned int>(DIM))});
+
   allocateAndBindKVCache();
   auto build_inference_inputs = [&]() {
     std::vector<std::pair<std::string, float *>> cache_inputs;

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -338,13 +338,14 @@ void NetworkGraph::resetInputDimension(std::vector<TensorDim> dims) {
     deallocateTensors();
 
   for (auto iter = cbegin(); iter != cend(); iter++) {
-    if ((*iter)->isFinalized()) {
+    /// @note InputLayer is excluded: its raw input tensor doesn't follow the
+    /// height-based convention `dims` uses for every other layer.
+    if ((*iter)->isFinalized() && (*iter)->getType() != InputLayer::type) {
       (*iter)->updateTensorsByInputDimensions(dims);
     }
   }
 
-  if (allocated)
-    allocateTensors(exec_mode);
+  allocateTensors(exec_mode);
 
   /** update input and label dimensions */
   for (unsigned int idx = 0; idx < input_list.size(); idx++)

--- a/nntrainer/layers/activation_layer.cpp
+++ b/nntrainer/layers/activation_layer.cpp
@@ -111,6 +111,17 @@ void ActivationLayer::incremental_forwarding(RunLayerContext &context,
   }
 }
 
+void ActivationLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void ActivationLayer::calcDerivative(RunLayerContext &context) {
   const Tensor &deriv = context.getIncomingDerivative(SINGLE_INOUT_IDX);
   Tensor &ret = context.getOutgoingDerivative(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/activation_layer.h
+++ b/nntrainer/layers/activation_layer.h
@@ -58,6 +58,15 @@ public:
                               unsigned int to, bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only height (sequence length) is resized; width (feature dim)
+   * is preserved from finalize().
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::calcDerivative(RunLayerContext &context)
    */
   void calcDerivative(RunLayerContext &context) override;

--- a/nntrainer/layers/cl_layers/addition_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.cpp
@@ -104,4 +104,13 @@ void AdditionLayerCL::setProperty(const std::vector<std::string> &values) {
     throw exception::not_supported(msg);
   }
 }
+
+void AdditionLayerCL::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  for (size_t i = 0; i < context.getNumInputs(); ++i) {
+    context.updateInput(i, input_dimensions[0]);
+  }
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/addition_layer_cl.h
+++ b/nntrainer/layers/cl_layers/addition_layer_cl.h
@@ -90,6 +90,13 @@ public:
   void setProperty(const std::vector<std::string> &values) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return AdditionLayerCL::type; };

--- a/nntrainer/layers/cl_layers/fc_layer_cl.cpp
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.cpp
@@ -198,4 +198,15 @@ void FullyConnectedLayerCl::calcGradient(RunLayerContext &context) {
     !context.isGradientFirstAccess(weight_idx[FCParams::weight]));
 }
 
+void FullyConnectedLayerCl::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/cl_layers/fc_layer_cl.h
+++ b/nntrainer/layers/cl_layers/fc_layer_cl.h
@@ -101,6 +101,13 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static bool registerClKernels([[maybe_unused]] ClContext &cl_context) {
     return true;
   };

--- a/nntrainer/layers/concat_layer.cpp
+++ b/nntrainer/layers/concat_layer.cpp
@@ -26,7 +26,8 @@
 #include <util_func.h>
 
 namespace nntrainer {
-ConcatLayer::ConcatLayer() : Layer(), leading_helper_dim(1) {}
+ConcatLayer::ConcatLayer() :
+  Layer(), concat_dimension(1), leading_helper_dim(1) {}
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
@@ -36,8 +37,7 @@ void ConcatLayer::finalize(InitLayerContext &context) {
   /// @todo this is hacky way to force concat dimension to width if channel
   /// dimension is taken, this is because recurrent realizer, return sequence
   /// exploits concat layer but have no control over where to stack/axis
-  unsigned int concat_dimension =
-    context.getInputDimensions().front().channel() > 1 ? 3 : 1;
+  concat_dimension = context.getInputDimensions().front().channel() > 1 ? 3 : 1;
   if (!concat_dimension_prop.empty())
     concat_dimension = concat_dimension_prop.get();
 
@@ -325,6 +325,61 @@ void ConcatLayer::exportTo(Exporter &exporter,
                            const ml::train::ExportMethods &method) const {
   Layer::exportTo(exporter, method);
   exporter.saveResult(concat_props, method, this);
+}
+
+void ConcatLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  /** @todo height-axis concat (concat_dimension == 2) sums heights across
+   * inputs rather than sharing a single sequence length, so the assumption
+   * below (all inputs/outputs simply adopt input_dimensions[0].height())
+   * does not hold for it */
+  NNTR_THROW_IF(concat_dimension == 2, std::invalid_argument)
+    << "[ConcatLayer] updateTensorsByInputDimensions does not support "
+       "concat_dimension == 2 (height-axis concat)";
+
+  unsigned int height = input_dimensions[0].height();
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  std::vector<TensorDim> input_dims(context.getNumInputs());
+  for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
+    TensorDim input_dim = context.getInput(idx).getDim();
+    input_dim.height(height);
+    context.updateInput(idx, input_dim);
+    input_dims[idx] = input_dim;
+  }
+
+  /// Recompute output_reshape_helper for the new height
+  output_reshape_helper.channel(1);
+  output_reshape_helper.height(1);
+  output_reshape_helper.width(1);
+  for (unsigned int axis = concat_dimension;
+       axis < ml::train::TensorDim::getNumDim(); ++axis) {
+    output_reshape_helper.width(output_reshape_helper.width() *
+                                output_dim.getTensorDim(axis));
+  }
+
+  /// Recompute input_reshape_helper for the new height
+  for (unsigned int idx = 0; idx < input_reshape_helper.size(); idx++) {
+    input_reshape_helper[idx].channel(1);
+    input_reshape_helper[idx].height(1);
+    input_reshape_helper[idx].width(1);
+
+    for (unsigned int axis = concat_dimension;
+         axis < ml::train::TensorDim::getNumDim(); ++axis) {
+      input_reshape_helper[idx].width(input_reshape_helper[idx].width() *
+                                      input_dims[idx].getTensorDim(axis));
+    }
+  }
+
+  leading_helper_dim = 1;
+  for (unsigned int idx = 1; idx < concat_dimension; ++idx) {
+    leading_helper_dim *= output_dim.getTensorDim(idx);
+  }
+
+  setBatch(output_dim.batch());
 }
 
 } /* namespace nntrainer */

--- a/nntrainer/layers/concat_layer.h
+++ b/nntrainer/layers/concat_layer.h
@@ -100,9 +100,18 @@ public:
     setBatch(batch);
   }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "concat";
 
 private:
+  unsigned int concat_dimension;   /**< axis along which inputs are
+                                      concatenated */
   unsigned int leading_helper_dim; /**< batch dimension of helper dimension not
                                 containing the actual batch */
   std::vector<TensorDim>

--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -228,4 +228,11 @@ void EmbeddingLayer::exportTo(Exporter &exporter,
   exporter.saveResult(embedding_props, method, this);
 }
 
+void EmbeddingLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 } // namespace nntrainer

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -101,6 +101,13 @@ public:
    */
   void setProperty(const std::vector<std::string> &values) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "embedding";
 
 private:

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -251,6 +251,17 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
   }
 }
 
+void FullyConnectedLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(input_dimensions[0].height());
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(input_dimensions[0].height());
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+}
+
 void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
                                                  unsigned int from,
                                                  unsigned int to,

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -59,6 +59,15 @@ public:
   void forwarding(RunLayerContext &context, bool training) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   * @details Only height (sequence length) is resized; width (feature dim)
+   * is preserved from finalize().
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
+  /**
 ￼   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
 ￼   * int from, unsigned int to, bool training)
 ￼   */

--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -332,4 +332,52 @@ void LayerNormalizationLayer::setBatch(RunLayerContext &context,
   context.updateTensor(wt_idx[LNParams::temp_normalized_size], batch);
 }
 
+void LayerNormalizationLayer::updateTensorsByInputDimensions(
+  RunLayerContext &context, std::vector<TensorDim> input_dimensions) {
+  // @todo: consider NHWC format
+  bool is_height_normalize =
+    std::find(normalize_axes.begin(), normalize_axes.end(), 1) !=
+    normalize_axes.end();
+
+  unsigned int height = input_dimensions[0].height();
+
+  TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
+  input_dim.height(height);
+  context.updateInput(SINGLE_INOUT_IDX, input_dim);
+
+  TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+  output_dim.height(height);
+  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  TensorDim deviation_dim =
+    context.getTensor(wt_idx[LNParams::deviation]).getDim();
+  deviation_dim.height(height);
+  context.updateTensor(wt_idx[LNParams::deviation], deviation_dim);
+
+  TensorDim temp_origin_dim =
+    context.getTensor(wt_idx[LNParams::temp_origin_size]).getDim();
+  temp_origin_dim.height(height);
+  context.updateTensor(wt_idx[LNParams::temp_origin_size], temp_origin_dim);
+
+  /** variance/inv_std_dev/temp_normalized_size only carry sequence length in
+   * their height when height is not one of the normalize axes */
+  if (!is_height_normalize) {
+    TensorDim variance_dim =
+      context.getTensor(wt_idx[LNParams::variance]).getDim();
+    variance_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::variance], variance_dim);
+
+    TensorDim inv_std_dev_dim =
+      context.getTensor(wt_idx[LNParams::inv_std_dev]).getDim();
+    inv_std_dev_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::inv_std_dev], inv_std_dev_dim);
+
+    TensorDim temp_normalized_dim =
+      context.getTensor(wt_idx[LNParams::temp_normalized_size]).getDim();
+    temp_normalized_dim.height(height);
+    context.updateTensor(wt_idx[LNParams::temp_normalized_size],
+                         temp_normalized_dim);
+  }
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/layer_normalization_layer.h
+++ b/nntrainer/layers/layer_normalization_layer.h
@@ -120,6 +120,13 @@ public:
    */
   void setBatch(RunLayerContext &context, unsigned int batch) override;
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context, std::vector<TensorDim> input_dimensions) override;
+
   static constexpr const char *type = "layer_normalization";
 
 private:

--- a/nntrainer/layers/multiply_layer.cpp
+++ b/nntrainer/layers/multiply_layer.cpp
@@ -60,4 +60,13 @@ void MultiplyLayer::setProperty(const std::vector<std::string> &values) {
     throw exception::not_supported(msg);
   }
 }
+
+void MultiplyLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  for (size_t i = 0; i < context.getNumInputs(); ++i) {
+    context.updateInput(i, input_dimensions[0]);
+  }
+  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+}
 } /* namespace nntrainer */

--- a/nntrainer/layers/multiply_layer.h
+++ b/nntrainer/layers/multiply_layer.h
@@ -139,6 +139,14 @@ public:
    */
   const std::string getType() const final { return MultiplyLayer::type; };
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   */
+  void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) final;
+
   std::tuple<props::Print, props::InPlaceProp, props::InPlaceDirectionProp,
              props::SkipPrefill>
     multiply_props;

--- a/nntrainer/layers/operation_layer.h
+++ b/nntrainer/layers/operation_layer.h
@@ -79,6 +79,23 @@ public:
     }
   }
 
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   *
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context,
+    std::vector<TensorDim> input_dimensions) override {
+    TensorDim input_dim = context.getInput(0).getDim();
+    input_dim.height(input_dimensions[0].height());
+    context.updateInput(0, input_dim);
+
+    TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+    output_dim.height(input_dimensions[0].height());
+    context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+  }
+
   static constexpr size_t SINGLE_INOUT_IDX = 0;
 };
 
@@ -154,6 +171,27 @@ public:
 
       forwarding_operation(input0_step, input1_step, hidden_step);
     }
+  }
+
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(RunLayerContext &context,
+   * std::vector<TensorDim> input_dimensions)
+   *
+   */
+  void updateTensorsByInputDimensions(
+    RunLayerContext &context,
+    std::vector<TensorDim> input_dimensions) override {
+    TensorDim input0_dim = context.getInput(0).getDim();
+    input0_dim.height(input_dimensions[0].height());
+    context.updateInput(0, input0_dim);
+
+    TensorDim input1_dim = context.getInput(1).getDim();
+    input1_dim.height(input_dimensions[0].height());
+    context.updateInput(1, input1_dim);
+
+    TensorDim output_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
+    output_dim.height(input_dimensions[0].height());
+    context.updateOutput(SINGLE_INOUT_IDX, output_dim);
   }
 
   static constexpr size_t SINGLE_INOUT_IDX = 0;

--- a/test/unittest/layers/unittest_layers_activation.cpp
+++ b/test/unittest/layers/unittest_layers_activation.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <activation_layer.h>
+#include <layer_context.h>
 #include <layers_common_tests.h>
 
 auto semantic_activation_relu = LayerSemanticsParamType(
@@ -57,3 +58,34 @@ GTEST_PARAMETER_TEST(
                     semantic_activation_gelu, semantic_activation_sigmoid,
                     semantic_activation_softmax, semantic_activation_tanh,
                     semantic_activation_none));
+
+TEST(ActivationUpdateTensorsByInputDimensions,
+     updates_input_output_height_only) {
+  nntrainer::ActivationLayer acti;
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "activation_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 8}), nntrainer::Initializer::NONE, true,
+    false, "activation_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  std::vector<nntrainer::Weight *> weights_view;
+  std::vector<nntrainer::Var_Grad *> inputs_view = {&inputs[0]};
+  std::vector<nntrainer::Var_Grad *> outputs_view = {&outputs[0]};
+  std::vector<nntrainer::Var_Grad *> tensors_view;
+
+  nntrainer::RunLayerContext context("activation_update_dims_test", true, 0.0f,
+                                     false, 1.0f, nullptr, false, weights_view,
+                                     inputs_view, outputs_view, tensors_view);
+
+  std::vector<nntrainer::TensorDim> dims = {nntrainer::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(acti.updateTensorsByInputDimensions(context, dims));
+
+  EXPECT_EQ(context.getInput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 8u);
+}

--- a/test/unittest/layers/unittest_layers_fully_connected.cpp
+++ b/test/unittest/layers/unittest_layers_fully_connected.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <fc_layer.h>
+#include <layer_context.h>
 #include <layers_common_tests.h>
 
 auto semantic_fc = LayerSemanticsParamType(
@@ -89,3 +90,34 @@ GTEST_PARAMETER_TEST(FullyConnected16, LayerGoldenTest,
                                        fc_basic_single_batch_w16a16,
                                        fc_basic_no_decay_w16a16));
 #endif
+
+TEST(FullyConnectedUpdateTensorsByInputDimensions,
+     updates_input_output_height_only) {
+  nntrainer::FullyConnectedLayer fc;
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs = {
+    nntrainer::Var_Grad(nntrainer::TensorDim({1, 1, 4, 8}),
+                        nntrainer::Initializer::NONE, true, false, "fc_input")};
+  std::vector<nntrainer::Var_Grad> outputs = {nntrainer::Var_Grad(
+    nntrainer::TensorDim({1, 1, 4, 16}), nntrainer::Initializer::NONE, true,
+    false, "fc_output")};
+  std::vector<nntrainer::Var_Grad> tensors;
+
+  std::vector<nntrainer::Weight *> weights_view;
+  std::vector<nntrainer::Var_Grad *> inputs_view = {&inputs[0]};
+  std::vector<nntrainer::Var_Grad *> outputs_view = {&outputs[0]};
+  std::vector<nntrainer::Var_Grad *> tensors_view;
+
+  nntrainer::RunLayerContext context("fc_update_dims_test", true, 0.0f, false,
+                                     1.0f, nullptr, false, weights_view,
+                                     inputs_view, outputs_view, tensors_view);
+
+  std::vector<nntrainer::TensorDim> dims = {nntrainer::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(fc.updateTensorsByInputDimensions(context, dims));
+
+  EXPECT_EQ(context.getInput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getInput(0).getDim().width(), 8u);
+  EXPECT_EQ(context.getOutput(0).getDim().height(), 6u);
+  EXPECT_EQ(context.getOutput(0).getDim().width(), 16u);
+}

--- a/test/unittest/models/causallm_test_utils.h
+++ b/test/unittest/models/causallm_test_utils.h
@@ -289,6 +289,16 @@ public:
 
     auto [input, cache_inputs] = buildCacheInput(input_sample);
     std::vector<float *> label;
+
+    // mha_core derives its step width from the query tensor's own height
+    // instead of an explicit incremental_forwarding from/to, so keep it in
+    // sync via resetInputDimension() the same way CausalLM::run() does
+    // before every prefill/decode phase change.
+    this->model->resetInputDimension({ml::train::TensorDim(
+      1, 1, init_len, static_cast<unsigned int>(this->DIM))});
+    this->kv_cache_bound = false;
+    this->allocateAndBindKVCache();
+
     this->setKVCachePosition(0);
     auto output = this->model->incremental_inference(
       this->BATCH_SIZE, input, label, init_len, 0, init_len, false);
@@ -319,12 +329,30 @@ public:
     auto [input, cache_inputs] = buildCacheInput(input_sample);
     std::vector<float *> label;
 
+    // mha_core derives its step width from the query tensor's own height
+    // instead of an explicit incremental_forwarding from/to, so keep it in
+    // sync via resetInputDimension() the same way CausalLM::run() does
+    // before every prefill/decode phase change.
+    this->model->resetInputDimension({ml::train::TensorDim(
+      1, 1, init_len, static_cast<unsigned int>(this->DIM))});
+    this->kv_cache_bound = false;
+    this->allocateAndBindKVCache();
+
     this->setKVCachePosition(0);
     auto output = this->model->incremental_inference(
       this->BATCH_SIZE, input, label, init_len, 0, init_len, false);
 
     std::vector<unsigned int> generated;
     generated.reserve(n);
+
+    if (n > 1) {
+      // Every subsequent decode step processes exactly one token; switch the
+      // graph to that width once before the loop, matching CausalLM::run()'s
+      // decode phase.
+      this->model->resetInputDimension(
+        {ml::train::TensorDim(1, 1, 1, static_cast<unsigned int>(this->DIM))});
+      this->kv_cache_bound = false;
+    }
 
     for (size_t step = 0; step < n; ++step) {
       unsigned int next_tok = static_cast<unsigned int>(std::distance(
@@ -342,6 +370,7 @@ public:
 
       unsigned int from = init_len + static_cast<unsigned int>(step);
       unsigned int to = from + 1;
+      this->allocateAndBindKVCache();
       this->setKVCachePosition(from);
       output = this->model->incremental_inference(this->BATCH_SIZE, input,
                                                   label, 1, from, to, false);

--- a/test/unittest/models/unittest_causallm_moe_resetinputdim.cpp
+++ b/test/unittest/models/unittest_causallm_moe_resetinputdim.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_causallm_moe_resetinputdim.cpp
+ * @date   08 July 2026
+ * @brief  End-to-end verification that MoE layers survive
+ *         CausalLM::run()'s resetInputDimension() call. Exercises the real
+ *         run()/resetInputDimension path, unlike the golden
+ *         prefillLogits()-based tests elsewhere in this suite which bypass
+ *         it entirely.
+ * @author Jungwon Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * @note Only Qwen3MoE (qwen_moe) is exercised here.
+ *       - GptOss (gpt_oss_moe) is intentionally NOT covered: once its MoE
+ *         layer's updateTensorsByInputDimensions() override stops throwing,
+ *         a separate pre-existing bug in GptOss's MHACoreLayer/sliding-window
+ *         attention path segfaults on resetInputDimension(). That is a
+ *         distinct, deeper issue outside the scope of the MoE tensor-resize
+ *         fix and is tracked separately.
+ *       - SlimMoE (moe_slim), Qwen3CachedSlimMoE (qwen_moe_cached), and
+ *         GptOssCachedSlim (gpt_oss_moe_slim_cached) call
+ *         Tensor::activate()/deactivate() unconditionally in forwarding() for
+ *         lazy mmap-based expert weight loading; in this in-process
+ *         tiny-test harness their weights are plain in-memory tensors, so
+ *         activate() hangs (see the pre-existing comment in
+ *         unittest_causallm_qwen3_slim_moe.cpp). Running them here would
+ *         risk hanging the test binary, so they are intentionally not
+ *         covered by this file; their fix was verified by structural code
+ *         inspection (identical requestTensor/updateTensor pattern to the
+ *         one covered here).
+ */
+
+#include <causallm_test_utils.h>
+
+#include <gtest/gtest.h>
+
+#include <layer.h>
+#include <layer_context.h>
+#include <qwen3_moe_causallm.h>
+
+namespace {
+
+using TinyQwen3MoECausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen3MoECausalLM>;
+
+causallm::json makeTinyQwen3MoEConfig() {
+  return {
+    {"architectures", {"Qwen3MoeForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"moe_intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"num_experts", 4},
+    {"num_experts_per_tok", 2},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+/**
+ * @brief Zero all FP32 weights, but set MoE gate weights to non-uniform
+ * values so routing is deterministic. No correctness assertions are made
+ * here -- this only needs to run forward without crashing/OOB.
+ */
+template <typename Model>
+void zeroWeightsWithMoEGate(Model &model, const std::string &moe_layer_type) {
+  model.forEachLayer(
+    [&](ml::train::Layer &layer, nntrainer::RunLayerContext &context, void *) {
+      if (layer.getName() == "output_of_causallm")
+        return;
+
+      if (layer.getType() == moe_layer_type) {
+        auto &gate = context.getWeight(0);
+        const auto dim = gate.getDim();
+        const unsigned hidden = dim.height();
+        const unsigned num_exp = dim.width();
+        for (unsigned h = 0; h < hidden; ++h)
+          for (unsigned e = 0; e < num_exp; ++e)
+            gate.setValue(0, 0, h, e, 1.0f / (e + 1));
+
+        for (unsigned int i = 1; i < context.getNumWeights(); ++i) {
+          auto &w = context.getWeight(i);
+          if (w.getDataType() == ml::train::TensorDim::DataType::FP32)
+            w.setValue(0.0f);
+        }
+        return;
+      }
+
+      for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+        auto &weight = context.getWeight(i);
+        if (weight.getDataType() != ml::train::TensorDim::DataType::FP32)
+          continue;
+
+        weight.setValue(0.0f);
+        if (layer.getType() == "rms_norm") {
+          weight.setValue(1.0f);
+        } else if (layer.getName() == "embedding0") {
+          weight.setValue(0, 0, 1, 0, 1.0f);
+          weight.setValue(0, 0, 4, 0, 2.0f);
+        }
+      }
+    });
+}
+
+TEST(MoEResetInputDimensionEndToEnd, Qwen3MoERunPromptDoesNotCrash) {
+  auto files = causallm_test::makeTinyCausalLMFiles(
+    "MoEResetInputDimensionEndToEnd", "Qwen3MoERunPromptDoesNotCrash",
+    "Qwen3MoE_FP32");
+
+  auto model_cfg = makeTinyQwen3MoEConfig();
+  auto gen_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyNntrainerConfig(
+    files.tokenizer_path, causallm_test::makeTinyFp32DataType());
+
+  auto model =
+    std::make_unique<TinyQwen3MoECausalLM>(model_cfg, gen_cfg, nntr_cfg);
+  model->initializeModel();
+  zeroWeightsWithMoEGate(*model, "qwen_moe");
+
+  // Longer than a single token so resetInputDimension() actually resizes the
+  // sequence length away from whatever finalize() originally allocated.
+  ASSERT_NO_THROW(model->runPrompt("hello tok4 tok5 tok6 tok7"));
+  EXPECT_TRUE(model->hasRun());
+
+  // Run a second, shorter prompt through the same model instance:
+  // resetInputDimension() is called on every run(), so this exercises
+  // shrinking the router_logits/expert_mask tensors back down too.
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_TRUE(model->hasRun());
+}
+
+} // namespace

--- a/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
+++ b/test/unittest/models/unittest_causallm_run_prompt_resetinputdim.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_causallm_run_prompt_resetinputdim.cpp
+ * @date   08 July 2026
+ * @brief  End-to-end verification that Qwen2, Qwen3, Gemma3 and Gemma4
+ *         survive CausalLM::run()'s resetInputDimension() call when the
+ *         same model instance is reused across prompts of different
+ *         lengths. Exercises the real run()/resetInputDimension() path,
+ *         unlike the golden prefillLogits()-based tests elsewhere in this
+ *         suite which call NeuralNetwork::incremental_inference() directly
+ *         and therefore never reach resetInputDimension() at all.
+ * @author Jungwon Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * @note See unittest_causallm_moe_resetinputdim.cpp for the equivalent
+ *       Qwen3MoE coverage, and for why GptOss / SlimMoE / CachedSlimMoE
+ *       variants are intentionally not covered by an analogous test here.
+ */
+
+#include <causallm_test_utils.h>
+
+#include <gtest/gtest.h>
+
+#include <gemma3_causallm.h>
+#include <gemma4_causallm.h>
+#include <layer.h>
+#include <layer_context.h>
+#include <qwen2_causallm.h>
+#include <qwen3_causallm.h>
+
+namespace {
+
+/**
+ * @brief Zero every FP32 weight, leaving rms_norm at 1 and a couple of
+ * embedding rows non-zero so the forward pass is deterministic. No
+ * correctness assertions are made on the produced logits here -- these
+ * tests only need the resetInputDimension()-driven forward pass to run
+ * without crashing/OOB across multiple prompt lengths on the same
+ * instance.
+ */
+template <typename Model> void zeroWeights(Model &model) {
+  model.forEachLayer(
+    [&](ml::train::Layer &layer, nntrainer::RunLayerContext &context, void *) {
+      if (layer.getName() == "output_of_causallm")
+        return;
+
+      for (unsigned int i = 0; i < context.getNumWeights(); ++i) {
+        auto &weight = context.getWeight(i);
+        if (weight.getDataType() != ml::train::TensorDim::DataType::FP32)
+          continue;
+
+        weight.setValue(0.0f);
+        if (layer.getType() == "rms_norm" ||
+            layer.getType() == "reshaped_rms_norm") {
+          weight.setValue(1.0f);
+        } else if (layer.getName() == "embedding0") {
+          weight.setValue(0, 0, 1, 0, 1.0f);
+          weight.setValue(0, 0, 4, 0, 2.0f);
+        } else if (layer.getName().find("_layer_scalar") != std::string::npos) {
+          weight.setValue(1.0f);
+        }
+      }
+    });
+}
+
+using TinyQwen2CausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen2CausalLM>;
+using TinyQwen3CausalLM =
+  causallm_test::CausalLMTestAdapter<causallm::Qwen3CausalLM>;
+
+/**
+ * @brief Tiny Gemma3 CausalLM adapter (needs sanitizeConfig() before the
+ * virtual Transformer base is constructed, see unittest_causallm_gemma3.cpp)
+ */
+class TinyGemma3CausalLM final
+  : public causallm_test::CausalLMTestAdapter<causallm::Gemma3CausalLM> {
+public:
+  TinyGemma3CausalLM(causallm::json &cfg, causallm::json &generation_cfg,
+                     causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm_test::CausalLMTestAdapter<causallm::Gemma3CausalLM>(
+      cfg, generation_cfg, nntr_cfg) {}
+};
+
+/**
+ * @brief Tiny Gemma4 CausalLM adapter (needs sanitizeConfig() to flatten
+ * text_config before the virtual Transformer base is constructed, see
+ * unittest_causallm_gemma4.cpp)
+ */
+class TinyGemma4CausalLM final
+  : public causallm_test::CausalLMTestAdapter<causallm::Gemma4CausalLM> {
+public:
+  TinyGemma4CausalLM(causallm::json &cfg, causallm::json &generation_cfg,
+                     causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm_test::CausalLMTestAdapter<causallm::Gemma4CausalLM>(
+      cfg, generation_cfg, nntr_cfg) {}
+};
+
+causallm::json makeTinyQwen2Config() {
+  return {
+    {"architectures", {"Qwen2ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyQwen3Config() {
+  return {
+    {"architectures", {"Qwen3ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 1},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-5},
+    {"rope_theta", 10000},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyGemma3Config() {
+  return {
+    {"architectures", {"Gemma3ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"head_dim", 8},
+    {"hidden_size", 64},
+    {"intermediate_size", 64},
+    {"is_causal", true},
+    {"max_position_embeddings", 8},
+    {"num_attention_heads", 8},
+    {"num_hidden_layers", 2},
+    {"num_key_value_heads", 4},
+    {"rms_norm_eps", 1e-6},
+    {"rope_theta", 1000000},
+    {"sliding_window", 4},
+    {"sliding_window_pattern", 2},
+    {"tie_word_embeddings", true},
+    {"vocab_size", 32},
+  };
+}
+
+causallm::json makeTinyGemma4Config() {
+  return {
+    {"architectures", {"Gemma4ForCausalLM"}},
+    {"bos_token_id", 0},
+    {"eos_token_id", {31}},
+    {"text_config",
+     {
+       {"head_dim", 8},
+       {"hidden_size", 64},
+       {"hidden_size_per_layer_input", 32},
+       {"intermediate_size", 64},
+       {"layer_types", {"sliding_attention", "full_attention"}},
+       {"max_position_embeddings", 8},
+       {"num_attention_heads", 8},
+       {"num_hidden_layers", 2},
+       {"num_key_value_heads", 4},
+       {"rms_norm_eps", 1e-6},
+       {"rope_theta", 1000000},
+       {"sliding_window", 4},
+       {"tie_word_embeddings", true},
+       {"vocab_size", 32},
+       {"vocab_size_per_layer_input", 32},
+     }},
+  };
+}
+
+/**
+ * @brief Build, initialize and zero-weight a tiny model of the given type,
+ * then run two prompts of different lengths through the same instance.
+ */
+template <typename Model>
+void runResetInputDimensionRegression(const std::string &suite,
+                                      const std::string &test,
+                                      const std::string &fixture_name,
+                                      causallm::json model_cfg) {
+  auto files = causallm_test::makeTinyCausalLMFiles(suite, test, fixture_name);
+
+  auto gen_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyNntrainerConfig(
+    files.tokenizer_path, causallm_test::makeTinyFp32DataType());
+
+  auto model = std::make_unique<Model>(model_cfg, gen_cfg, nntr_cfg);
+  model->initializeModel();
+  zeroWeights(*model);
+
+  // Longer than a single token so resetInputDimension() actually resizes
+  // the sequence length away from whatever finalize() originally allocated.
+  ASSERT_NO_THROW(model->runPrompt("hello tok4 tok5 tok6 tok7"));
+  EXPECT_TRUE(model->hasRun());
+
+  // Run a second, shorter prompt through the same model instance:
+  // resetInputDimension() is called on every run(), so this exercises
+  // shrinking tensors back down too.
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_TRUE(model->hasRun());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen2RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyQwen2CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen2RunPromptDoesNotCrash",
+    "Qwen2_FP32", makeTinyQwen2Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Qwen3RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyQwen3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Qwen3RunPromptDoesNotCrash",
+    "Qwen3_FP32", makeTinyQwen3Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma3RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyGemma3CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma3RunPromptDoesNotCrash",
+    "Gemma3_FP32", makeTinyGemma3Config());
+}
+
+TEST(RunPromptResetInputDimensionEndToEnd, Gemma4RunPromptDoesNotCrash) {
+  runResetInputDimensionRegression<TinyGemma4CausalLM>(
+    "RunPromptResetInputDimensionEndToEnd", "Gemma4RunPromptDoesNotCrash",
+    "Gemma4_FP32", makeTinyGemma4Config());
+}
+
+} // namespace

--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -403,6 +403,36 @@ TEST(nntrainerGraphUnitTest, NoLossLayerWhenInferenceMode) {
   ans.clear();
 }
 
+TEST(nntrainerGraphUnitTest, ResetInputDimensionSkipsInputLayer) {
+  std::unique_ptr<ml::train::Model> model =
+    ml::train::createModel(ml::train::ModelType::NEURAL_NET);
+
+  model->addLayer(ml::train::createLayer(
+    "input", {nntrainer::withKey("name", "input0"),
+              nntrainer::withKey("input_shape", "1:1:4")}));
+  model->addLayer(ml::train::createLayer(
+    "fully_connected",
+    {nntrainer::withKey("unit", 8),
+     nntrainer::withKey("weight_initializer", "xavier_uniform"),
+     nntrainer::withKey("bias_initializer", "zeros")}));
+
+  model->setProperty({nntrainer::withKey("batch_size", 1),
+                      nntrainer::withKey("model_tensor_type", "FP32-FP32")});
+
+  ASSERT_EQ(model->compile(ml::train::ExecutionMode::INFERENCE), ML_ERROR_NONE);
+  ASSERT_EQ(model->initialize(ml::train::ExecutionMode::INFERENCE),
+            ML_ERROR_NONE);
+
+  std::vector<ml::train::TensorDim> new_dims = {
+    ml::train::TensorDim({1, 1, 6, 8})};
+
+  EXPECT_NO_THROW(model->resetInputDimension(new_dims));
+
+  // input0's own dim (raw width-based shape) must stay untouched.
+  EXPECT_EQ(model->getInputDimension()[0].width(), 4u);
+  EXPECT_EQ(model->getInputDimension()[0].height(), 1u);
+}
+
 void check_sorted_graph(nntrainer::GraphCore graph,
                         std::vector<std::string> expected_layer_names) {
   int expected_graph_size = expected_layer_names.size();


### PR DESCRIPTION
## Summary
- Replaces the layer-by-layer explicit `from`/`to` step-index API (`incremental_forwarding`) across nntrainer/CausalLM layers with a `resetInputDimension()` / `updateTensorsByInputDimensions()`-driven model: each layer derives its own step width from its input tensor's own height, and `mha_core` reads the absolute KV cache write position from a shared `KVCacheManager` (with a local `cache_index` fallback) instead of receiving it as an explicit argument on every call.
- Adds `updateTensorsByInputDimensions()` support to the layers needed for this (FC, activation, embedding, MoE variants, embedding_pooling/normalize, Unary/BinaryOperation, mha_core, etc.), and wires `resetInputDimension()` into the CausalLM prefill/decode phase transitions.
- Cleans up `mha_core`'s `one_batch_incremental_forwarding()` overloads and helpers (`compute_kcaches`, `softmax_triangle`, `compute_fp16vcache_transposed`) to derive their window purely from `cache_index`/step size instead of redundant `from`/`to` parameters.
- Fixes a Gemma4-specific bug found while testing this change: `Gemma4CausalLM::allocateAndBindKVCache()` overrides the base `allocateAndBindKVCache()` (needed for per-layer variable KV cache widths) but never bound its `mha_core` layers to the shared `KVCacheManager`, so it silently fell back to a per-layer `cache_index` that isn't reset by `setKVCachePosition()` — this caused `Gemma4DifferentialTest.Q40CloseToFP32Reference` to crash with "Creating shared tensor of size bigger than tensor memory." when a single model instance was reused across prefill + generate.

## Test plan
- [x] `unittest_causallm_models` — 74/74 pass, including all 10 `Q40CloseToFP32Reference` tests (run with `NNTR_QUANTIZE_BIN` set, which are normally skipped)
- [x] `unittest_layers` — passes
- [x] Full project build via meson/ninja
- [x] clang-format-14 applied to all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)