### PR TITLE
[LayerNorm] Add parallel width-axis fast path

### DIFF
--- a/nntrainer/layers/layer_normalization_layer.cpp
+++ b/nntrainer/layers/layer_normalization_layer.cpp
@@ -22,6 +22,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
+#include <thread_manager.h>
 #include <util_func.h>
 
 namespace nntrainer {
@@ -37,6 +38,52 @@ enum LNParams {
   temp_origin_size,
   temp_normalized_size,
 };
+
+static void layerNormWrtWidthParallel(const Tensor &input, Tensor &output,
+                                      const Tensor &gamma, const Tensor &beta,
+                                      size_t rows, size_t width,
+                                      float epsilon) {
+  auto &thread_manager = ThreadManager::Global();
+  const size_t thread_count = thread_manager.getComputeThreadCount();
+  const size_t tasks = rows >= 4 ? std::min(rows, thread_count) : 1;
+
+  auto run_rows = [&](size_t task) {
+    const size_t row_begin = rows * task / tasks;
+    const size_t row_end = rows * (task + 1) / tasks;
+    if (input.getDataType() == TensorDim::DataType::FP32) {
+      layer_norm_wrt_width_fp32_intrinsic(
+        input.getData<float>() + row_begin * width,
+        output.getData<float>() + row_begin * width, gamma.getData<float>(),
+        beta.getData<float>(), row_end - row_begin, width, epsilon);
+    } else {
+#ifdef ENABLE_FP16
+      layer_norm_wrt_width_fp16_intrinsic(
+        input.getData<_FP16>() + row_begin * width,
+        output.getData<_FP16>() + row_begin * width, gamma.getData<float>(),
+        beta.getData<float>(), row_end - row_begin, width, epsilon);
+#endif
+    }
+  };
+
+  thread_manager.parallel_for(0, tasks, run_rows);
+}
+
+static bool supportsLayerNormWrtWidthFastPath(
+  const Tensor &input, const Tensor &output, const Tensor &gamma,
+  const Tensor &beta, const std::vector<unsigned int> &normalize_axes) {
+  const auto input_type = input.getDataType();
+  bool supported_input_type = input_type == TensorDim::DataType::FP32;
+#ifdef ENABLE_FP16
+  supported_input_type =
+    supported_input_type || input_type == TensorDim::DataType::FP16;
+#endif
+  return normalize_axes.size() == 1 &&
+         normalize_axes[0] == TensorDim::getNumDim() - 1 &&
+         input.getContiguous() && output.getContiguous() &&
+         gamma.getDataType() == TensorDim::DataType::FP32 &&
+         beta.getDataType() == TensorDim::DataType::FP32 &&
+         supported_input_type;
+}
 
 LayerNormalizationLayer::LayerNormalizationLayer() :
   Layer(),
@@ -147,6 +194,14 @@ void LayerNormalizationLayer::forwarding(RunLayerContext &context,
   Tensor &temp_full_size = output;
   Tensor &temp_norm_size = inv_std_dev;
 
+  if (!training && supportsLayerNormWrtWidthFastPath(input, output, gamma, beta,
+                                                     normalize_axes)) {
+    const size_t width = input.width();
+    const size_t rows = input.size() / width;
+    layerNormWrtWidthParallel(input, output, gamma, beta, rows, width, epsilon);
+    return;
+  }
+
   input.average(normalize_axes, temp_norm_size);
   input.subtract(temp_norm_size, deviation);
 
@@ -202,6 +257,30 @@ void LayerNormalizationLayer::incremental_forwarding(RunLayerContext &context,
 
   Tensor &temp_full_size = output;
   Tensor &temp_norm_size = inv_std_dev;
+
+  if (!training && supportsLayerNormWrtWidthFastPath(input, output, gamma, beta,
+                                                     normalize_axes)) {
+    const size_t width = input_dim.width();
+    const size_t rows_per_bc = to - from;
+    const size_t feature_len = input_dim.getFeatureLen();
+    for (unsigned int b = 0; b < input_dim.batch(); ++b) {
+      for (unsigned int c = 0; c < input_dim.channel(); ++c) {
+        const size_t offset =
+          static_cast<size_t>(b) * feature_len +
+          static_cast<size_t>(c) * input_dim.height() * width +
+          static_cast<size_t>(from) * width;
+        Tensor input_rows = input.getSharedDataTensor(
+          TensorDim(1, 1, rows_per_bc, width, input.getTensorType()), offset,
+          true);
+        Tensor output_rows = output.getSharedDataTensor(
+          TensorDim(1, 1, rows_per_bc, width, output.getTensorType()), offset,
+          true);
+        layerNormWrtWidthParallel(input_rows, output_rows, gamma, beta,
+                                  rows_per_bc, width, epsilon);
+      }
+    }
+    return;
+  }
 
   input.average(normalize_axes, temp_norm_size);
   input.subtract(temp_norm_size, deviation);

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.cpp
@@ -518,6 +518,14 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
   neon::rms_norm_wrt_width_fp32_intrinsic(X, Y, H, W, epsilon);
 }
 
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  neon::layer_norm_wrt_width_fp32_intrinsic(X, Y, gamma, beta, H, W, epsilon);
+}
+
 template <>
 void clamp(const float *input, float *output, size_t length, float lower_bound,
            float upper_bound) {

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1350,6 +1350,11 @@ void dequantize_row_q8_0(const void *x_raw, T *y, int64_t k);
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,
                                        float epsilon);
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 
 /**
  * @brief Causal depthwise Conv1D prefill for kernel size 3.
@@ -1401,6 +1406,11 @@ void causal_depthwise_conv1d_k3_decode(const float *x_cur,
 template <typename T = float>
 void rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
                                        size_t H, size_t W, float epsilon);
+template <typename T = float>
+void layer_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 #endif
 
 /**

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -408,6 +408,16 @@ void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
 }
 
 template <>
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  neon::layer_norm_wrt_width_fp16_intrinsic<_FP16>(X, Y, gamma, beta, H, W,
+                                                   epsilon);
+}
+
+template <>
 void sine(const unsigned int N, _FP16 *X, _FP16 *Y, float alpha, float beta) {
   nntrainer::neon::sine<_FP16>(N, X, Y, alpha, beta);
 }

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.cpp
@@ -1944,6 +1944,52 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
   }
 }
 
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const float *row_x = X + h * W;
+    float *row_y = Y + h * W;
+    size_t w = 0;
+    float32x4_t sum_v = vdupq_n_f32(0.0f);
+    for (; w + 4 <= W; w += 4)
+      sum_v = vaddq_f32(sum_v, vld1q_f32(row_x + w));
+    float sum = hsum_f32x4(sum_v);
+    for (; w < W; ++w)
+      sum += row_x[w];
+    const float mean = sum / static_cast<float>(W);
+    const float32x4_t mean_v = vdupq_n_f32(mean);
+
+    w = 0;
+    float32x4_t variance_v = vdupq_n_f32(0.0f);
+    for (; w + 4 <= W; w += 4) {
+      const float32x4_t deviation = vsubq_f32(vld1q_f32(row_x + w), mean_v);
+      variance_v = VFMAQ_F32(variance_v, deviation, deviation);
+    }
+    float variance = hsum_f32x4(variance_v);
+    for (; w < W; ++w) {
+      const float deviation = row_x[w] - mean;
+      variance += deviation * deviation;
+    }
+    const float inv_std_dev =
+      1.0f / std::sqrt(variance / static_cast<float>(W) + epsilon);
+    const float32x4_t inv_std_dev_v = vdupq_n_f32(inv_std_dev);
+
+    w = 0;
+    for (; w + 4 <= W; w += 4) {
+      float32x4_t normalized =
+        vmulq_f32(vsubq_f32(vld1q_f32(row_x + w), mean_v), inv_std_dev_v);
+      normalized =
+        VFMAQ_F32(vld1q_f32(beta + w), normalized, vld1q_f32(gamma + w));
+      vst1q_f32(row_y + w, normalized);
+    }
+    for (; w < W; ++w)
+      row_y[w] = (row_x[w] - mean) * inv_std_dev * gamma[w] + beta[w];
+  }
+}
+
 template <>
 void clamp(const float *input, float *output, size_t length, float lower_bound,
            float upper_bound) {

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl.h
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl.h
@@ -869,6 +869,11 @@ void softmax_row(__fp16 *qk_out, size_t start_row, size_t end_row,
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,
                                        float epsilon);
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
@@ -882,6 +887,11 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
 template <typename T = float>
 void rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
                                        size_t H, size_t W, float epsilon);
+template <typename T = float>
+void layer_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 
 /**
  * @brief fallback for clamping function.

--- a/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/neon_impl_fp16.cpp
@@ -2312,6 +2312,72 @@ void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
 }
 
 template <>
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const _FP16 *row_x = X + h * W;
+    _FP16 *row_y = Y + h * W;
+    size_t w = 0;
+    float32x4_t sum0 = vdupq_n_f32(0.0f);
+    float32x4_t sum1 = vdupq_n_f32(0.0f);
+    for (; w + 8 <= W; w += 8) {
+      const float16x8_t input = vld1q_f16(row_x + w);
+      sum0 = vaddq_f32(sum0, vcvt_f32_f16(vget_low_f16(input)));
+      sum1 = vaddq_f32(sum1, vcvt_f32_f16(vget_high_f16(input)));
+    }
+    float sum = vaddvq_f32(vaddq_f32(sum0, sum1));
+    for (; w < W; ++w)
+      sum += static_cast<float>(row_x[w]);
+    const float mean = sum / static_cast<float>(W);
+    const float32x4_t mean_v = vdupq_n_f32(mean);
+
+    w = 0;
+    float32x4_t variance0 = vdupq_n_f32(0.0f);
+    float32x4_t variance1 = vdupq_n_f32(0.0f);
+    for (; w + 8 <= W; w += 8) {
+      const float16x8_t input = vld1q_f16(row_x + w);
+      const float32x4_t deviation0 =
+        vsubq_f32(vcvt_f32_f16(vget_low_f16(input)), mean_v);
+      const float32x4_t deviation1 =
+        vsubq_f32(vcvt_f32_f16(vget_high_f16(input)), mean_v);
+      variance0 = vfmaq_f32(variance0, deviation0, deviation0);
+      variance1 = vfmaq_f32(variance1, deviation1, deviation1);
+    }
+    float variance = vaddvq_f32(vaddq_f32(variance0, variance1));
+    for (; w < W; ++w) {
+      const float deviation = static_cast<float>(row_x[w]) - mean;
+      variance += deviation * deviation;
+    }
+    const float inv_std_dev =
+      1.0f / std::sqrt(variance / static_cast<float>(W) + epsilon);
+    const float32x4_t inv_std_dev_v = vdupq_n_f32(inv_std_dev);
+
+    w = 0;
+    for (; w + 8 <= W; w += 8) {
+      const float16x8_t input = vld1q_f16(row_x + w);
+      float32x4_t normalized0 = vmulq_f32(
+        vsubq_f32(vcvt_f32_f16(vget_low_f16(input)), mean_v), inv_std_dev_v);
+      float32x4_t normalized1 = vmulq_f32(
+        vsubq_f32(vcvt_f32_f16(vget_high_f16(input)), mean_v), inv_std_dev_v);
+      normalized0 =
+        vfmaq_f32(vld1q_f32(beta + w), normalized0, vld1q_f32(gamma + w));
+      normalized1 = vfmaq_f32(vld1q_f32(beta + w + 4), normalized1,
+                              vld1q_f32(gamma + w + 4));
+      vst1q_f16(row_y + w, vcombine_f16(vcvt_f16_f32(normalized0),
+                                        vcvt_f16_f32(normalized1)));
+    }
+    for (; w < W; ++w) {
+      const float normalized =
+        (static_cast<float>(row_x[w]) - mean) * inv_std_dev;
+      row_y[w] = static_cast<_FP16>(normalized * gamma[w] + beta[w]);
+    }
+  }
+}
+
+template <>
 void rms_norm_wrt_width_fp16_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,
                                        float epsilon) {

--- a/nntrainer/tensor/cpu_backend/cpu_backend.h
+++ b/nntrainer/tensor/cpu_backend/cpu_backend.h
@@ -1452,6 +1452,9 @@ extern void compute_rotary_emb_value(unsigned int width, unsigned int dim,
 extern void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                               float *__restrict Y, size_t H,
                                               size_t W, float epsilon);
+extern void layer_norm_wrt_width_fp32_intrinsic(
+  const float *__restrict X, float *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon);
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
  *
@@ -1465,6 +1468,11 @@ template <typename T = float>
 extern void rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X,
                                               T *__restrict Y, size_t H,
                                               size_t W, float epsilon);
+#ifdef ENABLE_FP16
+extern void layer_norm_wrt_width_fp16_intrinsic(
+  const _FP16 *__restrict X, _FP16 *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon);
+#endif
 
 /**
  * @brief fallback for clamping function.

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.cpp
@@ -366,6 +366,15 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
   __fallback_rms_norm_wrt_width_fp32_intrinsic(X, Y, H, W, epsilon);
 }
 
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  __fallback_layer_norm_wrt_width_fp32_intrinsic(X, Y, gamma, beta, H, W,
+                                                 epsilon);
+}
+
 template <>
 void rms_norm_wrt_width_fp16_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback.h
@@ -1279,6 +1279,11 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,
                                        float epsilon);
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
  *
@@ -1291,6 +1296,13 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
 template <typename T = float>
 void rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
                                        size_t H, size_t W, float epsilon);
+#ifdef ENABLE_FP16
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
+#endif
 
 /**
  * @brief fallback for clamping function.

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_fp16.cpp
@@ -234,6 +234,15 @@ void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
   __fallback_rms_norm_wrt_width_fp16_intrinsic<_FP16>(X, Y, H, W, epsilon);
 }
 
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  __fallback_layer_norm_wrt_width_fp16_intrinsic(X, Y, gamma, beta, H, W,
+                                                 epsilon);
+}
+
 template <>
 void clamp(const _FP16 *input, _FP16 *output, size_t length, _FP16 lower_bound,
            _FP16 upper_bound) {

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp
@@ -651,6 +651,30 @@ void __fallback_rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
   }
 }
 
+void __fallback_layer_norm_wrt_width_fp32_intrinsic(
+  const float *__restrict X, float *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const float *row_x = X + h * W;
+    float *row_y = Y + h * W;
+    float mean = 0.0f;
+    for (size_t w = 0; w < W; ++w)
+      mean += row_x[w];
+    mean /= static_cast<float>(W);
+
+    float variance = 0.0f;
+    for (size_t w = 0; w < W; ++w) {
+      const float deviation = row_x[w] - mean;
+      variance += deviation * deviation;
+    }
+    variance /= static_cast<float>(W);
+    const float inv_std_dev = 1.0f / std::sqrt(variance + epsilon);
+
+    for (size_t w = 0; w < W; ++w)
+      row_y[w] = (row_x[w] - mean) * inv_std_dev * gamma[w] + beta[w];
+  }
+}
+
 template <>
 void __fallback_rms_norm_wrt_width_fp16_intrinsic(const float *__restrict X,
                                                   float *__restrict Y, size_t H,

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal.h
@@ -1196,6 +1196,9 @@ void __fallback_compute_rotary_emb_value(unsigned int width, unsigned int dim,
 void __fallback_rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                                   float *__restrict Y, size_t H,
                                                   size_t W, float epsilon);
+void __fallback_layer_norm_wrt_width_fp32_intrinsic(
+  const float *__restrict X, float *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon);
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
  *
@@ -1209,6 +1212,11 @@ template <typename T = float>
 void __fallback_rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X,
                                                   T *__restrict Y, size_t H,
                                                   size_t W, float epsilon);
+#ifdef ENABLE_FP16
+void __fallback_layer_norm_wrt_width_fp16_intrinsic(
+  const _FP16 *__restrict X, _FP16 *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon);
+#endif
 /**
  * @brief fallback for clamping function.
  *

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
@@ -501,6 +501,33 @@ void __fallback_rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
     "NYI : __fallback_rms_norm_wrt_width_fp16_intrinsic with FP16 type input");
 }
 
+void __fallback_layer_norm_wrt_width_fp16_intrinsic(
+  const _FP16 *__restrict X, _FP16 *__restrict Y, const float *__restrict gamma,
+  const float *__restrict beta, size_t H, size_t W, float epsilon) {
+  for (size_t h = 0; h < H; ++h) {
+    const _FP16 *row_x = X + h * W;
+    _FP16 *row_y = Y + h * W;
+    float mean = 0.0f;
+    for (size_t w = 0; w < W; ++w)
+      mean += static_cast<float>(row_x[w]);
+    mean /= static_cast<float>(W);
+
+    float variance = 0.0f;
+    for (size_t w = 0; w < W; ++w) {
+      const float deviation = static_cast<float>(row_x[w]) - mean;
+      variance += deviation * deviation;
+    }
+    variance /= static_cast<float>(W);
+    const float inv_std_dev = 1.0f / std::sqrt(variance + epsilon);
+
+    for (size_t w = 0; w < W; ++w) {
+      const float normalized =
+        (static_cast<float>(row_x[w]) - mean) * inv_std_dev;
+      row_y[w] = static_cast<_FP16>(normalized * gamma[w] + beta[w]);
+    }
+  }
+}
+
 template <>
 void __fallback_clamp(const _FP16 *input, _FP16 *output, size_t length,
                       _FP16 lower_bound, _FP16 upper_bound) {

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.cpp
@@ -493,6 +493,15 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
   nntrainer::avx2::rms_norm_wrt_width_fp32_intrinsic(X, Y, H, W, epsilon);
 }
 
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  __fallback_layer_norm_wrt_width_fp32_intrinsic(X, Y, gamma, beta, H, W,
+                                                 epsilon);
+}
+
 template <>
 void rms_norm_wrt_width_fp16_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend.h
@@ -1189,6 +1189,11 @@ void compute_rotary_emb_value(unsigned int width, unsigned int dim,
 void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
                                        float *__restrict Y, size_t H, size_t W,
                                        float epsilon);
+void layer_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
+                                         float *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
 /**
  * @brief rms normalization computation w.r.t. width in H*W matrix input
  *
@@ -1201,6 +1206,13 @@ void rms_norm_wrt_width_fp32_intrinsic(const float *__restrict X,
 template <typename T = float>
 void rms_norm_wrt_width_fp16_intrinsic(const T *__restrict X, T *__restrict Y,
                                        size_t H, size_t W, float epsilon);
+#ifdef ENABLE_FP16
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon);
+#endif
 
 /**
  * @brief fallback for clamping function.

--- a/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/x86/x86_compute_backend_fp16.cpp
@@ -339,4 +339,13 @@ void rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
   __fallback_rms_norm_wrt_width_fp16_intrinsic<_FP16>(X, Y, H, W, epsilon);
 }
 
+void layer_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
+                                         _FP16 *__restrict Y,
+                                         const float *__restrict gamma,
+                                         const float *__restrict beta, size_t H,
+                                         size_t W, float epsilon) {
+  __fallback_layer_norm_wrt_width_fp16_intrinsic(X, Y, gamma, beta, H, W,
+                                                 epsilon);
+}
+
 } /* namespace nntrainer */

--- a/test/unittest/layers/unittest_layers_layer_normalization.cpp
+++ b/test/unittest/layers/unittest_layers_layer_normalization.cpp
@@ -38,6 +38,14 @@ auto ln_axis_3 = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::LayerNormalizationLayer>, {"axis=3"},
   "2:4:2:3", "ln_axis_3.nnlayergolden", ln_option, "nchw", "fp32", "fp32");
 
