### PR TITLE
[x86] refactor: Extract shared AVX2 helpers into avx2_internal.h

### DIFF
--- a/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_impl.cpp
@@ -13,77 +13,23 @@
  */
 
 #include "avx2_impl.h"
+#include "avx2_internal.h"
 #include <array>
-#if __has_include(<bit>)
-#include <bit>
-#endif
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <fallback_internal.h>
 #include <fp16.h>
 #include <immintrin.h>
 #include <limits>
-#if __has_include(<numbers>)
-#include <numbers>
-#endif
-#include <type_traits>
-#if __has_include(<version>)
-#include <version>
-#endif
-#include <fallback_internal.h>
 #include <nntrainer_error.h>
 #include <thread_manager.h>
+#include <type_traits>
 #include <util_func.h>
 #include <vector>
 
 #include "nntr_ggml_impl_common.h"
-
-#if !defined(__has_constexpr_builtin)
-#define __has_constexpr_builtin(x) (0)
-#endif
-
-#if !defined(__has_cpp_attribute)
-#define __has_cpp_attribute(x) (0)
-#endif
-
-// VECTORCALL calling-conv (default for x86_64-linux-gnu)
-#if _MSC_VER >= 1700
-#define _nnt_CC_VECTORCALL __vectorcall
-#else
-#define _nnt_CC_VECTORCALL
-#endif
-
-// Flatten attribute
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
-#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
-#else
-#define _nnt_ATTR_FLATTEN
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::noinline)
-#define _nnt_ATTR_NOINLINE [[msvc::noinline]]
-#elif __has_cpp_attribute(gnu::flatten)
-// clang, g++
-#define _nnt_ATTR_NOINLINE [[gnu::noinline]]
-#else
-#define _nnt_ATTR_NOINLINE
-#endif
-
-#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
-#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
-#elif __has_cpp_attribute(gnu::always_inline)
-#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
-#endif
-
-#if __has_cpp_attribute(unikely)
-#define UNLIKELY [[unlikely]]
-#else
-#define UNLIKELY
-#endif
 
 #if !defined(_MSC_VER) && !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wattributes"
@@ -95,238 +41,16 @@
 #define RESTRICT
 #endif
 
-namespace {
-
-template <typename To_, typename From_>
-constexpr inline bool concept17_BinaryCastable =
-  sizeof(To_) == sizeof(From_) &&
-  std::is_trivially_copyable_v<From_> &&std::is_trivially_copyable_v<To_>;
-
-template <class To_, class From_>
-auto compat_bit_cast(const From_ &src) noexcept
-  -> std::enable_if_t<concept17_BinaryCastable<To_, From_>, To_> {
-#if __cpp_lib_bit_cast >= 201806L
-  return std::bit_cast<To_>(src);
-#else
-  To_ dst;
-  std::memcpy(&dst, &src, sizeof(To_));
-  return dst;
-#endif
-}
-
-[[nodiscard]] constexpr inline unsigned
-constexpr_popcount(uint32_t v) noexcept {
-#if __cpp_lib_bitops >= 201907L
-  return std::popcount(v);
-#else
-  // Popcount via bit-hack
-  v = v - ((v >> 1) & 0x55555555);                // reuse input as temporary
-  v = (v & 0x33333333) + ((v >> 2) & 0x33333333); // temp
-  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24; // count
-  return c;
-#endif
-}
-
-template <unsigned I_>
-constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
-
-namespace numbers {
-
-#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
-using std::numbers::ln2_v;
-using std::numbers::log2e_v;
-#else
-template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
-
-template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
-#endif
-} // namespace numbers
-
-constexpr inline float EXP_ARG_MIN = -87.0;
-constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
-
-// @brief Precalculated lookup table for 2^x calculation
-template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
-          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-struct Exp2Table {
-
-  constexpr static inline auto MANTISSA_BITS =
-    std::numeric_limits<Float_>::digits - 1;
-
-#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
-  [[nodiscard]] static consteval auto calculate() noexcept {
-    std::array<Ty_, N_> t;
-    for (unsigned i = 0; i < N_; ++i)
-      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
-             ((i << MANTISSA_BITS) / N_);
-    return t;
-  }
-#endif
-};
-
-#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
-
-// @brief Precalculated lookup table for 2^x calculation when we don't have
-// constexpr math functions
-template <> struct Exp2Table<8, uint32_t, float> {
-  [[nodiscard]] static constexpr auto calculate() noexcept {
-    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
-                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
-                                 0x3f7744fdU, 0x3f7ac0c7U};
-    return t;
-  }
-};
-
-#endif
-
-template <unsigned N_> // requires PowerOfTwo<N_>
-alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
-
-// Scalar version of expf() approximation with 3-th deg polynominal of
-// fractional part
-//
-// The error with regards to std::expf less than 5e-6
-// It is valid in range [-87, +88.37) - not handling +INF, NaN etc.
-// The function domain is clamped to valid function range.
-//
-// The strategy picked is to approximate exp as 2^K*2^F
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-[[nodiscard]] _nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline float
-approx_exp_exp2_lookup(float x) noexcept {
-  constexpr static unsigned N_MASK = uint32_t(N_ - 1U);
-  constexpr static unsigned FLT_MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1U;
-
-  x = std::max(x, EXP_ARG_MIN);
-  x *= float(0x1.0p1 / numbers::ln2_v<double> * N_);
-  x = std::min(x, float(EXP_ARG_MAX / numbers::ln2_v<double> * N_));
-
-  // Round nearest and convert integer part to an int (std::modf)
-  // NB: This way doesn't handle ties even.
-  auto x_int = x + 0x1.8p23f;
-  auto x_uint = compat_bit_cast<uint32_t>(x_int);
-  x_int -= 0x1.8p23f;
-  auto x_frac = x - x_int;
-
-  auto s_int = exp2_table_v<N_>[x_uint & N_MASK];
-  auto x_uint_shifted = x_uint
-                        << (FLT_MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_int_2 = s_int + x_uint_shifted;
-  auto s = compat_bit_cast<float>(s_int_2);
-
-  // Polynominal of form C0*x^3 + C1*x^2 + C2*x^1 + 1.0
-  static constexpr float poly_4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                     0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                     0x1.62e42ff0c52d6p-1f / N_};
-
-  auto q0 = std::fma(x_frac, poly_4[0], poly_4[1]);
-  auto x_frac_pow2 = x_frac * x_frac;
-  auto q2 = x_frac * poly_4[2]; // not adding +1.0
-
-  x = std::fma(q0, x_frac_pow2, q2);
-
-  return std::fma(x, s, s); // NB: (handles (x+1) by addition of s)
-}
-
-// Vectorized version of above
-template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
-avx2_approx_exp_e2lookup(__m256 xs) noexcept {
-
-  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
-  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
-  constexpr static unsigned MANTISSA_BITS =
-    std::numeric_limits<float>::digits - 1;
-
-  // Ensure arg in range [exp_arg_min, exp_arg_max]
-  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
-  // Would clamp to EXP_ARG_MAX but we move it after multiplication for IPC:
-  // xs = _mm256_min_ps(xs, _mm256_set1_ps(EXP_ARG_MAX));
-
-  xs =
-    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
-  // Clamp EXP_ARG_MAX after multiply
-  xs = _mm256_min_ps(
-    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
-
-  // Mostly equivalent to, doesn't round ties to even
-  // auto xs_int = _mm256_round_ps(xs, _MM_FROUND_TO_NEAREST_INT |
-  // _MM_FROUND_NO_EXC); auto xs_int_as_u32 = _mm256_cvtps_epi32(xs_int);
-  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
-  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
-  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
-
-  // Calculate fractional part
-  auto xs_frac = _mm256_sub_ps(xs, xs_int);
-  // Indices for lookup (modulo N_)
-  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
-
-  __m256i s_ints;
-
-  // Lookup e^xs_int s factor
-  if constexpr (N_ == 8) {
-    // Lookup by vector permute
-    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
-    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
-  } else {
-    // Falback for not fitting number of vector elements
-    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
-  }
-
-  auto xs_uint_shifted = _mm256_slli_epi32(
-    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
-  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
-  auto s_floats = _mm256_castsi256_ps(s_ints_2);
-
-  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
-                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
-                                      0x1.62e42ff0c52d6p-1f / N_};
-
-  const auto C0 = _mm256_set1_ps(poly_d4[0]);
-  const auto C1 = _mm256_set1_ps(poly_d4[1]);
-  const auto C2 = _mm256_set1_ps(poly_d4[2]);
-
-  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
-  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
-  auto qs2 = _mm256_mul_ps(xs_frac, C2);
-
-  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
-
-  return _mm256_fmadd_ps(xs, s_floats, s_floats);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_negate_ps(__m256 x) noexcept -> __m256 {
-  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
-  const auto UNDEF = _mm256_undefined_si256();
-  const auto sign_bit =
-    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
-  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
-  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
-  return neg_x;
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
-  auto neg_x = avx2_negate_ps(x);
-  auto inv_sigmoid =
-    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-
-_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN auto _nnt_CC_VECTORCALL
-avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
-  auto alpha_x = _mm256_mul_ps(alpha, x);
-  auto neg_alpha_x = avx2_negate_ps(alpha_x);
-  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
-                                   _mm256_set1_ps(1.0f));
-  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
-  return _mm256_mul_ps(swiglu_nonscaled, s);
-}
-} // namespace
-
 namespace nntrainer::avx2 {
+
+// Shared SIMD primitives defined in avx2_internal.h that this file depends on.
+using nntrainer::avx2::internal::avx2_approx_swiglu;
+using nntrainer::avx2::internal::avx2_approx_swiglu_alpha;
+using nntrainer::avx2::internal::exp256_ps;
+using nntrainer::avx2::internal::hsum_avx;
+using nntrainer::avx2::internal::poly_gelu_erf_avx2;
+using nntrainer::avx2::internal::poly_gelu_tanh_avx2;
+using nntrainer::avx2::internal::rcp_ps;
 
 /**
  * @brief struct of q4_0x8 block
@@ -701,16 +425,27 @@ static inline void convert_q4_0x8_noshuffle(const void *src,
 
 // ================== wrappers for your K,N combinations ==================
 // K = 3072 (UNIT = 768)
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=98304
+ */
 void convert_q4_0x8_shuffle_K3072_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = (N*8)/UNIT = 1024
   convert_q4_0x8_noshuffle<768, 1024>(src, d_out, qs_out);
 }
