### PR TITLE
[Activation] Integrate parallel FP16 GELU support

### DIFF
--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -18,6 +18,9 @@
 
 #include <common_properties.h>
 #include <cpu_backend.h>
+#include <thread_manager.h>
+
+#include <type_traits>
 
 #if defined(_WIN32)
 #define _USE_MATH_DEFINES
@@ -436,8 +439,40 @@ public:
    */
   template <typename T = float>
   static Tensor &gelu(Tensor const &t_in, Tensor &t_out) {
-    nntrainer::gelu_v2(t_in.size(), t_in.getData<float>(),
-                       t_out.getData<float>());
+    const size_t size = t_in.size();
+    const T *input = t_in.getData<T>();
+    T *output = t_out.getData<T>();
+
+    auto gelu_chunk = [=](size_t begin, size_t end) {
+      if constexpr (std::is_same_v<T, float>) {
+        nntrainer::gelu_v2(static_cast<unsigned int>(end - begin),
+                           input + begin, output + begin);
+#ifdef ENABLE_FP16
+      } else if constexpr (std::is_same_v<T, _FP16>) {
+        constexpr float inv_sqrt_two = 0.70710678118654752440f;
+        for (size_t i = begin; i < end; ++i) {
+          const float value = static_cast<float>(input[i]);
+          output[i] = static_cast<_FP16>(
+            0.5f * value * (1.0f + std::erf(value * inv_sqrt_two)));
+        }
+#endif
+      } else {
+        throw std::invalid_argument("unsupported data type for gelu");
+      }
+    };
+
+    auto &thread_manager = ThreadManager::Global();
+    const unsigned int thread_count = thread_manager.getComputeThreadCount();
+    if (thread_count <= 1 || size < 4096) {
+      gelu_chunk(0, size);
+      return t_out;
+    }
+
+    thread_manager.parallel_for(
+      0, static_cast<size_t>(thread_count), [=](size_t thread_index) {
+        gelu_chunk(size * thread_index / thread_count,
+                   size * (thread_index + 1) / thread_count);
+      });
     return t_out;
   }
 

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -442,6 +442,50 @@ TEST(nntrainer_activation, gelu_01_p) {
   }
 }
 
+TEST(nntrainer_activation, gelu_large_tensor_p) {
+  constexpr size_t size = 4097;
+  nntrainer::Tensor input(1, 1, 1, size);
+  nntrainer::Tensor results(1, 1, 1, size);
+  std::vector<float> expected(size);
+
+  float *input_data = input.getData<float>();
+  for (size_t i = 0; i < size; ++i)
+    input_data[i] = static_cast<float>(i % 101) / 10.0f - 5.0f;
+
+  nntrainer::gelu_v2(size, input_data, expected.data());
+  nntrainer::ActiFunc::gelu<float>(input, results);
+
+  const float *result_data = results.getData<float>();
+  for (size_t i = 0; i < size; ++i)
+    EXPECT_FLOAT_EQ(result_data[i], expected[i]);
+}
+
+#ifdef ENABLE_FP16
+TEST(nntrainer_activation, gelu_fp16_p) {
+  constexpr size_t size = 4097;
+  const nntrainer::TensorDim::TensorType fp16_type = {
+    nntrainer::TensorDim::Format::NCHW, nntrainer::TensorDim::DataType::FP16};
+  nntrainer::Tensor input(nntrainer::TensorDim(1, 1, 1, size, fp16_type));
+  nntrainer::Tensor results(nntrainer::TensorDim(1, 1, 1, size, fp16_type));
+
+  _FP16 *input_data = input.getData<_FP16>();
+  for (size_t i = 0; i < size; ++i)
+    input_data[i] =
+      static_cast<_FP16>(static_cast<float>(i % 101) / 10.0f - 5.0f);
+
+  nntrainer::ActiFunc::gelu<_FP16>(input, results);
+
+  constexpr float inv_sqrt_two = 0.70710678118654752440f;
+  const _FP16 *result_data = results.getData<_FP16>();
+  for (size_t i = 0; i < size; ++i) {
+    const float value = static_cast<float>(input_data[i]);
+    const float expected =
+      0.5f * value * (1.0f + std::erf(value * inv_sqrt_two));
+    EXPECT_NEAR(static_cast<float>(result_data[i]), expected, 0.004f);
+  }
+}
+#endif
+
 TEST(nntrainer_activation, geluPrime_01_p) {
   int batch = 3;
   int channel = 1;


### PR DESCRIPTION
## Summary
- parallelize exact-erf GELU over the global thread pool for large tensors
- fix the core GELU FP16 path by evaluating in FP32 and storing FP16 results
- add FP32 large-tensor and FP16 regression coverage

This folds the behavior introduced by `vjepa_gelu_layer` in #4005 into the existing core GELU activation, so V-JEPA can use the standard activation layer instead of maintaining a custom GELU implementation.

## Testing
- `git diff --check`
- compiled `unittest_nntrainer_activations.cpp` with `ENABLE_FP16=1` and `-Werror`
- attempted full macOS unit-test build; blocked by an existing unrelated error in `nntr_ggml_impl_fp16_fp32.cpp` (`vm_map_t` / `vm_address_t` undeclared)