### PR TITLE
[Embedding] Optimize contiguous row lookup

### DIFF
--- a/nntrainer/layers/embedding.cpp
+++ b/nntrainer/layers/embedding.cpp
@@ -17,8 +17,10 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
+#include <thread_manager.h>
 #include <util_func.h>
 
+#include <cstring>
 #include <iostream>
 
 namespace nntrainer {
@@ -82,43 +84,13 @@ void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {
 }
 
 void EmbeddingLayer::forwarding(RunLayerContext &context, bool training) {
-  /// @todo get input and output dimension from input_ and hidden itself
-  unsigned int in_dim = std::get<props::InDim>(embedding_props);
-  unsigned int out_dim = std::get<props::OutDim>(embedding_props);
-
-  Tensor &weight = context.getWeight(weight_idx);
-  Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
-  TensorDim out_tensor_dim =
-    TensorDim({1, 1, 1, out_dim}, hidden_.getTensorType());
-
-  for (unsigned int b = 0; b < input_.batch(); ++b) {
-    float *in_data =
-      input_.getAddress<float>(b * input_.getDim().getFeatureLen());
-
-    Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
-    for (unsigned int i = 0; i < input_.width(); ++i) {
-      unsigned int embed_idx = static_cast<unsigned int>(in_data[i]);
-      if (embed_idx >= in_dim) {
-        throw std::invalid_argument("input word index is greater than in_dim");
-      }
-
-      Tensor cur_weight =
-        weight.getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
-      Tensor out_tensor =
-        batchsliced_hidden.getSharedDataTensor(out_tensor_dim, out_dim * i);
-      out_tensor.copyData(cur_weight);
-    }
-  }
+  forwardRows(context, input_.width());
 }
 
 void EmbeddingLayer::incremental_forwarding(RunLayerContext &context,
                                             unsigned int from, unsigned int to,
                                             bool training) {
-
-  /// @todo get input and output dimension from input_ and hidden itself
-  unsigned int in_dim = std::get<props::InDim>(embedding_props);
-  unsigned int out_dim = std::get<props::OutDim>(embedding_props);
 
   if (from) {
     // Normalize to 0-based while preserving step size for multi-token prefill
@@ -126,30 +98,85 @@ void EmbeddingLayer::incremental_forwarding(RunLayerContext &context,
     from = 0;
   }
 
+  forwardRows(context, to - from);
+}
+
+void EmbeddingLayer::forwardRows(RunLayerContext &context,
+                                 unsigned int token_count) {
+  const unsigned int in_dim = std::get<props::InDim>(embedding_props);
+  const unsigned int out_dim = std::get<props::OutDim>(embedding_props);
+
   Tensor &weight = context.getWeight(weight_idx);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
+  const TensorDim &input_dim = input_.getDim();
+  const TensorDim &hidden_dim = hidden_.getDim();
+
+  NNTR_THROW_IF(token_count > input_.width(), std::invalid_argument)
+    << "embedding token count exceeds input width";
+
+  const size_t task_count = static_cast<size_t>(input_.batch()) * token_count;
+  auto get_index = [&](size_t task) {
+    const size_t batch = task / token_count;
+    const size_t token = task % token_count;
+    const float value =
+      input_.getValue<float>(batch * input_dim.getFeatureLen() + token);
+    const unsigned int embed_idx = static_cast<unsigned int>(value);
+    NNTR_THROW_IF(embed_idx >= in_dim, std::invalid_argument)
+      << "input word index is greater than in_dim";
+    return embed_idx;
+  };
+
+  const auto data_type = weight.getDataType();
+  const bool direct_copy = weight.getContiguous() && hidden_.getContiguous() &&
+                           data_type == hidden_.getDataType() &&
+                           (data_type == TensorDim::DataType::FP32 ||
+                            data_type == TensorDim::DataType::FP16);
+
+  if (direct_copy) {
+    const size_t row_bytes =
+      static_cast<size_t>(out_dim) * weight.getDim().getDataTypeSize();
+    const auto *weight_data =
+      reinterpret_cast<const unsigned char *>(weight.getData());
+    auto *output_data = reinterpret_cast<unsigned char *>(hidden_.getData());
+    auto copy_row = [&](size_t task, unsigned int embed_idx) {
+      const size_t batch = task / token_count;
+      const size_t token = task % token_count;
+      const size_t output_offset =
+        (batch * hidden_dim.getFeatureLen() + token * out_dim) *
+        hidden_dim.getDataTypeSize();
+      std::memcpy(output_data + output_offset,
+                  weight_data + static_cast<size_t>(embed_idx) * row_bytes,
+                  row_bytes);
+    };
+
+    constexpr size_t PARALLEL_COPY_THRESHOLD_BYTES = 64 * 1024;
+    if (task_count * row_bytes >= PARALLEL_COPY_THRESHOLD_BYTES) {
+      std::vector<unsigned int> indices(task_count);
+      for (size_t task = 0; task < task_count; ++task) {
+        indices[task] = get_index(task);
+      }
+      ThreadManager::Global().parallel_for(
+        0, task_count, [&](size_t task) { copy_row(task, indices[task]); });
+    } else {
+      for (size_t task = 0; task < task_count; ++task) {
+        copy_row(task, get_index(task));
+      }
+    }
+    return;
+  }
 
   TensorDim out_tensor_dim =
     TensorDim({1, 1, 1, out_dim}, hidden_.getTensorType());
 
   for (unsigned int b = 0; b < input_.batch(); ++b) {
-    float *in_data =
-      input_.getAddress<float>(b * input_.getDim().getFeatureLen());
-
     Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
-    for (unsigned int i = from; i < to; ++i) {
-      unsigned int embed_idx = static_cast<unsigned int>(in_data[i]);
-      if (embed_idx >= in_dim) {
-        throw std::invalid_argument("input word index is greater than in_dim");
-      }
-
+    for (unsigned int i = 0; i < token_count; ++i) {
+      const unsigned int embed_idx = get_index(b * token_count + i);
       Tensor cur_weight =
         weight.getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
-
-      Tensor out_tensor = batchsliced_hidden.getSharedDataTensor(
-        out_tensor_dim, out_dim * (i - from));
-
+      Tensor out_tensor =
+        batchsliced_hidden.getSharedDataTensor(out_tensor_dim, out_dim * i);
       out_tensor.copyData(cur_weight);
     }
   }

--- a/nntrainer/layers/embedding.h
+++ b/nntrainer/layers/embedding.h
@@ -104,6 +104,13 @@ public:
   static constexpr const char *type = "embedding";
 
 private:
+  /**
+   * @brief Copy embedding rows for the local input token chunk
+   * @param context run context
+   * @param token_count number of local tokens per batch
+   */
+  void forwardRows(RunLayerContext &context, unsigned int token_count);
+
   std::tuple<props::InDim, props::OutDim> embedding_props;
   unsigned int weight_idx;
 };


### PR DESCRIPTION
## Dependency of the PR

None. This PR is based on `main`.

## Commits to be reviewed in this PR


<details><summary>[Embedding] optimize contiguous row lookup</summary><br />

Use direct row copies for contiguous FP32 and FP16 embedding tensors and parallelize sufficiently large prefill workloads across batch-token rows. Keep the tensor-view implementation as a fallback for unsupported layouts and data types.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Avoid per-token Tensor view construction for contiguous FP32/FP16 embedding lookup.
- Parallelize embedding row copies for prefill workloads of at least 64 KiB.
- Preserve the existing Tensor-based path for unsupported data types and layouts.
- Docker x86 FP16 build passed; all 15 `*Embedding*` layer tests passed.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