+
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=36864
+ */
 void convert_q4_0x8_shuffle_K3072_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<768, 384>(src, d_out, qs_out);
 }
+
+/**
+ * @brief convert_q4_0x8_shuffle for K=3072 N=3072
+ */
 void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 32
@@ -718,16 +453,27 @@ void convert_q4_0x8_shuffle_K3072_N3072(const void *src, uint16_t *d_out,
 }
 
 // K = 8192 (UNIT = 2048)
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=98304
+ */
 void convert_q4_0x8_shuffle_K8192_N98304(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 384
   convert_q4_0x8_noshuffle<2048, 384>(src, d_out, qs_out);
 }
+
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=36864
+ */
 void convert_q4_0x8_shuffle_K8192_N36864(const void *src, uint16_t *d_out,
                                          uint8_t *qs_out) {
   // groups = 144
   convert_q4_0x8_noshuffle<2048, 144>(src, d_out, qs_out);
 }
+
+/**
+ * @brief convert_q4_0x8_shuffle for K=8192 N=3072
+ */
 void convert_q4_0x8_shuffle_K8192_N3072(const void *src, uint16_t *d_out,
                                         uint8_t *qs_out) {
   // groups = 12
@@ -993,122 +739,6 @@ void swiglu(const unsigned int N, float *X, const float *Y, const float *Z,
   _mm_setcsr(oldcsr);
 }
 
-#define gelu_start_tanh -4.38086284326899f
-#define gelu_end_tanh 4.38086284326899f
-
-#define tanh_c_gelu_p0 5.91303808e-6f
-#define tanh_c_gelu_p1 5.00000000e-1f
-#define tanh_c_gelu_p2 3.98865869e-1f
-#define tanh_c_gelu_p4 -6.66574676e-2f
-#define tanh_c_gelu_p6 1.00712610e-2f
-#define tanh_c_gelu_p8 -1.19336340e-3f
-#define tanh_c_gelu_p10 1.09543224e-4f
-#define tanh_c_gelu_p12 -7.55788500e-6f
-#define tanh_c_gelu_p14 3.73374142e-7f
-#define tanh_c_gelu_p16 -1.23162678e-8f
-#define tanh_c_gelu_p18 2.40940960e-10f
-#define tanh_c_gelu_p20 -2.10237709e-12f
-
-#define gelu_start_erf -4.59373833108583f
-#define gelu_end_erf 4.59373833108583f
-
-#define erf_c_gelu_p0 8.70757509e-06f
-#define erf_c_gelu_p1 5.00000000e-1f
-#define erf_c_gelu_p2 3.98833088e-01f
-#define erf_c_gelu_p4 -6.62633808e-02f
-#define erf_c_gelu_p6 9.78776282e-03f
-#define erf_c_gelu_p8 -1.10798998e-03f
-#define erf_c_gelu_p10 9.51056006e-05f
-#define erf_c_gelu_p12 -6.04633051e-06f
-#define erf_c_gelu_p14 2.73076070e-07f
-#define erf_c_gelu_p16 -8.20707325e-09f
-#define erf_c_gelu_p18 1.46115955e-10f
-#define erf_c_gelu_p20 -1.16009840e-12f
-
-static inline __m256 poly_gelu_tanh_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
-
-static inline __m256 poly_gelu_erf_avx2(__m256 x) {
-  const __m256 x2 = _mm256_mul_ps(x, x);
-
-  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
-  y = _mm256_mul_ps(x2, y);
-  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
-  y = _mm256_mul_ps(x2, y);
-
-  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
-  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
-
-  y = _mm256_add_ps(y, z);
-
-  const __m256 gt_start =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
-  const __m256 le_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
-  const __m256 gt_end =
-    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
-
-  y = _mm256_and_ps(y, gt_start);
-  y = _mm256_and_ps(y, le_end);
-  __m256 x_hi = _mm256_and_ps(x, gt_end);
-
-  return _mm256_add_ps(y, x_hi);
-}
-
 void tanh_gelu_v2(const unsigned int N, const float *X, float *Y) {
   unsigned int i = 0;
 
@@ -1228,109 +858,7 @@ void ele_add(const unsigned int N, const float *X, const float *Y, float *Z,
   }
 }
 
-static inline __m256 exp256_ps(__m256 x) {
-  /*  Low-Precision Version I*/
-  // const __m256 c1 = _mm256_set1_ps(12102203.0f);
-  // const __m256 c2 = _mm256_set1_ps(1065353216.0f);
-  // __m256 fx = _mm256_add_ps(_mm256_mul_ps(x, c1),c2);
-  // return _mm256_castsi256_ps(_mm256_cvtps_epi32(fx));
-
-  /* Low-Precision Version II*/
-  /*    const __m256 ln2 = _mm256_set1_ps(0.69314718056f);
-    const __m256 inv_ln2 = _mm256_set1_ps(1.44269504089f); // 1 / ln(2)
-
-    // Range reduction: x = n * ln2 + r,  where n is integer and |r| <= ln2/2
-    __m256 fx = _mm256_mul_ps(x, inv_ln2);
-    fx = _mm256_round_ps(fx, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
-    __m256i emm0 = _mm256_cvtps_epi32(fx);
-
-    __m256 tmp = _mm256_mul_ps(fx, ln2);
-    __m256 r = _mm256_sub_ps(x, tmp);
-
-    // Compute polynomial approximation of exp(r)
-    const __m256 c1 = _mm256_set1_ps(1.9875691500E-4f);
-    const __m256 c2 = _mm256_set1_ps(1.3981999507E-3f);
-    const __m256 c3 = _mm256_set1_ps(8.3334519073E-3f);
-    const __m256 c4 = _mm256_set1_ps(4.1665795894E-2f);
-    const __m256 c5 = _mm256_set1_ps(1.6666665459E-1f);
-    const __m256 c6 = _mm256_set1_ps(5.0000001201E-1f);
-
-  //  __m256 r2 = _mm256_mul_ps(r, r);
-  //  __m256 r3 = _mm256_mul_ps(r2, r);
-  //  __m256 r4 = _mm256_mul_ps(r2, r2);
-
-    __m256 y = _mm256_fmadd_ps(c1, r, c2);
-    y = _mm256_fmadd_ps(y, r, c3);
-    y = _mm256_fmadd_ps(y, r, c4);
-    y = _mm256_fmadd_ps(y, r, c5);
-    y = _mm256_fmadd_ps(y, r, c6);
-    y = _mm256_fmadd_ps(y, r, _mm256_set1_ps(1.0f));
-
-    // Reconstruct exp(x) = 2^n * exp(r)
-    emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-    emm0 = _mm256_slli_epi32(emm0, 23);
-    __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-    return _mm256_mul_ps(y, pow2n);
-  */
-  /* Low-Precision Versino III */
-  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f); // 1 / ln(2)
-  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);     // ln(2)
-
-  // Clamp input to range to prevent overflow/underflow
-  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);  // log(FLT_MAX)
-  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f); // log(FLT_MIN)
-  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
-
-  // Range reduction: x = n * ln2 + r
-  __m256 fx = _mm256_mul_ps(x, LOG2EF); // x * (1/ln(2))
-  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
-
-  __m256 tmp = _mm256_mul_ps(fx, LN2); // n * ln(2)
-  __m256 r = _mm256_sub_ps(x, tmp);    // r = x - n * ln2
-
-  // Compute exp(r) using 10th-order polynomial (Horner's method)
-  const __m256 c0 = _mm256_set1_ps(1.0f);
-  const __m256 c1 = _mm256_set1_ps(1.0f);
-  const __m256 c2 = _mm256_set1_ps(0.5f);
-  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
-  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
-  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
-  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
-  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
-  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
-  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
-  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
-
-  __m256 y = c10;
-  y = _mm256_fmadd_ps(y, r, c9);
-  y = _mm256_fmadd_ps(y, r, c8);
-  y = _mm256_fmadd_ps(y, r, c7);
-  y = _mm256_fmadd_ps(y, r, c6);
-  y = _mm256_fmadd_ps(y, r, c5);
-  y = _mm256_fmadd_ps(y, r, c4);
-  y = _mm256_fmadd_ps(y, r, c3);
-  y = _mm256_fmadd_ps(y, r, c2);
-  y = _mm256_fmadd_ps(y, r, c1);
-  y = _mm256_fmadd_ps(y, r, c0); // final y = (((...r+...)*r+...)*r + 1)
-
-  // Reconstruct exp(x) = 2^n * exp(r)
-  __m256i emm0 = _mm256_cvtps_epi32(fx);
-  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
-  emm0 = _mm256_slli_epi32(emm0, 23);
-  __m256 pow2n = _mm256_castsi256_ps(emm0);
-
-  return _mm256_mul_ps(y, pow2n);
-}
-
-static inline __m256 rcp_ps(__m256 x) {
-  // Use Newton-Raphson method to enhance accuracy
-  // x_n+1 = x_n * (2 - x_0 * x_n)
-  __m256 rcp = _mm256_rcp_ps(x);
-  __m256 two = _mm256_set1_ps(2.0f);
-  // rcp * (2 - x * rcp)
-  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
-}
+// exp256_ps and rcp_ps are now in avx2_internal.h
 
 static void softmax_row_inplace(float *qk_out, size_t start_row, size_t end_row,
                                 size_t num_heads) {
@@ -1629,11 +1157,10 @@ void compute_fp16vcache_fp32_transposed(int row_num, const float *in,
   for (int n = head_start; n < actual_head_end; ++n) {
     int rem = head_dim % 8;
 
-    /* Declaration: std::vector<__m256> sumVec(num_blocks * gqa_size,
-     * _mm256_setzero_ps()); caused warning: ignoring attributes on template
-     * argument ‘__m256’ [-Wignored-attributes].
-     * So it is implemented that way.
-     */
+    // Declaration: std::vector<__m256> sumVec(num_blocks * gqa_size,
+    // _mm256_setzero_ps()); caused warning: ignoring attributes on template
+    // argument ‘__m256’ [-Wignored-attributes].
+    // So it is implemented that way.
     for (int i = 0; i < num_blocks * gqa_size; i++) {
       sumVec[i] = _mm256_setzero_ps();
     }
@@ -1843,16 +1370,7 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
   }
 }
 
-static float hsum_avx(__m256 v) {
-  __m128 vlow = _mm256_castps256_ps128(v);
-  __m128 vhigh = _mm256_extractf128_ps(v, 1);
-  vlow = _mm_add_ps(vlow, vhigh);
-  __m128 shuf = _mm_movehdup_ps(vlow);
-  __m128 sums = _mm_add_ps(vlow, shuf);
-  shuf = _mm_movehl_ps(shuf, sums);
-  sums = _mm_add_ss(sums, shuf);
-  return _mm_cvtss_f32(sums);
-}
+// hsum_avx is now in avx2_internal.h
 
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,

--- a/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
+++ b/nntrainer/tensor/cpu_backend/x86/avx2_internal.h
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ *
+ * @file   avx2_internal.h
+ * @date   19 Jul 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Donghyeon Jeong <dhyeon.jeong@samsung.com>
+ * @author Sungsik Kong <ss.kong@samsung.com>
+ * @author YongHyeon02 <dyddyd8574@snu.ac.kr>
+ * @bug    No known bugs except for NYI items
+ * @brief  Shared AVX2 SIMD helper primitives extracted from avx2_impl.cpp,
+ *         reused by the x86 FP16 kernels
+ */
+
+#ifndef __AVX2_INTERNAL_H_
+#define __AVX2_INTERNAL_H_
+#ifdef __cplusplus
+
+#include <array>
+#if __has_include(<bit>)
+#include <bit>
+#endif
+#include <cmath>
+#include <cstdint>
+#include <immintrin.h>
+#include <limits>
+#if __has_include(<numbers>)
+#include <numbers>
+#endif
+#include <type_traits>
+#if __has_include(<version>)
+#include <version>
+#endif
+
+#if !defined(__has_constexpr_builtin)
+#define __has_constexpr_builtin(x) (0)
+#define _nnt_UNDEF_HAS_CONSTEXPR_BUILTIN
+#endif
+
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) (0)
+#define _nnt_UNDEF_HAS_CPP_ATTRIBUTE
+#endif
+
+// VECTORCALL calling-conv (default for x86_64-linux-gnu)
+#if _MSC_VER >= 1700
+#define _nnt_CC_VECTORCALL __vectorcall
+#else
+#define _nnt_CC_VECTORCALL
+#endif
+
+// Flatten attribute
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::flatten)
+#define _nnt_ATTR_FLATTEN [[msvc::flatten]]
+#elif __has_cpp_attribute(gnu::flatten)
+#define _nnt_ATTR_FLATTEN [[gnu::flatten]]
+#else
+#define _nnt_ATTR_FLATTEN
+#endif
+
+#if _MSC_VER >= 1700 || __has_cpp_attribute(msvc::forceinline)
+#define _nnt_ATTR_ALWAYS_INLINE [[msvc::forceinline]]
+#elif __has_cpp_attribute(gnu::always_inline)
+#define _nnt_ATTR_ALWAYS_INLINE [[gnu::always_inline]]
+#else
+#define _nnt_ATTR_ALWAYS_INLINE
+#endif
+
+#if !defined(_MSC_VER) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+namespace nntrainer::avx2::internal {
+
+// --- popcount / power-of-two helpers ---
+
+/**
+ * @brief constexpr population count (number of set bits)
+ * @param[in] v value to count bits of
+ * @return number of set bits in v
+ */
+[[nodiscard]] constexpr inline unsigned
+constexpr_popcount(uint32_t v) noexcept {
+#if __cpp_lib_bitops >= 201907L
+  return std::popcount(v);
+#else
+  v = v - ((v >> 1) & 0x55555555);
+  v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+  auto c = (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+  return c;
+#endif
+}
+
+/** @brief true when I_ is a power of two (C++17 stand-in for a concept) */
+template <unsigned I_>
+constexpr inline bool concept17_PowerOfTwo = (constexpr_popcount(I_) == 1);
+
+/** @brief ln2/log2e math constants with a pre-C++20 fallback */
+namespace numbers {
+#if __has_include(<numbers>) && __cpp_lib_math_constants >= 201907L
+using std::numbers::ln2_v;
+using std::numbers::log2e_v;
+#else
+template <typename Float_> constexpr inline auto ln2_v = Float_{M_LN2};
+template <typename Float_> constexpr inline auto log2e_v = Float_{M_LOG2E};
+#endif
+} // namespace numbers
+
+// --- Exp constants ---
+
+constexpr inline float EXP_ARG_MIN = -87.0;
+constexpr inline float EXP_ARG_MAX = +88.3762626647949f;
+
+// --- Exp2 lookup table ---
+
+/** @brief Exp2 lookup table for fast vectorized exponential approximation */
+template <unsigned N_, typename Ty_ = uint32_t, typename Float_ = float,
+          typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+struct Exp2Table {
+  constexpr static inline auto MANTISSA_BITS =
+    std::numeric_limits<Float_>::digits - 1;
+
+#if __cpp_consteval >= 201811L && __has_constexpr_builtin(__builtin_exp2)
+  /**
+   * @brief build the N_-entry exp2 correction table at compile time
+   * @return std::array<Ty_, N_> of biased exp2 mantissa entries
+   */
+  [[nodiscard]] static consteval auto calculate() noexcept {
+    std::array<Ty_, N_> t;
+    for (unsigned i = 0; i < N_; ++i)
+      t[i] = std::bit_cast<Ty_>(std::exp2(Float_{1.0} * i / N_)) -
+             ((i << MANTISSA_BITS) / N_);
+    return t;
+  }
+#endif
+};
+
+#if !__has_constexpr_builtin(__builtin_exp2) || !(__cpp_consteval >= 201811L)
+/** @brief Exp2 lookup table explicit specialization for 8-entry float table on
+ * platforms lacking consteval */
+template <> struct Exp2Table<8, uint32_t, float> {
+  /**
+   * @brief precomputed 8-entry exp2 correction table
+   * @return std::array<uint32_t, 8> of biased exp2 mantissa entries
+   */
+  [[nodiscard]] static constexpr auto calculate() noexcept {
+    std::array<uint32_t, 8> t = {0x3f800000U, 0x3f7b95c2U, 0x3f7837f0U,
+                                 0x3f75fed7U, 0x3f7504f3U, 0x3f75672aU,
+                                 0x3f7744fdU, 0x3f7ac0c7U};
+    return t;
+  }
+};
+#endif
+
+/** @brief materialized exp2 lookup table, aligned for vector loads */
+template <unsigned N_>
+alignas(__m256) inline constexpr auto exp2_table_v = Exp2Table<N_>::calculate();
+
+// --- Vectorized exp (lookup-based, used by swiglu) ---
+
+/**
+ * @brief fast vectorized exp(x) approximation via an N_-entry exp2 lookup
+ * @param[in] xs 8 packed float arguments, clamped to [EXP_ARG_MIN, EXP_ARG_MAX]
+ * @return 8 packed approximations of exp(xs)
+ */
+template <unsigned N_, typename = std::enable_if_t<concept17_PowerOfTwo<N_>>>
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_exp_e2lookup(__m256 xs) noexcept {
+  constexpr static uint32_t N_MASK = uint32_t(N_ - 1U);
+  alignas(64) constexpr static auto EXP2_TBL = exp2_table_v<N_>;
+  constexpr static unsigned MANTISSA_BITS =
+    std::numeric_limits<float>::digits - 1;
+
+  xs = _mm256_max_ps(xs, _mm256_set1_ps(EXP_ARG_MIN));
+  xs =
+    _mm256_mul_ps(xs, _mm256_set1_ps(float(1.0 / numbers::ln2_v<double> * N_)));
+  xs = _mm256_min_ps(
+    xs, _mm256_set1_ps(float(EXP_ARG_MAX / numbers::ln2_v<double> * N_)));
+
+  auto xs_int = _mm256_add_ps(xs, _mm256_set1_ps(0x1.8p23f));
+  auto xs_int_as_u32 = _mm256_castps_si256(xs_int);
+  xs_int = _mm256_sub_ps(xs_int, _mm256_set1_ps(0x1.8p23f));
+
+  auto xs_frac = _mm256_sub_ps(xs, xs_int);
+  auto exp2_idxs = _mm256_and_si256(xs_int_as_u32, _mm256_set1_epi32(N_MASK));
+
+  __m256i s_ints;
+  if constexpr (N_ == 8) {
+    auto tbl = _mm256_load_si256((__m256i *)EXP2_TBL.data());
+    s_ints = _mm256_permutevar8x32_epi32(tbl, exp2_idxs);
+  } else {
+    s_ints = _mm256_i32gather_epi32(EXP2_TBL.data(), exp2_idxs, 1);
+  }
+
+  auto xs_uint_shifted = _mm256_slli_epi32(
+    xs_int_as_u32, MANTISSA_BITS - constexpr_popcount(N_MASK));
+  auto s_ints_2 = _mm256_add_epi32(s_ints, xs_uint_shifted);
+  auto s_floats = _mm256_castsi256_ps(s_ints_2);
+
+  static constexpr float poly_d4[] = {0x1.c6af84b912394p-5f / N_ / N_ / N_,
+                                      0x1.ebfce50fac4f3p-3f / N_ / N_,
+                                      0x1.62e42ff0c52d6p-1f / N_};
+
+  const auto C0 = _mm256_set1_ps(poly_d4[0]);
+  const auto C1 = _mm256_set1_ps(poly_d4[1]);
+  const auto C2 = _mm256_set1_ps(poly_d4[2]);
+
+  auto qs0 = _mm256_fmadd_ps(xs_frac, C0, C1);
+  auto xs_frac_pow2 = _mm256_mul_ps(xs_frac, xs_frac);
+  auto qs2 = _mm256_mul_ps(xs_frac, C2);
+
+  xs = _mm256_fmadd_ps(qs0, xs_frac_pow2, qs2);
+
+  return _mm256_fmadd_ps(xs, s_floats, s_floats);
+}
+
+// --- Negate ---
+
+/**
+ * @brief negate 8 packed floats by flipping their sign bits
+ * @param[in] x 8 packed floats
+ * @return -x lanewise
+ */
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_negate_ps(__m256 x) noexcept -> __m256 {
+  constexpr auto SIGN_SHIFT = sizeof(float) * 8 - 1;
+  const auto UNDEF = _mm256_undefined_si256();
+  const auto sign_bit =
+    _mm256_slli_epi32(_mm256_cmpeq_epi16(UNDEF, UNDEF), SIGN_SHIFT);
+  auto flt_sign_bit = _mm256_castsi256_ps(sign_bit);
+  auto neg_x = _mm256_xor_ps(x, flt_sign_bit);
+  return neg_x;
+}
+
+// --- SwiGLU helpers ---
+
+/**
+ * @brief vectorized swiglu approximation: x * sigmoid(x) * s
+ * @param[in] x 8 packed gate values
+ * @param[in] s 8 packed multiplier values
+ * @return 8 packed swiglu results
+ */
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu(__m256 x, __m256 s) noexcept -> __m256 {
+  auto neg_x = avx2_negate_ps(x);
+  auto inv_sigmoid =
+    _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_x), _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+/**
+ * @brief vectorized swiglu approximation with slope: x * sigmoid(alpha * x) * s
+ * @param[in] x 8 packed gate values
+ * @param[in] s 8 packed multiplier values
+ * @param[in] alpha 8 packed sigmoid slope values
+ * @return 8 packed swiglu results
+ */
+_nnt_ATTR_ALWAYS_INLINE _nnt_ATTR_FLATTEN inline auto _nnt_CC_VECTORCALL
+avx2_approx_swiglu_alpha(__m256 x, __m256 s, __m256 alpha) noexcept -> __m256 {
+  auto alpha_x = _mm256_mul_ps(alpha, x);
+  auto neg_alpha_x = avx2_negate_ps(alpha_x);
+  auto inv_sigmoid = _mm256_add_ps(avx2_approx_exp_e2lookup<8>(neg_alpha_x),
+                                   _mm256_set1_ps(1.0f));
+  auto swiglu_nonscaled = _mm256_div_ps(x, inv_sigmoid);
+  return _mm256_mul_ps(swiglu_nonscaled, s);
+}
+
+// --- exp256_ps (used by softmax) ---
+
+/**
+ * @brief vectorized exp(x) via polynomial approximation (used by softmax)
+ * @param[in] x 8 packed float arguments
+ * @return 8 packed approximations of exp(x)
+ */
+inline __m256 exp256_ps(__m256 x) {
+  const __m256 LOG2EF = _mm256_set1_ps(1.44269504088896341f);
+  const __m256 LN2 = _mm256_set1_ps(0.6931471805599453f);
+
+  const __m256 max_x = _mm256_set1_ps(88.3762626647949f);
+  const __m256 min_x = _mm256_set1_ps(-88.3762626647949f);
+  x = _mm256_max_ps(min_x, _mm256_min_ps(max_x, x));
+
+  __m256 fx = _mm256_mul_ps(x, LOG2EF);
+  fx = _mm256_floor_ps(_mm256_add_ps(fx, _mm256_set1_ps(0.5f)));
+
+  __m256 tmp = _mm256_mul_ps(fx, LN2);
+  __m256 r = _mm256_sub_ps(x, tmp);
+
+  const __m256 c0 = _mm256_set1_ps(1.0f);
+  const __m256 c1 = _mm256_set1_ps(1.0f);
+  const __m256 c2 = _mm256_set1_ps(0.5f);
+  const __m256 c3 = _mm256_set1_ps(1.0f / 6.0f);
+  const __m256 c4 = _mm256_set1_ps(1.0f / 24.0f);
+  const __m256 c5 = _mm256_set1_ps(1.0f / 120.0f);
+  const __m256 c6 = _mm256_set1_ps(1.0f / 720.0f);
+  const __m256 c7 = _mm256_set1_ps(1.0f / 5040.0f);
+  const __m256 c8 = _mm256_set1_ps(1.0f / 40320.0f);
+  const __m256 c9 = _mm256_set1_ps(1.0f / 362880.0f);
+  const __m256 c10 = _mm256_set1_ps(1.0f / 3628800.0f);
+
+  __m256 y = c10;
+  y = _mm256_fmadd_ps(y, r, c9);
+  y = _mm256_fmadd_ps(y, r, c8);
+  y = _mm256_fmadd_ps(y, r, c7);
+  y = _mm256_fmadd_ps(y, r, c6);
+  y = _mm256_fmadd_ps(y, r, c5);
+  y = _mm256_fmadd_ps(y, r, c4);
+  y = _mm256_fmadd_ps(y, r, c3);
+  y = _mm256_fmadd_ps(y, r, c2);
+  y = _mm256_fmadd_ps(y, r, c1);
+  y = _mm256_fmadd_ps(y, r, c0);
+
+  __m256i emm0 = _mm256_cvtps_epi32(fx);
+  emm0 = _mm256_add_epi32(emm0, _mm256_set1_epi32(127));
+  emm0 = _mm256_slli_epi32(emm0, 23);
+  __m256 pow2n = _mm256_castsi256_ps(emm0);
+
+  return _mm256_mul_ps(y, pow2n);
+}
+
+// --- rcp_ps (Newton-Raphson reciprocal) ---
+
+/**
+ * @brief vectorized reciprocal 1/x refined with one Newton-Raphson step
+ * @param[in] x 8 packed floats
+ * @return 8 packed approximations of 1/x
+ */
+inline __m256 rcp_ps(__m256 x) {
+  __m256 rcp = _mm256_rcp_ps(x);
+  __m256 two = _mm256_set1_ps(2.0f);
+  return _mm256_mul_ps(rcp, _mm256_fnmadd_ps(x, rcp, two));
+}
+
+// --- hsum_avx (horizontal sum) ---
+
+/**
+ * @brief horizontal sum of the 8 lanes of a vector
+ * @param[in] v 8 packed floats
+ * @return sum of all lanes as a scalar
+ */
+inline float hsum_avx(__m256 v) {
+  __m128 vlow = _mm256_castps256_ps128(v);
+  __m128 vhigh = _mm256_extractf128_ps(v, 1);
+  vlow = _mm_add_ps(vlow, vhigh);
+  __m128 shuf = _mm_movehdup_ps(vlow);
+  __m128 sums = _mm_add_ps(vlow, shuf);
+  shuf = _mm_movehl_ps(shuf, sums);
+  sums = _mm_add_ss(sums, shuf);
+  return _mm_cvtss_f32(sums);
+}
+
+// --- GELU polynomial approximation (tanh variant) ---
+
+constexpr inline float gelu_start_tanh = -4.38086284326899f;
+constexpr inline float gelu_end_tanh = 4.38086284326899f;
+
+constexpr inline float tanh_c_gelu_p0 = 5.91303808e-6f;
+constexpr inline float tanh_c_gelu_p1 = 5.00000000e-1f;
+constexpr inline float tanh_c_gelu_p2 = 3.98865869e-1f;
+constexpr inline float tanh_c_gelu_p4 = -6.66574676e-2f;
+constexpr inline float tanh_c_gelu_p6 = 1.00712610e-2f;
+constexpr inline float tanh_c_gelu_p8 = -1.19336340e-3f;
+constexpr inline float tanh_c_gelu_p10 = 1.09543224e-4f;
+constexpr inline float tanh_c_gelu_p12 = -7.55788500e-6f;
+constexpr inline float tanh_c_gelu_p14 = 3.73374142e-7f;
+constexpr inline float tanh_c_gelu_p16 = -1.23162678e-8f;
+constexpr inline float tanh_c_gelu_p18 = 2.40940960e-10f;
+constexpr inline float tanh_c_gelu_p20 = -2.10237709e-12f;
+
+/**
+ * @brief vectorized tanh-form GELU polynomial approximation with clamped tails
+ * @param[in] x 8 packed float inputs
+ * @return 8 packed GELU(x) approximations
+ */
+inline __m256 poly_gelu_tanh_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(tanh_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(tanh_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(tanh_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(tanh_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_tanh), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_tanh), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+// --- GELU polynomial approximation (erf variant) ---
+
+constexpr inline float gelu_start_erf = -4.59373833108583f;
+constexpr inline float gelu_end_erf = 4.59373833108583f;
+
+constexpr inline float erf_c_gelu_p0 = 8.70757509e-06f;
+constexpr inline float erf_c_gelu_p1 = 5.00000000e-1f;
+constexpr inline float erf_c_gelu_p2 = 3.98833088e-01f;
+constexpr inline float erf_c_gelu_p4 = -6.62633808e-02f;
+constexpr inline float erf_c_gelu_p6 = 9.78776282e-03f;
+constexpr inline float erf_c_gelu_p8 = -1.10798998e-03f;
+constexpr inline float erf_c_gelu_p10 = 9.51056006e-05f;
+constexpr inline float erf_c_gelu_p12 = -6.04633051e-06f;
+constexpr inline float erf_c_gelu_p14 = 2.73076070e-07f;
+constexpr inline float erf_c_gelu_p16 = -8.20707325e-09f;
+constexpr inline float erf_c_gelu_p18 = 1.46115955e-10f;
+constexpr inline float erf_c_gelu_p20 = -1.16009840e-12f;
+
+/**
+ * @brief vectorized erf-form GELU polynomial approximation with clamped tails
+ * @param[in] x 8 packed float inputs
+ * @return 8 packed GELU(x) approximations
+ */
+inline __m256 poly_gelu_erf_avx2(__m256 x) {
+  const __m256 x2 = _mm256_mul_ps(x, x);
+
+  __m256 y = _mm256_mul_ps(x2, _mm256_set1_ps(erf_c_gelu_p20));
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p18));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p16));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p14));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p12));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p10));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p8));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p6));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p4));
+  y = _mm256_mul_ps(x2, y);
+  y = _mm256_add_ps(y, _mm256_set1_ps(erf_c_gelu_p2));
+  y = _mm256_mul_ps(x2, y);
+
+  __m256 z = _mm256_mul_ps(x, _mm256_set1_ps(erf_c_gelu_p1));
+  z = _mm256_add_ps(z, _mm256_set1_ps(erf_c_gelu_p0));
+
+  y = _mm256_add_ps(y, z);
+
+  const __m256 gt_start =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_start_erf), _CMP_GT_OQ);
+  const __m256 le_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_LE_OQ);
+  const __m256 gt_end =
+    _mm256_cmp_ps(x, _mm256_set1_ps(gelu_end_erf), _CMP_GT_OQ);
+
+  y = _mm256_and_ps(y, gt_start);
+  y = _mm256_and_ps(y, le_end);
+  __m256 x_hi = _mm256_and_ps(x, gt_end);
+
+  return _mm256_add_ps(y, x_hi);
+}
+
+} // namespace nntrainer::avx2::internal
+
+#if !defined(_MSC_VER) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+// Scrub the file-local compiler shims so they do not leak into includers.
+#undef _nnt_CC_VECTORCALL
+#undef _nnt_ATTR_FLATTEN
+#undef _nnt_ATTR_ALWAYS_INLINE
+#if defined(_nnt_UNDEF_HAS_CONSTEXPR_BUILTIN)
+#undef __has_constexpr_builtin
+#undef _nnt_UNDEF_HAS_CONSTEXPR_BUILTIN
+#endif
+#if defined(_nnt_UNDEF_HAS_CPP_ATTRIBUTE)
+#undef __has_cpp_attribute
+#undef _nnt_UNDEF_HAS_CPP_ATTRIBUTE
+#endif
+
+#endif /* __cplusplus */
+#endif /* __AVX2_INTERNAL_H_ */

