### PR TITLE
[layers/bn][build] Fix BatchNormalization multithreaded loading & add memory-planner options

### DIFF
--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -188,6 +188,17 @@ LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 LOCAL_ARM_NEON      := true
 LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@ @ML_API_COMMON@
 LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@
+# Opt-in inference memory planner (off by default; 'auto'/'v1' = OptimizedV1).
+# The YOLOv11 inference build sets ENABLE_MEMORY_PLANNER_V3=1 on the ndk-build
+# command line; ENABLE_MEMORY_PLANNER_V2=1 selects OptimizedV2Planner.
+ifeq ($(ENABLE_MEMORY_PLANNER_V2), 1)
+LOCAL_CFLAGS        += -DENABLE_MEMORY_PLANNER_V2=1
+LOCAL_CXXFLAGS      += -DENABLE_MEMORY_PLANNER_V2=1
+endif
+ifeq ($(ENABLE_MEMORY_PLANNER_V3), 1)
+LOCAL_CFLAGS        += -DENABLE_MEMORY_PLANNER_V3=1
+LOCAL_CXXFLAGS      += -DENABLE_MEMORY_PLANNER_V3=1
+endif
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,13 @@ if get_option('enable-transformer')
   add_project_arguments('-DENABLE_TRANSFORMER=1', language: ['c', 'cpp'])
 endif
 
+_memory_planner = get_option('memory-planner')
+if _memory_planner == 'v2'
+  add_project_arguments('-DENABLE_MEMORY_PLANNER_V2=1', language: ['c', 'cpp'])
+elif _memory_planner == 'v3'
+  add_project_arguments('-DENABLE_MEMORY_PLANNER_V3=1', language: ['c', 'cpp'])
+endif
+
 warning_flags = [
   '-Wredundant-decls',
   '-Wwrite-strings',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,12 @@ option('enable-tflite-interpreter', type: 'boolean', value: true)
 option('enable-onnx-interpreter', type: 'boolean', value: false)
 option('enable-fsu', type: 'boolean', value: false)
 option('fsu-path', type: 'string', value: '')
+# Tensor memory pool planner for inference. 'auto'/'v1' keep the validated
+# built-in OptimizedV1Planner (unchanged default); 'v2' compiles in
+# OptimizedV2Planner; 'v3' compiles in OptimizedV3Planner for lower peak memory.
+# Selected per build (e.g. the YOLOv11 inference build uses 'v3').
+option('memory-planner', type: 'combo', choices: ['auto', 'v1', 'v2', 'v3'],
+       value: 'auto')
 option('test-timeout', type: 'integer', value: 90)
 option('opencl-kernel-path', type: 'string', value: 'nntrainer_opencl_kernels')
 option('enable-mmap', type: 'boolean', value: true)

--- a/nntrainer/layers/bn_layer.cpp
+++ b/nntrainer/layers/bn_layer.cpp
@@ -432,7 +432,7 @@ void BatchNormalizationLayer::read(std::ifstream &file,
       if (run_context.isGradientLastAccess(i) && trainable) {
         /// @note read optimizer variables
         for (unsigned int j = 0; j < run_context.getNumWeightOptVar(i); ++j) {
-          run_context.getWeightOptVar(i, j).read(file);
+          run_context.getWeightOptVar(i, j).read(file, start_offset);
         }
       }
     }
@@ -452,10 +452,12 @@ void BatchNormalizationLayer::read(std::ifstream &file,
           TensorDim dim = run_context.getWeight(i).getDim();
           dim.setDataType(definedWeightDataType);
           Tensor T_read(dim, true);
-          T_read.read(file);
+          T_read.setFileOffset(run_context.getWeight(i).getFileOffset());
+          T_read.read(file, start_offset, read_from_offset, file_fd);
           run_context.getWeight(i).copyData(T_read);
         } else {
-          run_context.getWeight(i).read(file, start_offset);
+          run_context.getWeight(i).read(file, start_offset, read_from_offset,
+                                        file_fd);
         }
 
         if (run_context.isMixedPrecision(i) && trainable &&
@@ -478,7 +480,7 @@ void BatchNormalizationLayer::read(ReadSource src, RunLayerContext &run_context,
       if (run_context.isGradientLastAccess(i) && trainable) {
         /// @note read optimizer variables
         for (unsigned int j = 0; j < run_context.getNumWeightOptVar(i); ++j) {
-          run_context.getWeightOptVar(i, j).read(src);
+          run_context.getWeightOptVar(i, j).read(src, start_offset);
         }
       }
     }
@@ -498,10 +500,12 @@ void BatchNormalizationLayer::read(ReadSource src, RunLayerContext &run_context,
           TensorDim dim = run_context.getWeight(i).getDim();
           dim.setDataType(definedWeightDataType);
           Tensor T_read(dim, true);
-          T_read.read(src);
+          T_read.setFileOffset(run_context.getWeight(i).getFileOffset());
+          T_read.read(src, start_offset, read_from_offset, file_fd);
           run_context.getWeight(i).copyData(T_read);
         } else {
-          run_context.getWeight(i).read(src, start_offset);
+          run_context.getWeight(i).read(src, start_offset, read_from_offset,
+                                        file_fd);
         }
 
         if (run_context.isMixedPrecision(i) && trainable &&

--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -909,12 +909,19 @@ void Manager::flushCacheExcept(unsigned int order) {
 void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
                                  unsigned int end) {
   if (enable_optimizations) {
-    if (exec_mode == ExecutionMode::INFERENCE && enable_fsu) {
-      //@todo change V3 and validate
-      pool.finalize(OptimizedV1Planner(), start, end);
-    } else {
-      pool.finalize(OptimizedV1Planner(), start, end);
-    }
+    /// The memory planner is selected at compile time via
+    /// -DENABLE_MEMORY_PLANNER_V2 / -DENABLE_MEMORY_PLANNER_V3 (meson
+    /// -Dmemory-planner=v2/v3, or ndk-build ENABLE_MEMORY_PLANNER_V2/V3=1).
+    /// The default (and validated) planner is OptimizedV1Planner.
+    /// @note OptimizedV2/V3Planner produce lower peak memory layouts but are
+    /// not yet validated for correctness on all models; opt-in only.
+#if defined(ENABLE_MEMORY_PLANNER_V3)
+    pool.finalize(OptimizedV3Planner(), start, end);
+#elif defined(ENABLE_MEMORY_PLANNER_V2)
+    pool.finalize(OptimizedV2Planner(), start, end);
+#else
+    pool.finalize(OptimizedV1Planner(), start, end);
+#endif
   } else {
     pool.finalize(BasicPlanner(), start, end);
   }


### PR DESCRIPTION
- **BatchNormalization Loading Fix**: Fixed weight file offset loading corruption in `BatchNormalizationLayer::read`
under non-FP32 weight types during multithreaded initialization. It copies the weight's `file_offset` to `T_read` and
passes proper offset arguments (`start_offset`, `read_from_offset`, `file_fd`) to the read call.

- **Memory-Planner Options**: Added optional compilation choices for memory planners (`v2`/`v3` OptimizedPlanner) to
Meson and Android JNI build configurations.

### Self evaluation:
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>