+auto ln_axis_3_inference = LayerGoldenTestParamType(
+  nntrainer::createLayer<nntrainer::LayerNormalizationLayer>, {"axis=3"},
+  "2:4:2:3", "ln_axis_3.nnlayergolden",
+  LayerGoldenTestParamOptions::SKIP_CALC_DERIV |
+    LayerGoldenTestParamOptions::SKIP_CALC_GRAD |
+    LayerGoldenTestParamOptions::FORWARD_MODE_INFERENCE,
+  "nchw", "fp32", "fp32");
+
 auto ln_axis_1_2 = LayerGoldenTestParamType(
   nntrainer::createLayer<nntrainer::LayerNormalizationLayer>, {"axis=1, 2"},
   "2:4:2:3", "ln_axis_1_2.nnlayergolden", ln_option, "nchw", "fp32", "fp32");
@@ -56,7 +64,8 @@ auto ln_axis_1_2_3 = LayerGoldenTestParamType(
 
 GTEST_PARAMETER_TEST(LayerNormalization, LayerGoldenTest,
                      ::testing::Values(ln_axis_1, ln_axis_2, ln_axis_3,
-                                       ln_axis_1_2, ln_axis_2_3, ln_axis_1_3,
+                                       ln_axis_3_inference, ln_axis_1_2,
+                                       ln_axis_2_3, ln_axis_1_3,
                                        ln_axis_1_2_3));
 
 #ifdef ENABLE_FP16
@@ -98,7 +107,6 @@ auto ln_axis_1_2_3_w16a16 = LayerGoldenTestParamType(
 GTEST_PARAMETER_TEST(LayerNormalization16, LayerGoldenTest,
                      ::testing::Values(ln_axis_1_w16a16, ln_axis_2_w16a16,
                                        ln_axis_3_w16a16, ln_axis_1_2_w16a16,
-                                       ln_axis_2_3_w16a16,
-                                       ln_axis_1_3_w16a16,
+                                       ln_axis_2_3_w16a16, ln_axis_1_3_w16a16,
                                        ln_axis_1_2_3_w16a16));
 #endif

--- a/test/unittest/unittest_nntrainer_cpu_backend.cpp
+++ b/test/unittest/unittest_nntrainer_cpu_backend.cpp
@@ -809,6 +809,87 @@ TEST(nntrainer_cpu_backend_standalone, ele_mul_3072_istr_1) {
   run_ele_mul_test(N, alpha, beta, i_stride, o_stride);
 }
 
+static void run_layer_norm_wrt_width_test(size_t height, size_t width) {
+  constexpr float epsilon = 1e-6f;
+  std::vector<float> input =
+    generate_random_vector<float, false>(height * width);
+  std::vector<float> gamma = generate_random_vector<float, false>(width);
+  std::vector<float> beta = generate_random_vector<float, false>(width);
+  std::vector<float> output(height * width);
+  std::vector<float> reference(height * width);
+
+  for (size_t h = 0; h < height; ++h) {
+    const float *row = input.data() + h * width;
+    float mean = 0.0f;
+    for (size_t w = 0; w < width; ++w)
+      mean += row[w];
+    mean /= static_cast<float>(width);
+    float variance = 0.0f;
+    for (size_t w = 0; w < width; ++w) {
+      const float deviation = row[w] - mean;
+      variance += deviation * deviation;
+    }
+    variance /= static_cast<float>(width);
+    const float inv_std_dev = 1.0f / std::sqrt(variance + epsilon);
+    for (size_t w = 0; w < width; ++w)
+      reference[h * width + w] =
+        (row[w] - mean) * inv_std_dev * gamma[w] + beta[w];
+  }
+
+  nntrainer::layer_norm_wrt_width_fp32_intrinsic(input.data(), output.data(),
+                                                 gamma.data(), beta.data(),
+                                                 height, width, epsilon);
+
+  for (size_t i = 0; i < output.size(); ++i)
+    EXPECT_NEAR(output[i], reference[i], 1e-5f);
+}
+
+TEST(nntrainer_cpu_backend_standalone, layer_norm_wrt_width_fp32_tail) {
+  run_layer_norm_wrt_width_test(5, 769);
+}
+
+#ifdef ENABLE_FP16
+TEST(nntrainer_cpu_backend_standalone, layer_norm_wrt_width_fp16_tail) {
+  constexpr size_t height = 5;
+  constexpr size_t width = 769;
+  constexpr float epsilon = 1e-6f;
+  std::vector<float> input_fp32 =
+    generate_random_vector<float, false>(height * width);
+  std::vector<float> gamma = generate_random_vector<float, false>(width);
+  std::vector<float> beta = generate_random_vector<float, false>(width);
+  std::vector<_FP16> input(height * width);
+  for (size_t i = 0; i < input.size(); ++i)
+    input[i] = static_cast<_FP16>(input_fp32[i]);
+  std::vector<_FP16> output(height * width);
+
+  nntrainer::layer_norm_wrt_width_fp16_intrinsic(input.data(), output.data(),
+                                                 gamma.data(), beta.data(),
+                                                 height, width, epsilon);
+
+  for (size_t h = 0; h < height; ++h) {
+    float mean = 0.0f;
+    for (size_t w = 0; w < width; ++w)
+      mean += static_cast<float>(input[h * width + w]);
+    mean /= static_cast<float>(width);
+    float variance = 0.0f;
+    for (size_t w = 0; w < width; ++w) {
+      const float deviation = static_cast<float>(input[h * width + w]) - mean;
+      variance += deviation * deviation;
+    }
+    variance /= static_cast<float>(width);
+    const float inv_std_dev = 1.0f / std::sqrt(variance + epsilon);
+    for (size_t w = 0; w < width; ++w) {
+      const float normalized =
+        (static_cast<float>(input[h * width + w]) - mean) * inv_std_dev;
+      const _FP16 reference =
+        static_cast<_FP16>(normalized * gamma[w] + beta[w]);
+      EXPECT_NEAR(static_cast<float>(output[h * width + w]),
+                  static_cast<float>(reference), 0.004f);
+    }
+  }
+}
+#endif
+
 TEST(nntrainer_cpu_backend_standalone, ele_mul_3072_istr_16_ostr_16) {
   const unsigned int N = 3072;
   const float alpha = 3.f;


### PR DESCRIPTION
## Dependency of the PR

- Motivated by the V-JEPA LayerNorm implementation in #4005. This PR is based on `main` and has no code dependency on #4005.

## Commits to be reviewed in this PR

<details><summary>[LayerNorm] add parallel width-axis fast path</summary><br />

[LayerNorm] add parallel width-axis fast path

- Add FP32 and FP16 width-axis LayerNorm backend entry points with scalar fallbacks and ARM NEON implementations.
- Keep FP16 input/output conversion at the boundary while accumulating mean, variance, and affine operations in FP32.
- Use the optimized path for contiguous inference tensors normalized over axis 3, with row-level ThreadManager parallelism.
- Preserve the generic implementation for training, non-contiguous tensors, other axes, and unsupported affine tensor types.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Integrate the V-JEPA width-axis LayerNorm behavior into the core LayerNormalization layer.
- Add portable FP32/FP16 fallbacks and ARM NEON kernels using the RMSNorm-style naming convention.
- Validate backend tail handling and FP32/FP16 LayerNormalization inference paths in Docker/Linux.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
