### PR TITLE
fix: prevent EOS/EOT token leakage in CPU generation path

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -245,32 +245,45 @@ void CausalLM::registerOutputs(
 
   static const std::vector<char> puncts{',', '!', ':', ';', '?'};
   for (size_t b = 0; b < ids.size(); ++b) {
-    if (!eos_list[b]) {
+    if (eos_list[b])
+      continue;
+
+    ids_history[b * MAX_SEQ_LEN + pos] = ids[b];
+
+    const bool is_eos = std::find(EOS_TOKEN_ID.begin(), EOS_TOKEN_ID.end(),
+                                  ids[b]) != EOS_TOKEN_ID.end();
+    if (!is_eos)
       pending_ids_.push_back(static_cast<int>(ids[b]));
-      ids_history[b * MAX_SEQ_LEN + pos] = ids[b];
-      std::string decoded_str = tokenizer->Decode(pending_ids_);
 
-      if (decoded_str.empty()) {
-        continue;
-      }
+    if (pending_ids_.empty())
+      continue;
 
-      if (std::find(puncts.begin(), puncts.end(), decoded_str.back()) !=
-          puncts.end()) {
-        // last symbol is a punctuation, hold on
-      } else if (utf8stream::shouldHold(decoded_str, pending_ids_.size())) {
-      } else {
-        if (log_output && streamer_ == nullptr) {
-          std::cout << decoded_str;
-          std::cout.flush();
-        }
-        output_list[b].append(decoded_str);
-        if (streamer_ != nullptr &&
-            streamer_put(streamer_, decoded_str.c_str()) != 0) {
-          requestStop();
-        }
+    const std::string decoded_str = tokenizer->Decode(pending_ids_);
+    const bool should_hold_utf8 =
+      decoded_str.empty() ||
+      utf8stream::shouldHold(decoded_str, pending_ids_.size());
+    if (should_hold_utf8) {
+      if (is_eos)
         pending_ids_.clear();
-      }
+      continue;
     }
+
+    const bool ends_in_punctuation =
+      std::find(puncts.begin(), puncts.end(), decoded_str.back()) !=
+      puncts.end();
+    if (!is_eos && ends_in_punctuation)
+      continue;
+
+    if (log_output && streamer_ == nullptr) {
+      std::cout << decoded_str;
+      std::cout.flush();
+    }
+    output_list[b].append(decoded_str);
+    if (streamer_ != nullptr &&
+        streamer_put(streamer_, decoded_str.c_str()) != 0) {
+      requestStop();
+    }
+    pending_ids_.clear();
   }
 }
 
@@ -576,6 +589,15 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
     if (init_len < INIT_SEQ_LEN)
       registerOutputs(tokenizer, id_list, init_len, eos_list, log_output);
+
+    // Mark EOS after output registration so the sampled token remains in
+    // history while registerOutputs() suppresses it from decoded output.
+    for (unsigned int j = 0; j < BATCH_SIZE; ++j) {
+      if (std::find(EOS_TOKEN_ID.begin(), EOS_TOKEN_ID.end(), id_list[j]) !=
+          EOS_TOKEN_ID.end()) {
+        eos_list[j] = true;
+      }
+    }
   }
   // output should be deallocated after use
   for (auto &out : output) {
@@ -599,8 +621,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
+  bool all_batches_finished = std::all_of(eos_list.begin(), eos_list.end(),
+                                          [](bool is_eos) { return is_eos; });
   for (unsigned int token_generation_idx = input_len + 1;
        token_generation_idx < input_len + 1 + NUM_TO_GENERATE &&
+       !all_batches_finished &&
        !stop_requested_.load(std::memory_order_acquire);
        ++token_generation_idx) {
 
@@ -620,6 +645,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     }
     registerOutputs(tokenizer, ids_list, token_generation_idx, eos_list,
                     log_output);
+
+    // This iteration already consumed the previous input token and wrote its
+    // K/V, even when the newly sampled output token is EOS.
     ++generation_cnt;
 
     // output should be deallocated after use
@@ -635,17 +663,8 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
       }
     }
 