--- a/nntrainer/tensor/cpu_backend/x86/meson.build
+++ b/nntrainer/tensor/cpu_backend/x86/meson.build
@@ -1,3 +1,6 @@
+# avx2_internal.h is intentionally NOT listed here: it holds TU-internal SIMD
+# primitives shared between avx2_impl.cpp and the FP16 kernels and must not be
+# installed with nntrainer_headers.
 simd_interface_x86_headers = [
   'x86_compute_backend.h',
   'avx2_impl.h',

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -446,6 +446,9 @@ TEST(nntrainer_cpu_backend_standalone, q4_0_repack_unpack_dequantize) {
   }
 }
 
+/**
+ * @brief test for gemm_q4_0
+ */
 float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -492,6 +495,9 @@ float test_gemm_q4_0(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q4_K
+ */
 float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -535,6 +541,9 @@ float test_gemm_q4_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief test for gemm_q6_K
+ */
 float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
                      const float *weights, const float *activations,
                      std::vector<float> &ref_dst, bool print = false) {
@@ -572,6 +581,9 @@ float test_gemm_q6_K(const uint32_t M, const uint32_t K, const uint32_t N,
   return mean_squared_error;
 }
 
+/**
+ * @brief run quantization tests
+ */
 static void run_quant_test(const uint32_t M, const uint32_t K, const uint32_t N,
                            float &q4_0_mse, float &q4_k_mse, float &q6_k_mse,
                            bool print = false) {
@@ -668,6 +680,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_GEMV_1x512x512) {
   ASSERT_LE(q6_k_mse, q4_k_mse);
 }
 
+/**
+ * @brief run vec dot tests
+ */
 static void run_vec_dot_test(const uint32_t K, bool print = false) {
   const int TEST_CNT = 20;
   nanoseconds ref_time = (nanoseconds)0;
@@ -738,6 +753,9 @@ TEST(nntrainer_cpu_backend_standalone, quant_q_6_K_DOT_10240) {
   run_vec_dot_test(K);
 }
 
+/**
+ * @brief run elementwise multiplication test (Z = X ⊙ alpha * Y + beta * Z)
+ */
 static void run_ele_mul_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -818,6 +836,9 @@ TEST(nntrainer_cpu_backend_standalone, ele_mul_3072_istr_16_ostr_16) {
   run_ele_mul_test(N, alpha, beta, i_stride, o_stride);
 }
 
+/**
+ * @brief run elementwise addition test (Z = X + alpha * Y + beta * Z)
+ */
 static void run_ele_add_test(const unsigned int N, float alpha, float beta,
                              unsigned int i_stride, unsigned int o_stride,
                              bool print = false) {
@@ -1562,6 +1583,113 @@ DECLARE_transform_int4_test_K_N(1024, 648, 32);
 DECLARE_transform_int4_test_K_N(1024, 648, 64);
 DECLARE_transform_int4_test_K_N(1024, 648, 128);
 DECLARE_transform_int4_test_K_N(3072, 8192, 32);
+
+// The swiglu/gelu accuracy tests pin the AVX2 approximations moved into
+// avx2_internal.h; on other architectures the dispatcher routes to different
+// kernels whose error bounds these x86-measured tolerances do not describe.
+#if defined(__AVX2__)
+/**
+ * @brief run swiglu accuracy test: cpu backend (AVX2 approximation on x86)
+ * against the scalar fallback reference
+ */
+static void run_swiglu_test(const unsigned int N, float alpha, bool use_alpha,
+                            float abs_tol) {
+  // y spans the sigmoid saturation range on both sides; z is kept moderate so
+  // the absolute tolerance stays meaningful for the product. Drawn from one
+  // stream and split so y and z are not correlated by the fixed RNG seed.
+  std::vector<float> YZ = generate_random_vector<float>(2 * N, -1.0f, 1.0f);
+  std::vector<float> Y(N);
+  std::vector<float> Z(N);
+  for (unsigned int i = 0; i < N; ++i) {
+    Y[i] = 8.0f * YZ[i];
+    Z[i] = 2.0f * YZ[N + i];
+  }
+  std::vector<float> X(N, 0.0f);
+  std::vector<float> X_ref(N, 0.0f);
+
+  if (use_alpha) {
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y.data(), Z.data(), alpha);
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data(), alpha);
+  } else {
+    nntrainer::__fallback_swiglu(N, X_ref.data(), Y.data(), Z.data());
+    nntrainer::swiglu(N, X.data(), Y.data(), Z.data());
+  }
+
+  for (unsigned int i = 0; i < N; ++i) {
+    EXPECT_NEAR(X[i], X_ref[i], abs_tol)
+      << "swiglu mismatch at i=" << i << " y=" << Y[i] << " z=" << Z[i];
+  }
+}
+
+/**
+ * @brief run tanh-approximated gelu accuracy test: cpu backend (AVX2
+ * polynomial on x86) against the scalar fallback reference
+ */
+static void run_tanh_gelu_v2_test(const unsigned int N, float abs_tol) {
+  // range covers the polynomial region and both clamp branches (~ +-4.38)
+  std::vector<float> X = generate_random_vector<float>(N, -8.0f, 8.0f);
+  std::vector<float> Y(N, 0.0f);
+  std::vector<float> Y_ref(N, 0.0f);
+
+  nntrainer::__fallback_tanh_gelu(N, X.data(), Y_ref.data());
+  nntrainer::tanh_gelu_v2(N, X.data(), Y.data());
+
+  for (unsigned int i = 0; i < N; ++i) {
+    EXPECT_NEAR(Y[i], Y_ref[i], abs_tol)
+      << "tanh_gelu_v2 mismatch at i=" << i << " x=" << X[i];
+  }
+}
+
+/**
+ * @brief run erf-based gelu accuracy test: cpu backend (AVX2 polynomial on
+ * x86) against the scalar fallback reference
+ */
+static void run_gelu_v2_test(const unsigned int N, float abs_tol) {
+  // range covers the polynomial region and both clamp branches (~ +-4.59)
+  std::vector<float> X = generate_random_vector<float>(N, -8.0f, 8.0f);
+  std::vector<float> Y(N, 0.0f);
+  std::vector<float> Y_ref(N, 0.0f);
+
+  nntrainer::__fallback_gelu_v2(N, X.data(), Y_ref.data());
+  nntrainer::gelu_v2(N, X.data(), Y.data());
+
+  for (unsigned int i = 0; i < N; ++i) {
+    EXPECT_NEAR(Y[i], Y_ref[i], abs_tol)
+      << "gelu_v2 mismatch at i=" << i << " x=" << X[i];
+  }
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_3072) {
+  run_swiglu_test(3072, 1.0f, false, 1.0e-5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_3075_remainder) {
+  run_swiglu_test(3075, 1.0f, false, 1.0e-5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, swiglu_3072_alpha) {
+  run_swiglu_test(3072, 1.7f, true, 1.0e-5f);
+}
+
+// Tolerances below are ~2x the measured max abs error of the AVX2 polynomial
+// approximations against the scalar references over a dense [-10, 10] sweep
+// (tanh_gelu_v2: 3.7e-5, gelu_v2: 5.7e-5, both at the clamp boundary).
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_3072) {
+  run_tanh_gelu_v2_test(3072, 8.0e-5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, tanh_gelu_v2_3075_remainder) {
+  run_tanh_gelu_v2_test(3075, 8.0e-5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, gelu_v2_3072) {
+  run_gelu_v2_test(3072, 1.2e-4f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, gelu_v2_3075_remainder) {
+  run_gelu_v2_test(3075, 1.2e-4f);
+}
+#endif // __AVX2__
 
 int main(int argc, char **argv) {
   int result = -1;


### PR DESCRIPTION
## Dependency of the PR

- None (based on current `main`).
- First PR of the x86 AVX2/FP16 series re-split from #3834 / #3910 / #3967 / #3988 into small, independently reviewable units.

## Summary

Refactoring of `avx2_impl.cpp`: the file-local SIMD helper primitives (`exp256_ps`, `rcp_ps`, `hsum_avx`, `avx2_approx_swiglu(±alpha)`, `poly_gelu_tanh/erf_avx2`, `Exp2Table`, …) move into a new internal header `avx2_internal.h` under `namespace nntrainer::avx2::internal`. Missing doxygen briefs are added on the q4_0 shuffle helpers touched here.

This is the structure agreed with @jaemini-shin in the #3834 review thread: shared helpers live in one internal header (never in `avx2_impl.h`, never forward-declared per file), so the upcoming FP16 kernel PRs can reuse the same primitives without duplication.

- No behavior change; the public API header `avx2_impl.h` is untouched. Compiling `avx2_impl.cpp` on this commit and on `main` with identical flags yields the same symbol set and instruction stream (only assert() line-number/string operands shift).
- `avx2_internal.h` is internal and not installed — a note in the x86 `meson.build` records this.
- Unreferenced code is dropped rather than moved: the scalar `approx_exp_exp2_lookup` template, a commented-out low-precision `exp256_ps` variant, `compat_bit_cast`/`concept17_BinaryCastable` (left without users by that removal), and the unused `UNLIKELY`/`_nnt_ATTR_NOINLINE` macros.
- The header #undef's its compiler-shim macros at the end, so nothing leaks into including TUs.
- New swiglu / tanh_gelu_v2 / gelu_v2 accuracy tests against the scalar fallback references are added to `unittest_nntrainer_cpu_backend` (the moved primitives were previously exercised only by an Android-only test binary); tolerances are set from a measured dense-sweep of the approximation error, and the tests are gated to AVX2 builds since other architectures dispatch these entry points to different kernels.
- Every helper in `avx2_internal.h` carries function-level doxygen documentation, and the header suppresses `-Wattributes` around its attributed definitions itself so FP16 includers need no pragma of their own.

## Commits to be reviewed in this PR

<details><summary>[cpu_backend] Extract shared AVX2 helpers into internal header (fccc2d4a)</summary><br />

Move the file-local AVX2 helper primitives of avx2_impl.cpp (exp256_ps,
rcp_ps, hsum_avx, swiglu/gelu polynomial approximations and the exp2
lookup table) into a new avx2_internal.h under namespace
nntrainer::avx2::internal, so that upcoming FP16 x86 kernels can reuse
the same primitives without forward declarations or code duplication.

The helpers are defined as plain inline functions with function-level
doxygen documentation, and the gelu/erf polynomial coefficients are
constexpr constants scoped to the namespace. The header suppresses
-Wattributes around its attributed definitions itself, so future FP16
includers do not need to carry the pragma.
The compiler shim macros (_nnt_CC_VECTORCALL, _nnt_ATTR_FLATTEN,
_nnt_ATTR_ALWAYS_INLINE and the __has_* fallbacks) are #undef'ed at the
end of the header, so it leaks no macros into including translation
units. avx2_impl.cpp reaches the primitives through explicit
using-declarations rather than a blanket using-directive, keeping its
dependencies visible.

Unreferenced code paths are dropped along the way: the scalar
approx_exp_exp2_lookup template, a commented-out low-precision variant
of exp256_ps, the compat_bit_cast/concept17_BinaryCastable helpers that
removal leaves without users, and the unused UNLIKELY and
_nnt_ATTR_NOINLINE macros.

The swiglu and gelu primitives were previously exercised only by an
Android-only test binary, so swiglu/tanh_gelu_v2/gelu_v2 accuracy tests
against the scalar fallback references are added to
unittest_nntrainer_cpu_backend to pin the moved code down on x86 CI. The
tests are gated to AVX2 builds because other architectures dispatch these
entry points to different kernels whose error bounds the x86-measured
tolerances do not describe, and the swiglu inputs are drawn from one RNG
stream so the fixed seed cannot correlate them. A
note in the x86 meson.build records that avx2_internal.h is intentionally
not installed with nntrainer_headers.

Also adds missing doxygen briefs on the q4_0 wrappers and rewrites a
plain multi-line comment in compute_fp16vcache_fp32_transposed to //
form, which the doxygen tag checker rejects.

Generated code is verified unchanged: compiling avx2_impl.cpp on this
commit and on main with identical flags yields the same symbol set and
instruction stream, differing only in the source line numbers and string
addresses that assert() embeds into its failure messages.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>

</details>

Signed-off-by: YongHyeon02 <dyddyd8574@snu.ac.kr>