### PR TITLE
[Activation] Parallelize SiLU and SwiGLU

### DIFF
--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -11,6 +11,7 @@
  *
  */
 
+#include <thread_manager.h>
 #include <util_simd.h>
 
 #include "swiglu.h"
@@ -51,31 +52,32 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
   if (skip_prefill && is_prefill)
     return;
 
-  int iter = to - from;
+  const unsigned int iter = to - from;
+  const size_t rows = static_cast<size_t>(in1.batch()) * in1.channel() * iter;
+
+  auto &thread_manager = nntrainer::ThreadManager::Global();
 
   if (in1.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    for (unsigned int b = 0; b < in1.batch(); b++) {
-      for (unsigned int c = 0; c < in1.channel(); c++) {
-        for (unsigned int h = 0; h < iter; h++) {
-          nntrainer::swiglu(in1.width(),
-                            out.getData<float>() + out.getIndex(b, c, h, 0),
-                            in1.getData<float>() + in1.getIndex(b, c, h, 0),
-                            in2.getData<float>() + in2.getIndex(b, c, h, 0));
-        }
-      }
-    }
+    thread_manager.parallel_for(0, rows, [&](size_t row) {
+      const unsigned int b = row / (in1.channel() * iter);
+      const unsigned int c = row / iter % in1.channel();
+      const unsigned int h = row % iter;
+      nntrainer::swiglu(in1.width(),
+                        out.getData<float>() + out.getIndex(b, c, h, 0),
+                        in1.getData<float>() + in1.getIndex(b, c, h, 0),
+                        in2.getData<float>() + in2.getIndex(b, c, h, 0));
+    });
   } else if (in1.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    for (unsigned int b = 0; b < in1.batch(); b++) {
-      for (unsigned int c = 0; c < in1.channel(); c++) {
-        for (unsigned int h = 0; h < iter; h++) {
-          nntrainer::swiglu(in1.width(),
-                            out.getData<_FP16>() + out.getIndex(b, c, h, 0),
-                            in1.getData<_FP16>() + in1.getIndex(b, c, h, 0),
-                            in2.getData<_FP16>() + in2.getIndex(b, c, h, 0));
-        }
-      }
-    }
+    thread_manager.parallel_for(0, rows, [&](size_t row) {
+      const unsigned int b = row / (in1.channel() * iter);
+      const unsigned int c = row / iter % in1.channel();
+      const unsigned int h = row % iter;
+      nntrainer::swiglu(in1.width(),
+                        out.getData<_FP16>() + out.getIndex(b, c, h, 0),
+                        in1.getData<_FP16>() + in1.getIndex(b, c, h, 0),
+                        in2.getData<_FP16>() + in2.getIndex(b, c, h, 0));
+    });
 #else
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
 #endif

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -18,6 +18,7 @@
 
 #include <common_properties.h>
 #include <cpu_backend.h>
+#include <thread_manager.h>
 
 #if defined(_WIN32)
 #define _USE_MATH_DEFINES
@@ -398,6 +399,33 @@ public:
    */
   template <typename T = float>
   static Tensor &swish(Tensor const &t_in, Tensor &t_out) {
+    constexpr size_t parallel_threshold = 4096;
+    if (t_in.getContiguous() && t_out.getContiguous()) {
+      const size_t size = t_in.size();
+      const T *input = t_in.getData<T>();
+      T *output = t_out.getData<T>();
+
+      auto swish_chunk = [=](size_t begin, size_t end) {
+        for (size_t i = begin; i < end; ++i) {
+          const float value = static_cast<float>(input[i]);
+          output[i] = static_cast<T>(value / (1.0f + std::exp(-value)));
+        }
+      };
+
+      auto &thread_manager = ThreadManager::Global();
+      const unsigned int thread_count = thread_manager.getComputeThreadCount();
+      if (thread_count <= 1 || size < parallel_threshold) {
+        swish_chunk(0, size);
+      } else {
+        thread_manager.parallel_for(
+          0, static_cast<size_t>(thread_count), [=](size_t thread_index) {
+            swish_chunk(size * thread_index / thread_count,
+                        size * (thread_index + 1) / thread_count);
+          });
+      }
+      return t_out;
+    }
+
     t_in.apply<T>([&](T x) { return sigmoid<T>(x); }, t_out);
     t_out.multiply_i(t_in);
 

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -405,23 +405,18 @@ public:
       const T *input = t_in.getData<T>();
       T *output = t_out.getData<T>();
 
-      auto swish_chunk = [=](size_t begin, size_t end) {
-        for (size_t i = begin; i < end; ++i) {
-          const float value = static_cast<float>(input[i]);
-          output[i] = static_cast<T>(value / (1.0f + std::exp(-value)));
-        }
+      auto swish_at = [=](size_t i) {
+        const float value = static_cast<float>(input[i]);
+        output[i] = static_cast<T>(value / (1.0f + std::exp(-value)));
       };
 
       auto &thread_manager = ThreadManager::Global();
       const unsigned int thread_count = thread_manager.getComputeThreadCount();
       if (thread_count <= 1 || size < parallel_threshold) {
-        swish_chunk(0, size);
+        for (size_t i = 0; i < size; ++i)
+          swish_at(i);
       } else {
-        thread_manager.parallel_for(
-          0, static_cast<size_t>(thread_count), [=](size_t thread_index) {
-            swish_chunk(size * thread_index / thread_count,
-                        size * (thread_index + 1) / thread_count);
-          });
+        thread_manager.parallel_for(0, size, swish_at);
       }
       return t_out;
     }

--- a/test/unittest/unittest_nntrainer_activations.cpp
+++ b/test/unittest/unittest_nntrainer_activations.cpp
@@ -384,6 +384,48 @@ TEST(nntrainer_activation, swish_01_p) {
   }
 }
 
+TEST(nntrainer_activation, swish_large_tensor_p) {
+  constexpr size_t size = 4097;
+  nntrainer::Tensor input(1, 1, 1, size);
+  nntrainer::Tensor results(1, 1, 1, size);
+
+  float *input_data = input.getData<float>();
+  for (size_t i = 0; i < size; ++i)
+    input_data[i] = static_cast<float>(i % 101) / 10.0f - 5.0f;
+
+  nntrainer::ActiFunc::swish<float>(input, results);
+
+  const float *result_data = results.getData<float>();
+  for (size_t i = 0; i < size; ++i) {
+    const float value = input_data[i];
+    EXPECT_NEAR(result_data[i], value / (1.0f + std::exp(-value)), tolerance);
+  }
+}
+
+#ifdef ENABLE_FP16
+TEST(nntrainer_activation, swish_fp16_p) {
+  constexpr size_t size = 4097;
+  const nntrainer::TensorDim::TensorType fp16_type = {
+    nntrainer::TensorDim::Format::NCHW, nntrainer::TensorDim::DataType::FP16};
+  nntrainer::Tensor input(nntrainer::TensorDim(1, 1, 1, size, fp16_type));
+  nntrainer::Tensor results(nntrainer::TensorDim(1, 1, 1, size, fp16_type));
+
+  _FP16 *input_data = input.getData<_FP16>();
+  for (size_t i = 0; i < size; ++i)
+    input_data[i] =
+      static_cast<_FP16>(static_cast<float>(i % 101) / 10.0f - 5.0f);
+
+  nntrainer::ActiFunc::swish<_FP16>(input, results);
+
+  const _FP16 *result_data = results.getData<_FP16>();
+  for (size_t i = 0; i < size; ++i) {
+    const float value = static_cast<float>(input_data[i]);
+    EXPECT_NEAR(static_cast<float>(result_data[i]),
+                value / (1.0f + std::exp(-value)), 0.004f);
+  }
+}
+#endif
+
 TEST(nntrainer_activation, swishPrime_01_p) {
 
   int batch = 3;


### PR DESCRIPTION
## Summary
- add a one-pass, thread-pool-parallel path for contiguous SiLU/Swish tensors
- evaluate FP16 SiLU in FP32 and cast only the final result
- parallelize CausalLM SwiGLU across tensor rows while preserving the existing NEON/AVX/FP16 kernels
- retain the existing strided-tensor fallback for Swish
- add large FP32 and FP16 SiLU regression coverage

The SwiGLU backend kernels are intentionally left single-call SIMD kernels because several MoE call sites already parallelize across tokens. Parallelism is added at the sequential `SwiGLULayer` call site to avoid nested `ThreadManager::parallel_for()` calls.

This PR is independent of #4094 and is based directly on `main`.

## Testing
- `git diff --check`
- compiled `unittest_nntrainer_activations.cpp` with `ENABLE_FP16=1` and `-Werror`
- compiled `Applications/CausalLM/layers/swiglu.cpp` with `ENABLE_FP16=1` and `-Werror`
- full macOS unit-test linking remains blocked by an existing unrelated error in `nntr_ggml_impl_fp16_fp32.cpp` (`vm_map_t` / `vm_address_t` undeclared)