-    bool is_finish = true;
-    for (unsigned int j = 0; j < BATCH_SIZE; ++j) {
-      if (!eos_list[j]) {
-        is_finish = false;
-        break;
-      }
-    }
-
-    if (is_finish) {
-      break;
-    }
+    all_batches_finished = std::all_of(eos_list.begin(), eos_list.end(),
+                                       [](bool is_eos) { return is_eos; });
 
     if (stop_requested_.load(std::memory_order_acquire)) {
       break;

--- a/test/unittest/models/unittest_causallm_qwen2.cpp
+++ b/test/unittest/models/unittest_causallm_qwen2.cpp
@@ -478,6 +478,75 @@ makeDirectTinyQwen2Model(const causallm_test::TinyCausalLMFiles &files,
 }
 
 /**
+ * @brief Force a configured token sequence through the logits processor
+ * hook
+ */
+class TokenSequenceProcessor final : public causallm::LogitsProcessor {
+public:
+  explicit TokenSequenceProcessor(std::vector<unsigned int> tokens) :
+    tokens_(std::move(tokens)) {}
+
+  void process(float *logits, unsigned int vocab_size, unsigned int) override {
+    for (unsigned int i = 0; i < vocab_size; ++i)
+      logits[i] = -std::numeric_limits<float>::infinity();
+    logits[tokens_[std::min(accepted_count_, tokens_.size() - 1)]] = 100.0f;
+  }
+
+  void acceptToken(unsigned int, unsigned int) override { ++accepted_count_; }
+
+  size_t acceptedCount() const { return accepted_count_; }
+
+private:
+  std::vector<unsigned int> tokens_;
+  size_t accepted_count_ = 0;
+};
+
+/**
+ * @brief Test that EOS is hidden without changing generation accounting
+ */
+TEST(Qwen2CausalLMOutputTest, EosIsSuppressedOnlyFromDecodedOutput) {
+  TokenSequenceProcessor processor({2u, 31u});
+
+  const auto test_case = makeQwen2Case(causallm_test::makeTinyFp32DataType());
+  const auto files = causallm_test::makeTinyCausalLMFiles(
+    "Qwen2CausalLMOutputTest", "EosIsSuppressedOnlyFromDecodedOutput",
+    test_case.name);
+  auto model = makeDirectTinyQwen2Model(files, test_case);
+
+  model->initializeModel();
+  setupQwen2DeterministicWeights(*model);
+  model->setLogitsProcessor(&processor);
+
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_EQ(model->getOutputText(), "world");
+  EXPECT_EQ(model->tokenAt(1), 2u);
+  EXPECT_EQ(model->tokenAt(2), 31u);
+  EXPECT_EQ(model->getPerformanceMetrics().generation_tokens, 1u);
+}
+
+/**
+ * @brief Test that prefill EOS skips the decode stage
+ */
+TEST(Qwen2CausalLMOutputTest, PrefillEosSkipsDecodeStage) {
+  TokenSequenceProcessor processor({31u});
+
+  const auto test_case = makeQwen2Case(causallm_test::makeTinyFp32DataType());
+  const auto files = causallm_test::makeTinyCausalLMFiles(
+    "Qwen2CausalLMOutputTest", "PrefillEosSkipsDecodeStage", test_case.name);
+  auto model = makeDirectTinyQwen2Model(files, test_case);
+
+  model->initializeModel();
+  setupQwen2DeterministicWeights(*model);
+  model->setLogitsProcessor(&processor);
+
+  ASSERT_NO_THROW(model->runPrompt("hello"));
+  EXPECT_TRUE(model->getOutputText().empty());
+  EXPECT_EQ(model->tokenAt(1), 31u);
+  EXPECT_EQ(processor.acceptedCount(), 1u);
+  EXPECT_EQ(model->getPerformanceMetrics().generation_tokens, 0u);
+}
+
+/**
  * @brief Test that Transformer exposes the configured vocabulary size
  */
 TEST_P(Qwen2CausalLMTinyModelTest, TransformerReturnsConfiguredVocabSize) {


### PR DESCRIPTION
## Summary

Prevent EOS/EOT tokens such as `<turn|>` from leaking into decoded CPU-generation output, without changing token history or KV-cache/generation accounting.

## Root cause

`CausalLM::registerOutputs()` decoded every sampled token before the generation loop marked EOS. Moving the EOS-state update before `registerOutputs()` hid the token, but it also skipped `ids_history` registration and moved `generation_cnt` after the all-EOS break. The latter made `global_token_len` one cache step short because `incremental_inference()` had already consumed the previous input token in that iteration.

## Changes

- Keep EOS handling inside `registerOutputs()`'s decode/output path:
  - record EOS in `ids_history`;
  - do not add EOS itself to `pending_ids_` or decoded output;
  - flush any complete text that was pending immediately before EOS;
  - discard an incomplete UTF-8 fragment at end-of-stream.
- Update `eos_list` only after output/history registration.
- Increment `generation_cnt` before the all-EOS break, matching the cache step already completed by `incremental_inference()`.
- Add a Qwen2 regression test that forces one normal token followed by EOS and verifies:
  - decoded output contains only the normal token (`world`);
  - both the normal token and EOS remain in token history;
  - generation/cache-step accounting remains `1`.