### PR TITLE
[CL] meson: install missing GPU headers + stop installing generated k…

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -13,6 +13,16 @@ NNTRAINER_ROOT := $(LOCAL_PATH)/../../..
 endif
 
 # Common Includes Definition
+#
+# The last entry is TEMPORARY and app-local: four layer TUs here (mha_core,
+# reshaped_rms_norm, rms_norm_gpu, per_layer_slice_gpu) still include the raw
+# OpenCL kernel wrappers <blas_kernels.h> / <attention_kernels.h> instead of
+# going through the ComputeOps table. Those two headers are private to
+# libnntrainer and are deliberately not installed, so the ndk build reaches
+# them through the nntrainer source dir rather than through the prebuilt
+# include export. Delete that entry together with the last raw
+# nntrainer::*_cl(...) call site under ../layers; it exists to keep the bypass
+# visible and app-local, never to make it ABI.
 CAUSALLM_COMMON_INCLUDES := \
     $(LOCAL_PATH)/.. \
     $(LOCAL_PATH)/../layers \
@@ -33,6 +43,7 @@ CAUSALLM_COMMON_INCLUDES := \
     $(LOCAL_PATH)/../models/lfm2 \
     $(LOCAL_PATH)/../third_party/minja/include \
     $(LOCAL_PATH)/../third_party \
+    $(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
 
 # Common compile flags. -std=c++17/-fexceptions/-frtti come from Application.mk
 # (APP_CPPFLAGS); -march and the FP16 ABI defines are inherited from the
@@ -248,6 +259,7 @@ LOCAL_C_INCLUDES += \
     $(LOCAL_PATH)/../models/gemma4 \
     $(LOCAL_PATH)/../models/xlm_roberta \
     $(LOCAL_PATH)/../models/lfm2 \
+    $(NNTRAINER_ROOT)/nntrainer/tensor/cl_operations \
 
 include $(BUILD_EXECUTABLE)
 

--- a/nntrainer/opencl/meson.build
+++ b/nntrainer/opencl/meson.build
@@ -11,10 +11,13 @@ opencl_sources = [
 
 opencl_headers = [
   'CL/cl_platform.h',
+  'opencl_buffer.h',
   'opencl_buffer_manager.h',
   'opencl_command_queue_manager.h',
   'opencl_context_manager.h',
   'opencl_kernel.h',
+  'opencl_loader.h',
+  'opencl_device_info.h',
   'opencl_program.h'
 ]
 

--- a/nntrainer/tensor/cl_operations/cl_kernels/meson.build
+++ b/nntrainer/tensor/cl_operations/cl_kernels/meson.build
@@ -85,7 +85,12 @@ foreach k : cl_op_kernels
 
   # source.full_path() does not work: https://github.com/mesonbuild/meson/issues/5273#issuecomment-1851811417
   # can be used when meson is upgraded to 1.4.0
-  nntrainer_headers += meson.current_build_dir() / basename + '.h'
+  # NOTE: the generated per-kernel string headers (e.g. swiglu.h, geglu.h) are
+  # INTERNAL to libnntrainer (consumed by the *.cpp below via the build-dir
+  # include path). They are intentionally NOT added to nntrainer_headers, i.e.
+  # not installed: installing them into <prefix>/include/nntrainer shadows
+  # app-side layer headers of the same name (CausalLM's swiglu.h = SwiGLULayer),
+  # breaking the app build. Only the generated .cpp goes into nntrainer_sources.
   nntrainer_sources += meson.current_build_dir() / basename + '.cpp'
 
   all_includes += f'#include "@basename@.h"\n'
@@ -95,7 +100,6 @@ configure_file(
   output: 'cl_kernels.h',
   configuration: {'includes': all_includes},
 )
-nntrainer_headers += meson.current_build_dir() / 'cl_kernels.h'
 
 nntrainer_inc += include_directories('..')
 nntrainer_inc_abs += meson.current_build_dir() / '..'


### PR DESCRIPTION

A from-scratch Android (ndk-build) app build failed because several OpenCL headers the app includes (via the installed <prefix>/include/nntrainer tree) were never added to the meson install lists:
  - nntrainer/opencl: opencl_buffer.h, opencl_loader.h, opencl_device_info.h
  - nntrainer/tensor/cl_operations: blas_kernels.h, attention_kernels.h These are pulled in transitively through cl_context.h and the blas/attention kernel interfaces, so the app could only build when stale copies happened to linger in the install dir (an x86-only-looking build in practice).

Also stop installing the generated per-kernel string headers (swiglu.h, geglu.h, ... and cl_kernels.h). They are INTERNAL to libnntrainer -- consumed by the generated *.cpp via the build-dir include path, never by consumers. Installing them shadows app-side layer headers of the same name (CausalLM's swiglu.h = SwiGLULayer), which broke the app build with a confusing collision.

Build-only change (install lists); no source/runtime behavior change.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
