### PR TITLE
[context] Add the ExecPlan resolver over DeviceCaps + ModelFeatures (shadow)

### DIFF
--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -47,10 +47,11 @@ enum class ExecutionMode {
  * @brief     Enumeration of layer compute engine
  */
 enum LayerComputeEngine {
-  CPU, /**< CPU as the compute engine */
-  GPU, /**< GPU as the compute engine */
-  QNN, /**< QNN as the compute engine */
-  HTP, /**< HTP (Hexagon/HMX NPU) as the compute engine */
+  CPU,  /**< CPU as the compute engine */
+  GPU,  /**< GPU (OpenCL) as the compute engine */
+  QNN,  /**< QNN as the compute engine */
+  HTP,  /**< HTP (Hexagon/HMX NPU) as the compute engine */
+  CUDA, /**< CUDA (NVIDIA GPU) as the compute engine */
 };
 
 /**

--- a/api/ccapi/include/common.h
+++ b/api/ccapi/include/common.h
@@ -47,9 +47,10 @@ enum class ExecutionMode {
  * @brief     Enumeration of layer compute engine
  */
 enum LayerComputeEngine {
-  CPU, /**< CPU as the compute engine */
-  GPU, /**< GPU as the compute engine */
-  QNN, /**< QNN as the compute engine */
+  CPU,  /**< CPU as the compute engine */
+  GPU,  /**< GPU (OpenCL) as the compute engine */
+  QNN,  /**< QNN as the compute engine */
+  CUDA, /**< CUDA (NVIDIA GPU) as the compute engine */
 };
 
 /**

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -47,6 +47,7 @@
 # custom layer kits
 /usr/include/nntrainer/app_context.h
 /usr/include/nntrainer/context.h
+/usr/include/nntrainer/model_features.h
 /usr/include/nntrainer/engine.h
 # logger
 /usr/include/nntrainer/nntrainer_log.h

--- a/debian/nntrainer-dev.install
+++ b/debian/nntrainer-dev.install
@@ -46,6 +46,7 @@
 # custom layer kits
 /usr/include/nntrainer/app_context.h
 /usr/include/nntrainer/context.h
+/usr/include/nntrainer/model_features.h
 /usr/include/nntrainer/engine.h
 # logger
 /usr/include/nntrainer/nntrainer_log.h

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -259,6 +259,10 @@ void AppContext::initialize() noexcept {
 
     add_default_object();
     add_extension_object();
+
+    // Log device capabilities once (log-only, docs/ARCHITECTURE_REFACTOR.md
+    // §10 T1). AppContext inherits the base CPU snapshot (host-coherent).
+    ml_logi("[AppContext] %s", caps().toString().c_str());
   } catch (std::exception &e) {
     ml_loge("registering layers failed!!, reason: %s", e.what());
   } catch (...) {
@@ -703,6 +707,15 @@ template const int AppContext::registerFactory<nntrainer::Optimizer>(
 template const int AppContext::registerFactory<nntrainer::Layer>(
   const FactoryType<nntrainer::Layer> factory, const std::string &key,
   const int int_key);
+
+// Non-template seam (Context::registerLayerFactory override): forwards to the
+// per-class registerFactory<Layer> here in the same TU so the explicit
+// instantiation is used and no template crosses the .so boundary.
+int AppContext::registerLayerFactory(PtrFactoryType<nntrainer::Layer> factory,
+                                     const std::string &key,
+                                     const int int_key) {
+  return registerFactory<nntrainer::Layer>(factory, key, int_key);
+}
 
 /**
  * @copydoc const int AppContext::registerFactory

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -263,6 +263,9 @@ void AppContext::initialize() noexcept {
     // Log device capabilities once (log-only, docs/ARCHITECTURE_REFACTOR.md
     // §10 T1). AppContext inherits the base CPU snapshot (host-coherent).
     ml_logi("[AppContext] %s", caps().toString().c_str());
+    // ExecPlan resolver SHADOW (§10 T4): CPU resolves to gemm_path=CPU.
+    ml_logi("[AppContext] %s (shadow)",
+            resolveExecPlan(caps()).toString().c_str());
   } catch (std::exception &e) {
     ml_loge("registering layers failed!!, reason: %s", e.what());
   } catch (...) {

--- a/nntrainer/app_context.h
+++ b/nntrainer/app_context.h
@@ -181,6 +181,12 @@ public:
                             const std::string &key = "",
                             const int int_key = -1);
 
+  /**
+   * @copydoc Context::registerLayerFactory
+   */
+  int registerLayerFactory(PtrFactoryType<nntrainer::Layer> factory,
+                           const std::string &key, const int int_key) override;
+
   std::unique_ptr<nntrainer::Layer>
   createLayerObject(const std::string &type,
                     const std::vector<std::string> &properties = {}) override {

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -31,6 +31,7 @@
 #include <layer.h>
 #include <layer_devel.h>
 #include <mem_allocator.h>
+#include <model_features.h>
 #include <optimizer.h>
 #include <optimizer_devel.h>
 
@@ -142,14 +143,24 @@ inline const char *toString(GemmPath p) {
  *        decision site reads it, so it is byte-identical.
  *
  *        Only cleanly caps-derivable cells are resolved here. Cells that are
- * NOT a pure function of caps stay env overrides for now and are NOT shadowed:
- *        - kv_backing (Adreno image2d vs Intel cl_mem buffer) — both advertise
- *          image2d; the split is the NEO "cannot compile read_imageui" quirk,
- *          which has no probe. (NNTR_V8C_BUF / NNTR_KV_IMG_ATTN)
- *        - queue sync (NNTR_XE3_SYNC) — a new-ISA coherence regression; wrong ⇒
- *          garbage, so it stays a conservative override.
+ *        NOT a pure function of caps stay env overrides for now and are NOT
+ *        shadowed:
+ *        - kv_backing (image2d vs cl_mem buffer) — both kinds of device
+ *          advertise image2d; the split is a compiler quirk (one vendor's
+ *          driver rejects the integer-coordinate read_imageui kernel), which
+ *          has no direct probe and is derived from the vendor id instead.
+ *        - the SVM coherence drain — a coherence regression whose failure mode
+ *          is wrong output, so it stays a conservative decision. It does have
+ *          a probe (the device's fine-grain-SVM capability), and is the first
+ *          cell scheduled to become resolver-authoritative.
  *        Model-dependent cells (head_dim attention path, KV-share/skip-prefill)
- *        arrive with ModelFeatures (T11).
+ *        arrive with ModelFeatures.
+ *
+ *        Plan ownership: once the resolver is authoritative, the resolved
+ *        ExecPlan belongs to the compiled MODEL (one plan per model instance,
+ *        resolved at compile from that model's ModelFeatures); a Context owns
+ *        only its DeviceCaps. Two models in one process then get two plans
+ *        over one caps.
  */
 struct ExecPlan {
   GemmPath gemm_path = GemmPath::CPU;
@@ -186,74 +197,6 @@ inline ExecPlan resolveExecPlan(const DeviceCaps &c) {
     p.gemm_path = GemmPath::CPU;
   return p;
 }
-
-/** @brief MLP kind a model uses (the gate activation). */
-enum class MlpKind { SWIGLU, GEGLU };
-/** @brief Transformer-block normalization placement. */
-enum class NormStyle { PRE, SANDWICH };
-/** @brief LM-head weight scheme. */
-enum class LmHeadKind { TIED, UNTIED_QINT4 };
-
-inline const char *toString(MlpKind k) {
-  return k == MlpKind::SWIGLU ? "swiglu" : "geglu";
-}
-inline const char *toString(NormStyle s) {
-  return s == NormStyle::SANDWICH ? "sandwich" : "pre";
-}
-inline const char *toString(LmHeadKind k) {
-  return k == LmHeadKind::UNTIED_QINT4 ? "untied_qint4" : "tied";
-}
-
-/**
- * @struct ModelFeatures
- * @brief What the model IS, declared by the model itself (NOT inferred from a
- *        model-name/`is_gemma2` proxy). This is the other half of the resolver
- *        input: `ModelFeatures × DeviceCaps → ExecPlan`. Fields are attributes
- *        (independent feature combos), so a new model is "set the flags" with
- * no backend edit. Currently consumed only by the SHADOW matcher overload below
- * (log-only, byte-identical). docs/ARCHITECTURE_REFACTOR.md §10 T11.
- */
-struct ModelFeatures {
-  bool has_qk_norm = false; /**< per-head q/k RMSNorm (qwen3, gemma4) */
-  bool has_v_norm = false;  /**< gamma-free v-norm (gemma4) */
-  MlpKind mlp_kind = MlpKind::SWIGLU;
-  NormStyle norm_style = NormStyle::PRE;
-  bool sliding_window = false; /**< any sliding-window attention layers */
-  bool kv_share_skip_prefill =
-    false;                    /**< KV-shared layers skip prefill (gemma4) */
-  bool dual_head_dim = false; /**< two head_dims (gemma4 sliding/global) */
-  bool ple = false;           /**< per-layer input embedding (gemma4) */
-  bool attn_softcap = false;  /**< QK logit soft-cap (gemma2/gemma4) */
-  bool final_softcap = false; /**< final-logit soft-cap */
-  LmHeadKind lmhead_kind = LmHeadKind::TIED;
-  bool decode_gpu = false;      /**< GPU attn + OHWI-rope at decode (off for
-                                     d=128); drives gpu_decode_attn /
-                                     gpu_ohwi_rope on the attention layer */
-  bool decode_rope_gpu = false; /**< GPU decode-RoPE (a strict subset of
-                                     decode_gpu: gemma2 diverges, so attn=GPU
-                                     but rope=HOST); drives gpu_decode_rope */
-  unsigned int head_dim = 0;    /**< attention head dim (0 = derive) */
-
-  /**
-   * @brief One-line dump for the shadow log.
-   */
-  std::string toString() const {
-    std::ostringstream os;
-    os << "ModelFeatures{qk_norm=" << has_qk_norm << ", v_norm=" << has_v_norm
-       << ", mlp=" << nntrainer::toString(mlp_kind)
-       << ", norm=" << nntrainer::toString(norm_style)
-       << ", sliding=" << sliding_window
-       << ", kv_share=" << kv_share_skip_prefill
-       << ", dual_head_dim=" << dual_head_dim << ", ple=" << ple
-       << ", attn_softcap=" << attn_softcap
-       << ", final_softcap=" << final_softcap
-       << ", lmhead=" << nntrainer::toString(lmhead_kind)
-       << ", decode_gpu=" << decode_gpu
-       << ", decode_rope_gpu=" << decode_rope_gpu << ", head_dim=" << head_dim
-       << "}";
-    return os.str();
-  }
-};
 
 /**
  * @brief The matcher: resolve the ExecPlan from device caps AND the model's

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -15,6 +15,7 @@
 #define __CONTEXT_H__
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -39,6 +40,67 @@ namespace nntrainer {
 
 // ContextData lives in its own header so that layer_context.h / layer_node.h
 // can pull it in without triggering the context.h → layer_devel.h cycle.
+
+/**
+ * @struct DeviceCaps
+ * @brief Read-only snapshot of device capabilities, probed ONCE per backend at
+ *        Context init from real device queries (clGetDeviceInfo /
+ *        cudaGetDeviceProperties via the per-backend ContextManagers) rather
+ *        than from NNTR_* env flags. Currently LOG-ONLY — no decision site
+ *        reads it yet; it is the input the ExecPlan resolver will consume (see
+ *        docs/ARCHITECTURE_REFACTOR.md §10 T1/T4). Fields describe attributes
+ *        (what the device can do), never identity (who it is); unknown values
+ *        stay at the defaults below.
+ */
+struct DeviceCaps {
+  std::string backend = "cpu";  /**< "cpu" / "gpu" (OpenCL) / "cuda" */
+  std::string device_name = ""; /**< human-readable device name */
+  std::string arch = "";        /**< backend arch tag, e.g. "compute_120" */
+  uint32_t vendor_id = 0;       /**< OpenCL CL_DEVICE_VENDOR_ID; 0 = n/a */
+  bool integrated = true;       /**< host+device share one physical pool
+                                     (host-coherent); CPU = true */
+  bool unified_memory = false;  /**< single-pointer SVM/UVM available */
+  bool subgroups = false;       /**< OpenCL cl_intel_subgroups (XMX/DPAS) */
+  uint32_t compute_units = 0;   /**< OpenCL CL_DEVICE_MAX_COMPUTE_UNITS */
+  uint64_t max_alloc_bytes = 0; /**< per-alloc cap (CL MAX_MEM_ALLOC_SIZE);
+                                     0 = unknown/unbounded */
+  bool image_v8c = true;        /**< device uses the image2d v8c path (FC GEMM +
+                                     KV attention) rather than the cl_mem buffer
+                                     path. Both report CL_DEVICE_IMAGE_SUPPORT, so
+                                     this is not a clean query — it is set from
+                                     vendor_id at init (Intel NEO's compiler
+                                     rejects the integer-coord read_imageui v8c
+                                     kernel ⇒ buffer; Adreno/unknown ⇒ image). The
+                                     V8C_BUF cell of the resolver. */
+  bool dpas = false; /**< OpenCL cl_intel_subgroup_matrix_multiply_accumulate
+                          — the actual systolic-array/DPAS matrix engine
+                          (Xe2/Xe3 "Arc"/"Battlemage" and later). NOT the
+                          same as `subgroups`: cl_intel_subgroups is
+                          advertised by every Intel GPU since Gen9
+                          (Meteor-Lake Xe-LPG included) and has no matrix
+                          unit, so gating XMX on it silently ropes
+                          non-DPAS Intel iGPUs into the DPAS kernel
+                          (IGC emulates it — catastrophic slowdown). This
+                          is the real XMX-capability gate. Declared LAST
+                          so appending it leaves the other field offsets
+                          unmoved (ABI-safe for an app built against the
+                          old DeviceCaps). */
+
+  /**
+   * @brief One-line human-readable dump for the init-time log.
+   */
+  std::string toString() const {
+    std::ostringstream os;
+    os << "DeviceCaps{backend=" << backend << ", device=\"" << device_name
+       << "\", arch=" << (arch.empty() ? "-" : arch) << ", vendor_id=0x"
+       << std::hex << vendor_id << std::dec << ", integrated=" << integrated
+       << ", unified_memory=" << unified_memory << ", subgroups=" << subgroups
+       << ", image_v8c=" << image_v8c << ", dpas=" << dpas
+       << ", compute_units=" << compute_units
+       << ", max_alloc_bytes=" << max_alloc_bytes << "}";
+    return os.str();
+  }
+};
 
 /**
  * @class Context contains user-dependent configuration for  support
@@ -196,6 +258,65 @@ public:
    * @return return 0 for success
    */
   virtual int load(const std::string &file_path) { return 0; };
+
+  /**
+   * @brief Read-only device capability snapshot for this backend, probed once
+   *        at init. The base returns CPU caps (host-coherent, no accelerator);
+   *        ClContext / CudaContext override with a probed snapshot. LOG-ONLY
+   * for now (docs/ARCHITECTURE_REFACTOR.md §10 T1) — no decision site reads it
+   * yet, so adding/overriding it is byte-identical.
+   *
+   * @return const DeviceCaps& capabilities of the device backing this context
+   */
+  virtual const DeviceCaps &caps() const {
+    static const DeviceCaps
+      cpu_caps; // backend="cpu", integrated=true, defaults
+    return cpu_caps;
+  }
+
+  /**
+   * @brief Register a layer factory under this backend. The base default is
+   *        "unsupported" (returns -1); each concrete Context overrides it to
+   *        forward to its own registerFactory<Layer>. This is the non-template
+   *        seam that lets callers register a layer on any backend through
+   *        Engine::registerLayerFactory(engine, creator) WITHOUT a
+   *        static_cast to a concrete ClContext/CudaContext (whose
+   *        registerFactory is a per-class explicit template instantiation, an
+   *        ABI hazard across the .so boundary). [docs/ARCHITECTURE_REFACTOR.md
+   *        §10 T3 / §11 S1]
+   *
+   * @param factory layer creator (createLayer<T> result)
+   * @param key string key (empty ⇒ derived from the layer's getType())
+   * @param int_key integer key (-1 ⇒ auto-assigned)
+   * @return registered integer key, or -1 if the backend cannot register
+   */
+  virtual int registerLayerFactory(PtrFactoryType<nntrainer::Layer>,
+                                   const std::string & = "", const int = -1) {
+    ml_logw("[Context] this backend does not support layer registration");
+    return -1;
+  }
+
+  /**
+   * @brief Which residency plane (LayerComputeEngine) this backend's tensors
+   *        live on. This is the single authority the layer graph consults to
+   *        map a registered engine NAME onto the tensor/residency-plane enum
+   *        (toLayerComputeEngine, layer_node.cpp) — retiring the central
+   *        name→enum string table (ComputeEngineTypeInfo::EnumStr) in favour of
+   *        a per-context declaration. The base is CPU (host residency);
+   *        ClContext→GPU, CudaContext→CUDA, QNNContext→QNN override it. A new
+   *        aliased/added backend just declares its plane here, with no central
+   *        table to edit (add-only). [docs/ARCHITECTURE_REFACTOR.md §10 T3]
+   * @note  NEW vtable tail: appended after every pre-existing slot so a rebuilt
+   *        libnntrainer.so stays ABI-compatible with an app/ccapi built against
+   *        the old vtable. The QNN context lives in the libqnn_context.so
+   *        plugin, which subclasses Context, so that plugin must be rebuilt
+   *        alongside libnntrainer.so (an old plugin lacks this slot entirely —
+   *        calling residencyEngine() on it is UB).
+   * @return residency-plane enum backing this context's tensors
+   */
+  virtual ml::train::LayerComputeEngine residencyEngine() const {
+    return ml::train::LayerComputeEngine::CPU;
+  }
 
 private:
   /**

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -103,6 +103,174 @@ struct DeviceCaps {
 };
 
 /**
+ * @brief Which quantized FC GEMM family this device should run. Derived from
+ *        DeviceCaps (attributes), never from env flags or a device name.
+ */
+enum class GemmPath {
+  CPU,    /**< host CPU backend */
+  DP4A,   /**< OpenCL dp4a / buffer int8xint4 (Adreno, non-XMX Intel) */
+  XMX,    /**< Intel Xe2/Xe3 systolic DPAS
+             (cl_intel_subgroup_matrix_multiply_accumulate present) */
+  CUBLAS, /**< CUDA cuBLAS int8 + dp4a */
+};
+
+/**
+ * @brief Convert a GemmPath to its log string.
+ */
+inline const char *toString(GemmPath p) {
+  switch (p) {
+  case GemmPath::CPU:
+    return "CPU";
+  case GemmPath::DP4A:
+    return "DP4A";
+  case GemmPath::XMX:
+    return "XMX";
+  case GemmPath::CUBLAS:
+    return "CUBLAS";
+  }
+  return "?";
+}
+
+/**
+ * @struct ExecPlan
+ * @brief The backend's resolved execution decisions, derived from DeviceCaps.
+ *        This is the output of the ExecPlan resolver — the single place where
+ *        device attributes (and later ModelFeatures) decide which kernels run,
+ *        replacing scattered NNTR_* env flags. Currently a SHADOW
+ *        (docs/ARCHITECTURE_REFACTOR.md §10 T4): resolved + logged + asserted
+ *        ==  the current env-driven choice, but NOT yet authoritative — no
+ *        decision site reads it, so it is byte-identical.
+ *
+ *        Only cleanly caps-derivable cells are resolved here. Cells that are
+ * NOT a pure function of caps stay env overrides for now and are NOT shadowed:
+ *        - kv_backing (Adreno image2d vs Intel cl_mem buffer) — both advertise
+ *          image2d; the split is the NEO "cannot compile read_imageui" quirk,
+ *          which has no probe. (NNTR_V8C_BUF / NNTR_KV_IMG_ATTN)
+ *        - queue sync (NNTR_XE3_SYNC) — a new-ISA coherence regression; wrong ⇒
+ *          garbage, so it stays a conservative override.
+ *        Model-dependent cells (head_dim attention path, KV-share/skip-prefill)
+ *        arrive with ModelFeatures (T11).
+ */
+struct ExecPlan {
+  GemmPath gemm_path = GemmPath::CPU;
+  bool host_coherent = true; /**< host+device share one pool (no copy needed) */
+  bool decode_gpu = false; /**< run attention/RoPE on the GPU at the M=1 decode
+                                step (model-dependent: gemma2/gemma4 yes, qwen3
+                                no — d=128 diverges). Filled by the
+                              ModelFeatures matcher overload; default off. */
+
+  /**
+   * @brief One-line dump for the shadow log.
+   */
+  std::string toString() const {
+    std::ostringstream os;
+    os << "ExecPlan{gemm_path=" << nntrainer::toString(gemm_path)
+       << ", host_coherent=" << host_coherent << ", decode_gpu=" << decode_gpu
+       << "}";
+    return os.str();
+  }
+};
+
+/**
+ * @brief Resolve the ExecPlan from device capabilities alone (no env, no
+ *        device-name branch). Pure function — the seam the resolver owns.
+ */
+inline ExecPlan resolveExecPlan(const DeviceCaps &c) {
+  ExecPlan p;
+  p.host_coherent = c.integrated;
+  if (c.backend == "cuda")
+    p.gemm_path = GemmPath::CUBLAS;
+  else if (c.backend == "gpu")
+    p.gemm_path = c.dpas ? GemmPath::XMX : GemmPath::DP4A;
+  else
+    p.gemm_path = GemmPath::CPU;
+  return p;
+}
+
+/** @brief MLP kind a model uses (the gate activation). */
+enum class MlpKind { SWIGLU, GEGLU };
+/** @brief Transformer-block normalization placement. */
+enum class NormStyle { PRE, SANDWICH };
+/** @brief LM-head weight scheme. */
+enum class LmHeadKind { TIED, UNTIED_QINT4 };
+
+inline const char *toString(MlpKind k) {
+  return k == MlpKind::SWIGLU ? "swiglu" : "geglu";
+}
+inline const char *toString(NormStyle s) {
+  return s == NormStyle::SANDWICH ? "sandwich" : "pre";
+}
+inline const char *toString(LmHeadKind k) {
+  return k == LmHeadKind::UNTIED_QINT4 ? "untied_qint4" : "tied";
+}
+
+/**
+ * @struct ModelFeatures
+ * @brief What the model IS, declared by the model itself (NOT inferred from a
+ *        model-name/`is_gemma2` proxy). This is the other half of the resolver
+ *        input: `ModelFeatures × DeviceCaps → ExecPlan`. Fields are attributes
+ *        (independent feature combos), so a new model is "set the flags" with
+ * no backend edit. Currently consumed only by the SHADOW matcher overload below
+ * (log-only, byte-identical). docs/ARCHITECTURE_REFACTOR.md §10 T11.
+ */
+struct ModelFeatures {
+  bool has_qk_norm = false; /**< per-head q/k RMSNorm (qwen3, gemma4) */
+  bool has_v_norm = false;  /**< gamma-free v-norm (gemma4) */
+  MlpKind mlp_kind = MlpKind::SWIGLU;
+  NormStyle norm_style = NormStyle::PRE;
+  bool sliding_window = false; /**< any sliding-window attention layers */
+  bool kv_share_skip_prefill =
+    false;                    /**< KV-shared layers skip prefill (gemma4) */
+  bool dual_head_dim = false; /**< two head_dims (gemma4 sliding/global) */
+  bool ple = false;           /**< per-layer input embedding (gemma4) */
+  bool attn_softcap = false;  /**< QK logit soft-cap (gemma2/gemma4) */
+  bool final_softcap = false; /**< final-logit soft-cap */
+  LmHeadKind lmhead_kind = LmHeadKind::TIED;
+  bool decode_gpu = false;      /**< GPU attn + OHWI-rope at decode (off for
+                                     d=128); drives gpu_decode_attn /
+                                     gpu_ohwi_rope on the attention layer */
+  bool decode_rope_gpu = false; /**< GPU decode-RoPE (a strict subset of
+                                     decode_gpu: gemma2 diverges, so attn=GPU
+                                     but rope=HOST); drives gpu_decode_rope */
+  unsigned int head_dim = 0;    /**< attention head dim (0 = derive) */
+
+  /**
+   * @brief One-line dump for the shadow log.
+   */
+  std::string toString() const {
+    std::ostringstream os;
+    os << "ModelFeatures{qk_norm=" << has_qk_norm << ", v_norm=" << has_v_norm
+       << ", mlp=" << nntrainer::toString(mlp_kind)
+       << ", norm=" << nntrainer::toString(norm_style)
+       << ", sliding=" << sliding_window
+       << ", kv_share=" << kv_share_skip_prefill
+       << ", dual_head_dim=" << dual_head_dim << ", ple=" << ple
+       << ", attn_softcap=" << attn_softcap
+       << ", final_softcap=" << final_softcap
+       << ", lmhead=" << nntrainer::toString(lmhead_kind)
+       << ", decode_gpu=" << decode_gpu
+       << ", decode_rope_gpu=" << decode_rope_gpu << ", head_dim=" << head_dim
+       << "}";
+    return os.str();
+  }
+};
+
+/**
+ * @brief The matcher: resolve the ExecPlan from device caps AND the model's
+ *        declared features. The caps-only cells (gemm_path, host_coherent) come
+ *        from resolveExecPlan(caps); the model-dependent cells (decode_gpu, and
+ *        later the head_dim attention path / KV-share) come from ModelFeatures.
+ *        SHADOW for now (no decision site reads it) — byte-identical.
+ */
+inline ExecPlan resolveExecPlan(const DeviceCaps &c, const ModelFeatures &m) {
+  ExecPlan p = resolveExecPlan(c);
+  // A model that wants GPU decode only gets it on a device that can actually
+  // run the resident decode path (a real GPU backend, not the host CPU).
+  p.decode_gpu = m.decode_gpu && (c.backend == "gpu" || c.backend == "cuda");
+  return p;
+}
+
+/**
  * @class Context contains user-dependent configuration for  support
  * @brief  support for app context
  */

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -98,6 +98,10 @@ Engine::parseComputeEngine(const std::vector<std::string> &props) const {
       // self-registers a Context (e.g. "npu", "exynos") then resolves with no
       // enum edit; an unknown/unavailable engine falls back to "cpu" instead of
       // resolving to a name that getRegisteredContext would later reject.
+      // An engine tag is therefore a registered Context NAME, not a device
+      // taxonomy: names are flat keys bound one-per-Context, so "gpu" and
+      // "cuda" are disjoint by construction and no tag is a superset of
+      // another. Nothing downstream should read a hierarchy into them.
       // [docs/ARCHITECTURE_REFACTOR.md §10 T3]
       std::string name = value;
       std::transform(name.begin(), name.end(), name.begin(),

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -93,15 +93,17 @@ Engine::parseComputeEngine(const std::vector<std::string> &props) const {
     std::string key, value;
     int status = nntrainer::getKeyValue(prop, key, value);
     if (nntrainer::istrequal(key, "engine")) {
-      constexpr const auto data =
-        std::data(props::ComputeEngineTypeInfo::EnumList);
-      for (unsigned int i = 0;
-           i < props::ComputeEngineTypeInfo::EnumList.size(); ++i) {
-        if (nntrainer::istrequal(value.c_str(),
-                                 props::ComputeEngineTypeInfo::EnumStr[i])) {
-          return props::ComputeEngineTypeInfo::EnumStr[i];
-        }
-      }
+      // Validate against the LIVE registered-context name set, not the closed
+      // LayerComputeEngine enum + string list. A vendor backend that
+      // self-registers a Context (e.g. "npu", "exynos") then resolves with no
+      // enum edit; an unknown/unavailable engine falls back to "cpu" instead of
+      // resolving to a name that getRegisteredContext would later reject.
+      // [docs/ARCHITECTURE_REFACTOR.md §10 T3]
+      std::string name = value;
+      std::transform(name.begin(), name.end(), name.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      if (engines.find(name) != engines.end())
+        return name;
     }
   }
 

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -101,15 +101,17 @@ Engine::parseComputeEngine(const std::vector<std::string> &props) const {
     std::string key, value;
     int status = nntrainer::getKeyValue(prop, key, value);
     if (nntrainer::istrequal(key, "engine")) {
-      constexpr const auto data =
-        std::data(props::ComputeEngineTypeInfo::EnumList);
-      for (unsigned int i = 0;
-           i < props::ComputeEngineTypeInfo::EnumList.size(); ++i) {
-        if (nntrainer::istrequal(value.c_str(),
-                                 props::ComputeEngineTypeInfo::EnumStr[i])) {
-          return props::ComputeEngineTypeInfo::EnumStr[i];
-        }
-      }
+      // Validate against the LIVE registered-context name set, not the closed
+      // LayerComputeEngine enum + string list. A vendor backend that
+      // self-registers a Context (e.g. "npu", "exynos") then resolves with no
+      // enum edit; an unknown/unavailable engine falls back to "cpu" instead of
+      // resolving to a name that getRegisteredContext would later reject.
+      // [docs/ARCHITECTURE_REFACTOR.md §10 T3]
+      std::string name = value;
+      std::transform(name.begin(), name.end(), name.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      if (engines.find(name) != engines.end())
+        return name;
     }
   }
 

--- a/nntrainer/engine.cpp
+++ b/nntrainer/engine.cpp
@@ -106,6 +106,10 @@ Engine::parseComputeEngine(const std::vector<std::string> &props) const {
       // self-registers a Context (e.g. "npu", "exynos") then resolves with no
       // enum edit; an unknown/unavailable engine falls back to "cpu" instead of
       // resolving to a name that getRegisteredContext would later reject.
+      // An engine tag is therefore a registered Context NAME, not a device
+      // taxonomy: names are flat keys bound one-per-Context, so "gpu" and
+      // "cuda" are disjoint by construction and no tag is a superset of
+      // another. Nothing downstream should read a hierarchy into them.
       // [docs/ARCHITECTURE_REFACTOR.md §10 T3]
       std::string name = value;
       std::transform(name.begin(), name.end(), name.begin(),

--- a/nntrainer/engine.h
+++ b/nntrainer/engine.h
@@ -175,6 +175,29 @@ public:
   std::string parseComputeEngine(const std::vector<std::string> &props) const;
 
   /**
+   * @brief Register a layer factory on a backend by engine name, without a
+   *        static_cast to a concrete Context. Resolves the engine to its
+   *        Context and dispatches through the Context::registerLayerFactory
+   *        virtual (each backend forwards to its own registerFactory<Layer>).
+   *        This is the registration facade for vendor add-only backends and
+   *        the Application layer. [docs/ARCHITECTURE_REFACTOR.md §10 T3 / §11
+   * S1]
+   *
+   * @param engine registered context name ("cpu"/"gpu"/"cuda"/...)
+   * @param creator layer creator (createLayer<T> result)
+   * @param key string key (empty ⇒ derived from getType())
+   * @param int_key integer key (-1 ⇒ auto-assigned)
+   * @return registered integer key, or -1 if the backend cannot register
+   */
+  int registerLayerFactory(
+    const std::string &engine,
+    nntrainer::Context::PtrFactoryType<nntrainer::Layer> creator,
+    const std::string &key = "", const int int_key = -1) const {
+    return getRegisteredContext(engine)->registerLayerFactory(creator, key,
+                                                              int_key);
+  }
+
+  /**
    * @brief Create an Layer Object with Layer name
    *
    * @param type layer name

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -15,6 +15,7 @@
 #include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <node_exporter.h>
+#include <tensor.h>
 #include <util_func.h>
 
 #include <layer_context.h>
@@ -35,11 +36,13 @@ void AdditionLayer::forwarding(RunLayerContext &context, bool training) {
   /** @todo check possibility for in-place of addition layer */
   for (unsigned int idx = 0; idx < context.getNumInputs(); ++idx) {
     const Tensor &input_ = context.getInput(idx);
-    if (!idx) {
-      hidden_.copy(input_);
-    } else {
-      hidden_.add_i(input_);
-    }
+    // idx 0 copies into hidden, the rest accumulate. The tensor's attached
+    // ComputeOps picks the residency path: CpuComputeOps::residual_op is the
+    // host copy()/add_i() this used to call inline (also correct for CUDA UVM),
+    // while ClComputeOps::residual_op keeps a cl_mem/SVM-resident activation on
+    // the device. A host copy()/add_i() on a GPU-resident plane writes only the
+    // host shadow, which a GPU consumer never reads.
+    hidden_.getOps()->residual_op(hidden_, input_, /** accumulate */ idx != 0);
   }
 }
 
@@ -72,11 +75,10 @@ void AdditionLayer::incremental_forwarding(RunLayerContext &context,
 
       Tensor input_step = input_.getSharedDataTensor(
         input_step_dim, b * input_dim.getFeatureLen(), true);
-      if (!idx) {
-        hidden_step.copy(input_step);
-      } else {
-        hidden_step.add_i(input_step);
-      }
+      // Same ComputeOps dispatch as forwarding() above -- this is the path the
+      // decoder residuals (decoder_add / decoder_output) actually take.
+      hidden_step.getOps()->residual_op(hidden_step, input_step,
+                                        /** accumulate */ idx != 0);
     }
   }
 }

--- a/nntrainer/layers/common_properties.h
+++ b/nntrainer/layers/common_properties.h
@@ -1016,6 +1016,21 @@ public:
 };
 
 /**
+ * @brief FusedActivation — a layer-internal activation applied inline in the
+ *        compute layer's forward (after GEMM+bias), instead of as a separate
+ *        ActivationLayer node. Distinct key from `activation` (which is a
+ *        LayerNode *realization* property consumed by ActivationRealizer) so
+ * the FusionRealizer can move the activation onto the compute layer without it
+ *        being split back out into a node.
+ */
+class FusedActivation final
+  : public EnumProperty<nntrainer::props::ActivationTypeInfo> {
+public:
+  using prop_tag = enum_class_prop_tag;
+  static constexpr const char *key = "fused_activation";
+};
+
+/**
  * @brief HiddenStateActivation Enumeration Information
  *
  */

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -308,6 +308,19 @@ void Conv2DLayer::finalize(InitLayerContext &context) {
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "Convolution layer takes only one input";
 
+  // The fusion is a forward-only epilogue: calcDerivative()/calcGradient() do
+  // not chain the activation derivative. Reject it wherever a backward pass
+  // can run instead of silently dropping that term, the same posture the
+  // tflite exporter takes at its own boundary (node_exporter.cpp).
+  if (auto &fused_act = std::get<props::FusedActivation>(conv_props);
+      !fused_act.empty() && fused_act.get() != ActivationType::ACT_NONE) {
+    if (context.getExecutionMode() != ml::train::ExecutionMode::INFERENCE)
+      throw exception::not_supported(
+        "fused_activation on conv2d is inference-only: the backward pass does "
+        "not chain the activation derivative. Use a standalone activation "
+        "layer for training.");
+  }
+
   const TensorDim &in_dim = context.getInputDimensions()[0];
 
   auto &weight_regularizer =

--- a/nntrainer/layers/conv2d_layer.cpp
+++ b/nntrainer/layers/conv2d_layer.cpp
@@ -299,7 +299,8 @@ Conv2DLayer::Conv2DLayer(
   padding(padding_),
   conv_props(props::FilterSize(), std::array<props::KernelSize, CONV2D_DIM>(),
              std::array<props::Stride, CONV2D_DIM>(), props::Padding2D(),
-             std::array<props::Dilation, CONV2D_DIM>()) {
+             std::array<props::Dilation, CONV2D_DIM>(),
+             props::FusedActivation()) {
   wt_idx.fill(std::numeric_limits<unsigned>::max());
 }
 
@@ -475,6 +476,13 @@ void Conv2DLayer::forwarding(RunLayerContext &context, bool training) {
       throw std::invalid_argument("[Conv2D] adding bias failed");
     }
   }
+
+  // Fused activation epilogue dispatched through the op table (backend-
+  // neutral: CPU host ActiFunc / GPU kernel). Value-identical to the standalone
+  // ActivationLayer node it replaces.
+  auto &fused_act = std::get<props::FusedActivation>(conv_props);
+  if (!fused_act.empty() && fused_act.get() != ActivationType::ACT_NONE)
+    hidden_.getOps()->apply_activation(hidden_, (int)fused_act.get());
 }
 
 void Conv2DLayer::calcDerivative(RunLayerContext &context) {

--- a/nntrainer/layers/conv2d_layer.h
+++ b/nntrainer/layers/conv2d_layer.h
@@ -112,7 +112,7 @@ private:
   std::array<unsigned int, CONV2D_DIM * 2> padding;
   std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
              std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-             std::array<props::Dilation, CONV2D_DIM>>
+             std::array<props::Dilation, CONV2D_DIM>, props::FusedActivation>
     conv_props;
 
   std::array<unsigned int, 5> wt_idx; /**< indices of the weights and tensors */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -50,6 +50,19 @@ FullyConnectedLayer::FullyConnectedLayer() :
 }
 
 void FullyConnectedLayer::finalize(InitLayerContext &context) {
+  // The fusion is a forward-only epilogue: calcDerivative()/calcGradient() do
+  // not chain the activation derivative. Reject it wherever a backward pass
+  // can run instead of silently dropping that term, the same posture the
+  // tflite exporter takes at its own boundary (node_exporter.cpp).
+  if (auto &fused_act = std::get<props::FusedActivation>(fc_props);
+      !fused_act.empty() && fused_act.get() != ActivationType::ACT_NONE) {
+    if (context.getExecutionMode() != ml::train::ExecutionMode::INFERENCE)
+      throw exception::not_supported(
+        "fused_activation on fully_connected is inference-only: the backward "
+        "pass does not chain the activation derivative. Use a standalone "
+        "activation layer for training.");
+  }
+
   auto &weight_regularizer =
     std::get<props::WeightRegularizer>(*layer_impl_props);
   auto &weight_regularizer_constant =
@@ -338,6 +351,14 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
         hidden_step.add_i(bias);
       }
     }
+
+    // Same fused activation epilogue as forwarding(), applied to this step's
+    // view only: hidden_ still holds the positions written by earlier
+    // incremental calls, so running it over the whole output would activate
+    // them a second time.
+    if (auto &fused_act = std::get<props::FusedActivation>(fc_props);
+        !fused_act.empty() && fused_act.get() != ActivationType::ACT_NONE)
+      hidden_step.getOps()->apply_activation(hidden_step, (int)fused_act.get());
   }
 }
 

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -42,7 +42,8 @@ enum LORAParams { loraA, loraB, loraTmp, loraOut };
 FullyConnectedLayer::FullyConnectedLayer() :
   LayerImpl(),
   lora_scaling(1.0f),
-  fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha()),
+  fc_props(props::Unit(), props::LoraRank(), props::LoraAlpha(),
+           props::FusedActivation()),
   quantizer(nullptr) {
   weight_idx.fill(std::numeric_limits<unsigned>::max());
   lora_idx.fill(std::numeric_limits<unsigned>::max());
@@ -249,6 +250,14 @@ void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
       hidden_.add_i(bias);
     }
   }
+
+  // Fused activation epilogue dispatched through the op table, so the
+  // fusion is backend-neutral: CpuComputeOps runs the host ActiFunc, a GPU
+  // ComputeOps can fuse it into the GEMM epilogue. Eliminates the separate
+  // ActivationLayer node; value-identical to it.
+  auto &fused_act = std::get<props::FusedActivation>(fc_props);
+  if (!fused_act.empty() && fused_act.get() != ActivationType::ACT_NONE)
+    hidden_.getOps()->apply_activation(hidden_, (int)fused_act.get());
 }
 
 void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -113,12 +113,15 @@ public:
 
 private:
   float lora_scaling;
-  std::tuple<props::Unit, props::LoraRank, props::LoraAlpha>
+  std::tuple<props::Unit, props::LoraRank, props::LoraAlpha,
+             props::FusedActivation>
     fc_props;                             /**< fc layer properties :
                                                 unit - number of output neurons,
                                                 lora_rank - rank of lora (optional)
                                                 lora_scaling - scaling factor of LoRA apply, i.e.,
-                                             lora_scaling = alpha / lora_rank */
+                                             lora_scaling = alpha / lora_rank
+                                                fused_activation - inline activation
+                                             applied after GEMM+bias (T10) */
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   std::array<unsigned int, 4> lora_idx;   /**< indices of the lora weights */
   std::unique_ptr<nntrainer::Quantizer> quantizer;

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -114,6 +114,11 @@ void InitLayerContext::requestOutputs(std::vector<VarGradSpecV2> &&out_specs) {
   for (unsigned i = 0u, sz = out_specs.size(); i < sz; ++i) {
     auto &spec = out_specs.at(i);
     suffixSpec(spec, i);
+    /** stamp this layer's compute engine on its output activation so TensorPool
+     * derives the static residency class (GPU layer output => GPU_CLMEM); input
+     * views inherit it via the shared MemoryData. outSpec() is static so this
+     * is done here, the single chokepoint every output spec passes through. */
+    spec.variable_spec.engine = engine;
     if (is_dangled(i)) {
       ml_logw("given output is being dangled: %s in context: %s",
               spec.variable_spec.name.c_str(), name.c_str());

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -104,6 +104,13 @@ public:
   ml::train::LayerComputeEngine getComputeEngineType() { return engine; };
 
   /**
+   * @brief  set the layer compute engine (used by refinalize, which builds the
+   *         context without the engine arg). Must be set before the layer
+   *         requests its outputs so outSpec() stamps the right residency.
+   */
+  void setComputeEngine(ml::train::LayerComputeEngine e) { engine = e; }
+
+  /**
    * @brief   get name by the layer
    *
    * @return name of the layer
@@ -995,6 +1002,23 @@ public:
    */
   bool reStoreData() { return restoreData; }
 
+  /**
+   * @brief  Set the layer's compute engine on the run context (NNTR_DEVRES
+   *         Step 0). Threaded in from LayerNode::compute_engine at
+   *         configureRunContext time. Lets the residency overlay know, at the
+   *         universal getInput/getOutput accessor, whether THIS consuming layer
+   *         runs on GPU or CPU (needed to decide device->host sync). Inert
+   * until a later step reads it; default CPU keeps the host path.
+   */
+  void setRunComputeEngine(ml::train::LayerComputeEngine e) { run_engine = e; }
+
+  /**
+   * @brief  Get the layer's compute engine (CPU/GPU) for this run context.
+   */
+  ml::train::LayerComputeEngine getRunComputeEngine() const {
+    return run_engine;
+  }
+
 private:
   std::tuple<props::Name, props::Trainable> props; /**< props of the layer */
   std::shared_ptr<ContextData> ct_data;
@@ -1002,6 +1026,8 @@ private:
   bool is_inplace;  /**< if the layer is expected to run in-place */
   float loss_scale; /**< loss_scale of the layer */
   bool restoreData; /**< reset output for mixed precsion */
+  ml::train::LayerComputeEngine run_engine =
+    ml::train::LayerComputeEngine::CPU; /**< NNTR_DEVRES: this layer's engine */
 
   std::vector<Weight *> weights;   /**< weights of the layer */
   std::vector<Var_Grad *> inputs;  /**< inputs of the layer */

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -339,25 +339,28 @@ void LayerNode::setComputeEngine(
   this->compute_engine = "cpu";
 }
 
-bool LayerNode::isComputeEngineGPU() const {
+ml::train::LayerComputeEngine LayerNode::residencyEngine() const {
   if (!layer_node_props)
-    return false;
+    return ml::train::LayerComputeEngine::CPU;
   auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
-  return !ce.empty() && istrequal(ce.get(), "gpu");
+  if (ce.empty())
+    return ml::train::LayerComputeEngine::CPU;
+  // The engine tag is a registered Context NAME, so the plane is whatever that
+  // Context declares (Context::residencyEngine()) -- not something decided
+  // here by comparing the name against a hardcoded spelling.
+  return toLayerComputeEngine(ce.get());
+}
+
+bool LayerNode::isComputeEngineGPU() const {
+  return residencyEngine() == ml::train::LayerComputeEngine::GPU;
 }
 
 bool LayerNode::isComputeEngineCUDA() const {
-  if (!layer_node_props)
-    return false;
-  auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
-  return !ce.empty() && istrequal(ce.get(), "cuda");
+  return residencyEngine() == ml::train::LayerComputeEngine::CUDA;
 }
 
 bool LayerNode::isComputeEngineCPU() const {
-  if (!layer_node_props)
-    return true;
-  auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
-  return ce.empty() || istrequal(ce.get(), "cpu");
+  return residencyEngine() == ml::train::LayerComputeEngine::CPU;
 }
 
 const std::string LayerNode::getName() const {

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -132,29 +132,38 @@ public:
 LayerNode::~LayerNode() = default;
 
 /**
- * @brief get the compute engine property from property string vector
- *  : default is CPU
- * @return LayerComputeEngine Enum : CPU, GPU, QNN
- *
+ * @brief map a registered engine NAME onto the residency-plane enum: the
+ *        tensor/residency plane (tensor_wrap_specs, InitLayerContext,
+ *        RunLayerContext) still speaks LayerComputeEngine. cpu/gpu/qnn/cuda
+ *        map 1:1; "npu" is a QNN context alias; any other registered name
+ *        gets CPU (host) residency — its DISPATCH is name-based via
+ *        getRegisteredContext, only the memory plane defaults to host.
  */
-ml::train::LayerComputeEngine
-getComputeEngine(const std::vector<std::string> &props) {
-  for (auto &prop : props) {
-    std::string key, value;
-    int status = nntrainer::getKeyValue(prop, key, value);
-    if (nntrainer::istrequal(key, "engine")) {
-      constexpr const auto data =
-        std::data(props::ComputeEngineTypeInfo::EnumList);
-      for (unsigned int i = 0;
-           i < props::ComputeEngineTypeInfo::EnumList.size(); ++i) {
-        if (nntrainer::istrequal(value.c_str(),
-                                 props::ComputeEngineTypeInfo::EnumStr[i])) {
-          return data[i];
-        }
-      }
-    }
+static ml::train::LayerComputeEngine
+toLayerComputeEngine(const std::string &name) {
+  // A registered context DECLARES its own residency plane via
+  // Context::residencyEngine() -- the single authority, retiring the central
+  // name->enum string table below. Registry ALIASES collapse onto their backend
+  // for free: "npu" is registered as an alias of the "qnn" context
+  // (engine.cpp), so getRegisteredContext("npu") returns the QNN context and
+  // residencyEngine() reports QNN -- no per-alias special case here, and a new
+  // aliased/added backend just declares its plane in its Context override
+  // (add-only, no edit here). [docs/ARCHITECTURE_REFACTOR.md §10 T3]
+  try {
+    auto ctx = nntrainer::Engine::Global().getRegisteredContext(name);
+    if (ctx != nullptr)
+      return ctx->residencyEngine();
+  } catch (...) {
+    // fall through to the enum table below
   }
-
+  // Name not registered in this build (e.g. a cpu-only build that still parsed
+  // "cuda"): map the raw spelling through the string table, defaulting to CPU.
+  constexpr const auto data = std::data(props::ComputeEngineTypeInfo::EnumList);
+  for (unsigned int i = 0; i < props::ComputeEngineTypeInfo::EnumList.size();
+       ++i) {
+    if (nntrainer::istrequal(name, props::ComputeEngineTypeInfo::EnumStr[i]))
+      return data[i];
+  }
   return ml::train::LayerComputeEngine::CPU;
 }
 
@@ -219,6 +228,17 @@ void LayerNode::setProperty(const std::vector<std::string> &properties) {
   auto left_properties = loadProperties(properties, *layer_node_props);
   left_properties =
     loadProperties(left_properties, *layer_node_props_realization);
+
+  /// registry-open engine name [§10 T3]: normalize the parsed name against
+  /// the live Engine registry (lowercase; unregistered -> "cpu" fallback), so
+  /// the node's engine always names a context that getRegisteredContext() can
+  /// resolve and always matches the backend createLayerObject() chose via the
+  /// same parseComputeEngine call.
+  auto &ce_prop = std::get<props::ComputeEngine>(*layer_node_props);
+  if (!ce_prop.empty())
+    ce_prop.set(
+      Engine::Global().parseComputeEngine({"engine=" + ce_prop.get()}));
+
   layer->setProperty(left_properties);
 
   if (getType() == ActivationLayer::type) {
@@ -306,9 +326,38 @@ void LayerNode::setOutputConnection(unsigned nth, const std::string &name,
 
 void LayerNode::setComputeEngine(
   const ml::train::LayerComputeEngine &compute_engine) {
-  // setting compute_engine of LayerNode
-  // can be reused later to propagate this info
-  this->compute_engine = compute_engine;
+  // compat shim (no callers in-tree): the node-level engine is stored as the
+  // registered context NAME now; map the legacy enum to its canonical name.
+  constexpr const auto data = std::data(props::ComputeEngineTypeInfo::EnumList);
+  for (unsigned int i = 0; i < props::ComputeEngineTypeInfo::EnumList.size();
+       ++i) {
+    if (data[i] == compute_engine) {
+      this->compute_engine = props::ComputeEngineTypeInfo::EnumStr[i];
+      return;
+    }
+  }
+  this->compute_engine = "cpu";
+}
+
+bool LayerNode::isComputeEngineGPU() const {
+  if (!layer_node_props)
+    return false;
+  auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
+  return !ce.empty() && istrequal(ce.get(), "gpu");
+}
+
+bool LayerNode::isComputeEngineCUDA() const {
+  if (!layer_node_props)
+    return false;
+  auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
+  return !ce.empty() && istrequal(ce.get(), "cuda");
+}
+
+bool LayerNode::isComputeEngineCPU() const {
+  if (!layer_node_props)
+    return true;
+  auto &ce = std::get<props::ComputeEngine>(*layer_node_props);
+  return ce.empty() || istrequal(ce.get(), "cpu");
 }
 
 const std::string LayerNode::getName() const {
@@ -664,7 +713,8 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
 
   auto context = InitLayerContext(
     actual_input_dims, out_info, getInPlaceType() != InPlaceType::NONE,
-    getName(), scope, max_norm, tensor_type, loss_scale, mode, compute_engine);
+    getName(), scope, max_norm, tensor_type, loss_scale, mode,
+    toLayerComputeEngine(compute_engine));
 
   layer->finalize(context);
 
@@ -969,6 +1019,10 @@ void LayerNode::configureRunContext(const std::vector<Weight *> &weights,
   run_context = std::make_unique<RunLayerContext>(
     getName(), getTrainable(), 0.0f, getInPlaceType() != InPlaceType::NONE,
     loss_scale, ct_data, false, weights, inputs, outputs, tensors);
+  // NNTR_DEVRES Step 0: thread the layer's compute engine onto the run context
+  // so the residency overlay can tell CPU vs GPU consumers at
+  // getInput/getOutput. Inert (default CPU; nothing reads it yet).
+  run_context->setRunComputeEngine(toLayerComputeEngine(compute_engine));
 }
 
 /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -1000,30 +1000,50 @@ public:
   std::string getComputeEngineType() { return compute_engine; }
 
   /**
-   * @brief Query whether this node requests the GPU compute engine via its
-   *        `engine` property. Unlike getComputeEngineType() (which reflects the
-   *        cached member set only during finalize()), this reads the property
-   *        directly and is therefore valid earlier, e.g. when choosing the
-   *        graph-wide memory allocator at NetworkGraph construction.
-   * @return true iff the `engine` property is set and equals GPU
+   * @brief Which residency plane this node's tensors live on, resolved from
+   *        its `engine` property.
+   *
+   * An engine tag is a registered Context NAME, not a device taxonomy: names
+   * are flat map keys bound one-per-Context by registerContext(), so "gpu" and
+   * "cuda" are disjoint by construction and neither is a superset of the
+   * other. The name is therefore not something to pattern-match on; the
+   * Context it resolves to declares its own plane via
+   * Context::residencyEngine(), and this query reports that declaration. A
+   * vendor backend that self-registers under any name (e.g. "npu", "exynos")
+   * resolves here with no edit to this class.
+   *
+   * Unlike getComputeEngineType() (which reflects the cached member set only
+   * during finalize()), this reads the property directly and is therefore
+   * valid earlier, e.g. when choosing the graph-wide memory allocator at
+   * NetworkGraph construction.
+   *
+   * @return residency plane of this node (CPU when the property is unset)
+   */
+  ml::train::LayerComputeEngine residencyEngine() const;
+
+  /**
+   * @brief Query whether this node's tensors live on the OpenCL residency
+   *        plane. Shorthand for `residencyEngine() == GPU`; a CUDA node
+   *        reports CUDA, not GPU, because the two are separate planes with
+   *        separate allocators - see residencyEngine() for the contract.
+   * @return true iff this node's engine resolves to the GPU plane
    */
   bool isComputeEngineGPU() const;
 
   /**
-   * @brief Query whether this node requests the CUDA compute engine via its
-   *        `engine` property (the additive NVIDIA backend). Same direct-read
-   *        rationale as isComputeEngineGPU(); used to route the graph's memory
-   *        allocator to CUDA Unified Memory.
-   * @return true iff the `engine` property is set and equals CUDA
+   * @brief Query whether this node's tensors live on the CUDA residency plane
+   *        (the additive NVIDIA backend); used to route the graph's memory
+   *        allocator to CUDA Unified Memory. Shorthand for
+   *        `residencyEngine() == CUDA`.
+   * @return true iff this node's engine resolves to the CUDA plane
    */
   bool isComputeEngineCUDA() const;
 
   /**
-   * @brief Query whether this node runs on the CPU compute engine (the
-   *        `engine` property is unset — CPU is the default — or explicitly
-   *        CPU). Same direct-read rationale as isComputeEngineGPU(): valid
-   *        before finalize(), e.g. for compile-time graph realizers.
-   * @return true iff the node's engine resolves to CPU
+   * @brief Query whether this node runs on the host residency plane (the
+   *        `engine` property is unset — CPU is the default — or resolves to a
+   *        host-resident Context). Shorthand for `residencyEngine() == CPU`.
+   * @return true iff this node's engine resolves to CPU
    */
   bool isComputeEngineCPU() const;
 

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -991,16 +991,41 @@ public:
    */
   bool reStoreData() { return needs_restore_data; }
 
-  std::string getComputeEngineType() {
-    auto size = props::ComputeEngineTypeInfo::EnumList.size();
-    auto data = std::data(props::ComputeEngineTypeInfo::EnumList);
-    for (unsigned i = 0; i < size; ++i) {
-      if (data[i] == compute_engine) {
-        return props::ComputeEngineTypeInfo::EnumStr[i];
-      }
-    }
-    return "cpu";
-  }
+  /**
+   * @brief the node's compute-engine NAME — a registered Context name, cached
+   *        from the `engine=` property at finalize() ("cpu" until then).
+   *        Registry-open: may be any Engine-registered name (e.g. "npu"), not
+   *        just the closed enum's four; feeds getRegisteredContext() directly.
+   */
+  std::string getComputeEngineType() { return compute_engine; }
+
+  /**
+   * @brief Query whether this node requests the GPU compute engine via its
+   *        `engine` property. Unlike getComputeEngineType() (which reflects the
+   *        cached member set only during finalize()), this reads the property
+   *        directly and is therefore valid earlier, e.g. when choosing the
+   *        graph-wide memory allocator at NetworkGraph construction.
+   * @return true iff the `engine` property is set and equals GPU
+   */
+  bool isComputeEngineGPU() const;
+
+  /**
+   * @brief Query whether this node requests the CUDA compute engine via its
+   *        `engine` property (the additive NVIDIA backend). Same direct-read
+   *        rationale as isComputeEngineGPU(); used to route the graph's memory
+   *        allocator to CUDA Unified Memory.
+   * @return true iff the `engine` property is set and equals CUDA
+   */
+  bool isComputeEngineCUDA() const;
+
+  /**
+   * @brief Query whether this node runs on the CPU compute engine (the
+   *        `engine` property is unset — CPU is the default — or explicitly
+   *        CPU). Same direct-read rationale as isComputeEngineGPU(): valid
+   *        before finalize(), e.g. for compile-time graph realizers.
+   * @return true iff the node's engine resolves to CPU
+   */
+  bool isComputeEngineCPU() const;
 
 private:
   /**
@@ -1030,11 +1055,13 @@ private:
     output_connections; /**< output layer names */
 
   /**
-   * @brief compute_engine Information about the compute backend being used
-   *
+   * @brief compute_engine — the compute backend as a registered Context NAME
+   *        (registry-open; "npu"/"vulkan"-style self-registered backends need
+   *        no enum edit). The residency plane still speaks the
+   *        LayerComputeEngine enum via toLayerComputeEngine() in
+   *        layer_node.cpp.
    */
-  ml::train::LayerComputeEngine compute_engine =
-    ml::train::LayerComputeEngine::CPU;
+  std::string compute_engine = "cpu";
 
 #ifdef ENABLE_TEST
   /**

--- a/nntrainer/meson.build
+++ b/nntrainer/meson.build
@@ -21,6 +21,7 @@ nntrainer_headers = [
    meson.current_source_dir() / 'context_data.h',
    meson.current_source_dir() / 'engine.h',
    meson.current_source_dir() / 'mem_allocator.h',
+   meson.current_source_dir() / 'model_features.h',
 ]
 
 nntrainer_base_deps=[

--- a/nntrainer/model_features.h
+++ b/nntrainer/model_features.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file    model_features.h
+ * @date    29 Jul 2026
+ * @see     https://github.com/nntrainer/nntrainer
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug     No known bugs except for NYI items
+ * @brief   What a model IS — the model-side half of the ExecPlan resolver
+ * input.
+ *
+ * Kept in its own dependency-free header so a model can declare its features
+ * without including the Context header: these fields are model topology, not
+ * device capability, and the model layer must not have to reach into the
+ * backend layer to describe itself. The resolver (context.h) includes this
+ * header, not the other way round.
+ */
+
+#ifndef __MODEL_FEATURES_H__
+#define __MODEL_FEATURES_H__
+
+#include <sstream>
+#include <string>
+
+namespace nntrainer {
+
+/** @brief MLP kind a model uses (the gate activation). */
+enum class MlpKind { SWIGLU, GEGLU };
+/** @brief Transformer-block normalization placement. */
+enum class NormStyle { PRE, SANDWICH };
+/** @brief LM-head weight scheme. */
+enum class LmHeadKind { TIED, UNTIED_QINT4 };
+
+inline const char *toString(MlpKind k) {
+  return k == MlpKind::SWIGLU ? "swiglu" : "geglu";
+}
+inline const char *toString(NormStyle s) {
+  return s == NormStyle::SANDWICH ? "sandwich" : "pre";
+}
+inline const char *toString(LmHeadKind k) {
+  return k == LmHeadKind::UNTIED_QINT4 ? "untied_qint4" : "tied";
+}
+
+/**
+ * @struct ModelFeatures
+ * @brief What the model IS, declared by the model itself (NOT inferred from a
+ *        model-name/`is_gemma2` proxy). This is the other half of the resolver
+ *        input: `ModelFeatures × DeviceCaps → ExecPlan`. Fields are attributes
+ *        (independent feature combos), so a new model is "set the flags" with
+ *        no backend edit. Currently consumed only by the SHADOW matcher
+ *        overload in context.h (log-only, byte-identical).
+ *        docs/ARCHITECTURE_REFACTOR.md §10 T11.
+ */
+struct ModelFeatures {
+  bool has_qk_norm = false; /**< per-head q/k RMSNorm (qwen3, gemma4) */
+  bool has_v_norm = false;  /**< gamma-free v-norm (gemma4) */
+  MlpKind mlp_kind = MlpKind::SWIGLU;
+  NormStyle norm_style = NormStyle::PRE;
+  bool sliding_window = false; /**< any sliding-window attention layers */
+  bool kv_share_skip_prefill =
+    false;                    /**< KV-shared layers skip prefill (gemma4) */
+  bool dual_head_dim = false; /**< two head_dims (gemma4 sliding/global) */
+  bool ple = false;           /**< per-layer input embedding (gemma4) */
+  bool attn_softcap = false;  /**< QK logit soft-cap (gemma2/gemma4) */
+  bool final_softcap = false; /**< final-logit soft-cap */
+  LmHeadKind lmhead_kind = LmHeadKind::TIED;
+  bool decode_gpu = false;      /**< GPU attn + OHWI-rope at decode (off for
+                                     d=128); drives gpu_decode_attn /
+                                     gpu_ohwi_rope on the attention layer */
+  bool decode_rope_gpu = false; /**< GPU decode-RoPE (a strict subset of
+                                     decode_gpu: gemma2 diverges, so attn=GPU
+                                     but rope=HOST); drives gpu_decode_rope */
+  unsigned int head_dim = 0;    /**< attention head dim (0 = derive) */
+
+  /**
+   * @brief One-line dump for the shadow log.
+   */
+  std::string toString() const {
+    std::ostringstream os;
+    os << "ModelFeatures{qk_norm=" << has_qk_norm << ", v_norm=" << has_v_norm
+       << ", mlp=" << nntrainer::toString(mlp_kind)
+       << ", norm=" << nntrainer::toString(norm_style)
+       << ", sliding=" << sliding_window
+       << ", kv_share=" << kv_share_skip_prefill
+       << ", dual_head_dim=" << dual_head_dim << ", ple=" << ple
+       << ", attn_softcap=" << attn_softcap
+       << ", final_softcap=" << final_softcap
+       << ", lmhead=" << nntrainer::toString(lmhead_kind)
+       << ", decode_gpu=" << decode_gpu
+       << ", decode_rope_gpu=" << decode_rope_gpu << ", head_dim=" << head_dim
+       << "}";
+    return os.str();
+  }
+};
+
+} // namespace nntrainer
+
+#endif // __MODEL_FEATURES_H__

--- a/nntrainer/tensor/cpu_backend/compute_ops.cpp
+++ b/nntrainer/tensor/cpu_backend/compute_ops.cpp
@@ -48,6 +48,13 @@ void ensureComputeOps() {
   std::call_once(g_compute_ops_init_flag, []() { init_backend(); });
 }
 
+ComputeOps *getComputeOps() {
+  // Out-of-line on purpose — see the header note (shared-build data-export).
+  if (g_compute_ops == nullptr)
+    ensureComputeOps();
+  return g_compute_ops;
+}
+
 [[noreturn]] void ComputeOps::throwNotImplemented(const char *op) {
   throw std::runtime_error(std::string("ComputeOps::") + op +
                            " not implemented by this backend");
@@ -405,6 +412,29 @@ void ComputeOps::compute_rotary_embedding_value(unsigned int, unsigned int,
   NI(compute_rotary_embedding_value);
 }
 #endif // ENABLE_FP16
+
+// Whole-op (Tensor-level) — default throw; Cpu/Cl/Cuda subclasses override.
+void ComputeOps::geglu(const Tensor &, const Tensor &, Tensor &, unsigned int,
+                       unsigned int) {
+  NI(geglu);
+}
+void ComputeOps::swiglu(const Tensor &, const Tensor &, Tensor &, unsigned int,
+                        unsigned int) {
+  NI(swiglu);
+}
+void ComputeOps::sigmoid_glu(const Tensor &, const Tensor &, Tensor &,
+                             unsigned int, unsigned int) {
+  NI(sigmoid_glu);
+}
+void ComputeOps::sigmoid_add(const Tensor &, const Tensor &, Tensor &,
+                             unsigned int, unsigned int) {
+  NI(sigmoid_add);
+}
+void ComputeOps::residual_op(Tensor &, const Tensor &, bool) {
+  NI(residual_op);
+}
+void ComputeOps::fc(Tensor &, Tensor &, Tensor &) { NI(fc); }
+void ComputeOps::apply_activation(Tensor &, int) { NI(apply_activation); }
 
 #undef NI
 

--- a/nntrainer/tensor/cpu_backend/compute_ops.h
+++ b/nntrainer/tensor/cpu_backend/compute_ops.h
@@ -40,6 +40,8 @@
 
 namespace nntrainer {
 
+class Tensor;
+
 /**
  * @class ComputeOps
  * @brief Abstract dispatch interface for tensor compute kernels.
@@ -375,6 +377,90 @@ public:
                                               float *sin_);
 #endif // ENABLE_FP16
 
+  // ===========================================================================
+  // Whole-op (Tensor-level) ops — the §11 op_table pattern: a thin neutral
+  // Layer owns structure/shape/orchestration while ComputeOps owns the whole
+  // kernel. Unlike the raw-pointer ops above, these take Tensors so the backend
+  // impl can introspect residency (isClMem/getClMem/isSVM) and bind device
+  // buffers directly. Default throws; CPU/CL/CUDA subclasses override.
+  // ===========================================================================
+
+  /**
+   * @brief GeGLU activation over the first `active_rows` rows starting at
+   *        `row_offset`: out = gelu_tanh(in1) * in2 ({gate, up} -> result).
+   *        in1/in2/out share shape; width() is the per-row element count.
+   */
+  virtual void geglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                     unsigned int active_rows, unsigned int row_offset);
+
+  /**
+   * @brief SwiGLU activation over the first `active_rows` rows starting at
+   *        `row_offset`: out = silu(in1) * in2 = (in1 * sigmoid(in1)) * in2
+   *        ({gate, up} -> result). in1/in2/out share shape; width() is the
+   *        per-row element count.
+   */
+  virtual void swiglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                      unsigned int active_rows, unsigned int row_offset);
+
+  /**
+   * @brief Sigmoid-GLU over the first `active_rows` rows starting at
+   *        `row_offset`: out = sigmoid(in1) * in2 ({gate, up} -> result).
+   *        in1/in2/out share shape; width() is the per-row element count.
+   *        E.g. a sigmoid-gated attention output gate.
+   */
+  virtual void sigmoid_glu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                           unsigned int active_rows, unsigned int row_offset);
+
+  /**
+   * @brief Sigmoid-add over the first `active_rows` rows starting at
+   *        `row_offset`: out = sigmoid(in1) + in2 ({gate, emb} -> result).
+   *        in1/in2/out share shape; width() is the per-row element count.
+   *        E.g. a per-layer-embedding (PLE) mix path (method=1).
+   */
+  virtual void sigmoid_add(const Tensor &in1, const Tensor &in2, Tensor &out,
+                           unsigned int active_rows, unsigned int row_offset);
+
+  /**
+   * @brief One residual-add operand: hidden = input (accumulate=false, the
+   *        first operand) or hidden += input (accumulate=true). The neutral
+   *        AdditionLayer calls this per input so the GPU backend can keep the
+   *        residual stream device-resident (cl_mem/SVM) while CPU/CUDA run the
+   *        host Tensor copy/add on the managed buffer.
+   */
+  virtual void residual_op(Tensor &hidden, const Tensor &input,
+                           bool accumulate);
+
+  /**
+   * @brief Fully-connected GEMM: output = input * weight. The neutral
+   *        FullyConnectedLayer owns the weight/bias binding and calls this for
+   *        the matmul, so the quantized accelerator path (OpenCL v8c w4a8 /
+   *        CUDA cuda_fc_qint4) lives in the op table instead of a forked Layer.
+   *        input/weight may carry residency state the impl reads, hence
+   * non-const.
+   */
+  virtual void fc(Tensor &input, Tensor &weight, Tensor &output);
+
+  /**
+   * @brief Optional one-time weight transform at load (e.g. the OpenCL v8c
+   *        repack). Default no-op; backends that benefit override it. Called
+   *        from the layer's read() after the weights are loaded.
+   */
+  virtual void fc_prebuild_weight(Tensor &weight) { (void)weight; }
+
+  /**
+   * @brief Fused activation epilogue: apply an element-wise activation in place
+   *        on a compute layer's output, after GEMM+bias. This is the op-table
+   *        half of the FusionRealizer (§10 T10): the neutral conv/fc layer
+   * calls out.getOps()->apply_activation(out, act) instead of routing the data
+   *        through a separate ActivationLayer node, so the fusion is
+   *        backend-neutral — CpuComputeOps runs the host ActiFunc, and a GPU
+   *        backend can override with a kernel that fuses it into the GEMM
+   *        epilogue. @p act_type is an nntrainer::ActivationType cast to int
+   * (kept as int here so compute_ops.h stays free of the layers headers);
+   * ACT_NONE is a no-op.
+   */
+  virtual void apply_activation(Tensor &out, int act_type);
+
 protected:
   /**
    * @brief Helper used by default impls to throw a uniform "not
@@ -398,16 +484,14 @@ void ensureComputeOps();
 
 /**
  * @brief Get the active compute ops with lazy initialization.
+ * @note  Out-of-line on purpose (defined in compute_ops.cpp): the previous
+ *        inline definition dereferenced the extern g_compute_ops data symbol
+ *        from consumer modules — under default_library=shared on Windows the
+ *        auto-generated export .def covers functions but not data, so every
+ *        external TU that inlined this failed to link (LNK2019 on
+ *        g_compute_ops). An exported function keeps the data module-private.
  */
-inline ComputeOps *getComputeOps() {
-#if defined(__GNUC__) || defined(__clang__)
-  if (__builtin_expect(g_compute_ops == nullptr, 0))
-#else
-  if (g_compute_ops == nullptr)
-#endif
-    ensureComputeOps();
-  return g_compute_ops;
-}
+ComputeOps *getComputeOps();
 
 /**
  * @brief Initialize the CPU compute backend.

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -16,350 +16,194 @@
  * dispatch picks the right symbol at link time.
  */
 
-#include <compute_ops.h>
-#include <cpu_backend.h>
+#include "cpu_ops_table.h"
+
+#include <cmath>
+#include <stdexcept>
+
+#include <acti_func.h>
+#include <tensor.h>
 
 namespace nntrainer {
-
-class CpuComputeOps : public ComputeOps {
-public:
-  // FP32 BLAS
-  void sgemm_fp32(unsigned int o, bool tA, bool tB, unsigned int M,
-                  unsigned int N, unsigned int K, float a, const float *A,
-                  unsigned int lda, const float *B, unsigned int ldb, float b,
-                  float *C, unsigned int ldc) override {
-    nntrainer::sgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
-  }
-  void sgemv_fp32(unsigned int o, bool tA, unsigned int M, unsigned int N,
-                  float a, const float *A, unsigned int lda, const float *X,
-                  unsigned int iX, float b, float *Y,
-                  unsigned int iY) override {
-    nntrainer::sgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
-  }
-  float sdot_fp32(unsigned int N, const float *X, unsigned int iX,
-                  const float *Y, unsigned int iY) override {
-    return nntrainer::sdot(N, X, iX, Y, iY);
-  }
-  void saxpy_fp32(unsigned int N, float a, const float *X, unsigned int iX,
-                  float *Y, unsigned int iY) override {
-    nntrainer::saxpy(N, a, X, iX, Y, iY);
-  }
-  void scopy_fp32(unsigned int N, const float *X, unsigned int iX, float *Y,
-                  unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void sscal_fp32(unsigned int N, float a, float *X, unsigned int iX) override {
-    nntrainer::sscal(N, a, X, iX);
-  }
-  float snrm2_fp32(unsigned int N, const float *X, unsigned int iX) override {
-    return nntrainer::snrm2(N, X, iX);
-  }
-  unsigned int isamax_fp32(unsigned int N, const float *X,
-                           unsigned int iX) override {
-    return nntrainer::isamax(N, X, iX);
-  }
-
-  // FP32 Element-wise
-  void ele_mul_fp32(unsigned int N, const float *X, const float *Y, float *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_mul(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_add_fp32(unsigned int N, const float *X, const float *Y, float *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_add(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_sub_fp32(unsigned int N, const float *X, const float *Y, float *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_sub(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_div_fp32(unsigned int N, const float *X, const float *Y, float *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_div(N, X, Y, Z, a, b, is, os);
-  }
-
-  // FP32 Activation / Special
-  void swiglu_fp32(unsigned int N, float *X, float *Y, float *Z) override {
-    nntrainer::swiglu(N, X, Y, Z);
-  }
-  void swiglu_alpha_fp32(unsigned int N, float *X, float *Y, float *Z,
-                         float alpha) override {
-    nntrainer::swiglu(N, X, Y, Z, alpha);
-  }
-  void tanh_gelu_fp32(unsigned int N, const float *X, float *Y) override {
-    nntrainer::tanh_gelu(N, X, Y);
-  }
-  void gelu_v2_fp32(unsigned int N, const float *X, float *Y) override {
-    nntrainer::gelu_v2(N, X, Y);
-  }
-  void tanh_gelu_v2_fp32(unsigned int N, const float *X, float *Y) override {
-    nntrainer::tanh_gelu_v2(N, X, Y);
-  }
-  void tanh_gelu_mul_fp32(unsigned int N, float *X, float *Y,
-                          float *Z) override {
-    nntrainer::tanh_gelu_mul(N, X, Y, Z);
-  }
-  void tanh_gelu_v2_mul_fp32(unsigned int N, float *X, float *Y,
-                             float *Z) override {
-    nntrainer::tanh_gelu_v2_mul(N, X, Y, Z);
-  }
-  float max_val_fp32(unsigned int N, float *X) override {
-    return nntrainer::max_val(N, X);
-  }
-  void softmax_fp32(unsigned int N, float *X, float *Y) override {
-    nntrainer::softmax(N, X, Y);
-  }
-  bool is_valid_fp32(unsigned int N, const float *X) override {
-    return nntrainer::is_valid(N, X);
-  }
-
-  // FP32 Matrix
-  void transpose_matrix_fp32(unsigned int M, unsigned int N, const float *s,
-                             unsigned int lds, float *d,
-                             unsigned int ldd) override {
-    nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
-  }
-
-  // FP32 Data conversion / Copy
-  void scopy_u8(unsigned int N, const uint8_t *X, unsigned int iX, uint8_t *Y,
-                unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void scopy_s8(unsigned int N, const int8_t *X, unsigned int iX, int8_t *Y,
-                unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void scopy_int4_to_float32(unsigned int N, const uint8_t *X, unsigned int iX,
-                             float *Y, unsigned int iY) override {
-    nntrainer::scopy_int4_to_float32(N, X, iX, Y, iY);
-  }
-  void copy_s16_fp32(unsigned int N, const int16_t *X, float *Y) override {
-    nntrainer::copy_s16_fp32(N, X, Y);
-  }
-  void copy_u16_fp32(unsigned int N, const uint16_t *X, float *Y) override {
-    nntrainer::copy_u16_fp32(N, X, Y);
-  }
-  void copy_fp32_u32(unsigned int N, const float *X, uint32_t *Y) override {
-    nntrainer::copy_fp32_u32(N, X, Y);
-  }
-  void copy_fp32_u16(unsigned int N, const float *X, uint16_t *Y) override {
-    nntrainer::copy_fp32_u16(N, X, Y);
-  }
-  void copy_fp32_u8(unsigned int N, const float *X, uint8_t *Y) override {
-    nntrainer::copy_fp32_u8(N, X, Y);
-  }
-  void copy_fp32_s16(unsigned int N, const float *X, int16_t *Y) override {
-    nntrainer::copy_fp32_s16(N, X, Y);
-  }
-  void copy_fp32_s8(unsigned int N, const float *X, int8_t *Y) override {
-    nntrainer::copy_fp32_s8(N, X, Y);
-  }
-
-  // Quantized GEMM
-  void gemm_q4_0_fp32(unsigned int M, unsigned int N, unsigned int K,
-                      const float *A, unsigned int lda, const void *B,
-                      unsigned int ldb, float *C, unsigned int ldc) override {
-    nntrainer::gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
-  }
-  void gemm_q4_K_fp32(unsigned int M, unsigned int N, unsigned int K,
-                      const float *A, unsigned int lda, const void *B,
-                      unsigned int ldb, float *C, unsigned int ldc) override {
-    nntrainer::gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
-  }
-  void gemm_q6_K_fp32(unsigned int M, unsigned int N, unsigned int K,
-                      const float *A, unsigned int lda, const void *B,
-                      unsigned int ldb, float *C, unsigned int ldc) override {
-    nntrainer::gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
-  }
-
-  // Quantization / Utility
-  void unpack_q4_0(const void *in, void *out, size_t ds, unsigned int M,
-                   unsigned int N) override {
-    nntrainer::unpack_q4_0(in, out, ds, M, N);
-  }
-  void unpack_q4_0x8_transpose16(const void *src, uint16_t *d_out,
-                                 uint16_t *qs_out, int N, int K) override {
-    nntrainer::unpack_q4_0x8_transpose16(src, d_out, qs_out, N, K);
-  }
-  size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
-                       int64_t n_per_row, const float *qw) override {
-    return nntrainer::quantize_q4_0(src, dst, nrow, n_per_row, qw);
-  }
-  void dequantize_row_q4_0(const void *x, float *y, int64_t k) override {
-    nntrainer::dequantize_row_q4_0(x, y, k);
-  }
-  void repack_q4_0(void *dst, void *src, size_t ds, unsigned int M,
-                   unsigned int N) override {
-    nntrainer::repack_q4_0(dst, src, ds, M, N);
-  }
-
-  void clamp_fp32(const float *in, float *out, size_t len, float lb,
-                  float ub) override {
-    nntrainer::clamp(in, out, len, lb, ub);
-  }
-
-  void scopy_int8_to_fp32_u(unsigned int N, const uint8_t *X, unsigned int iX,
-                            float *Y, unsigned int iY) override {
-    nntrainer::scopy_int8_to_float32(N, X, iX, Y, iY);
-  }
-  void scopy_int8_to_fp32_s(unsigned int N, const int8_t *X, unsigned int iX,
-                            float *Y, unsigned int iY) override {
-    nntrainer::scopy_int8_to_float32(N, X, iX, Y, iY);
-  }
-
-  // Accelerator-only ops: CPU backends do not implement these — base
-  // class defaults (throw + supports_*() = false) are correct.
-
-#ifdef ENABLE_FP16
-  void sgemm_fp16(unsigned int o, bool tA, bool tB, unsigned int M,
-                  unsigned int N, unsigned int K, float a, const _FP16 *A,
-                  unsigned int lda, const _FP16 *B, unsigned int ldb, float b,
-                  _FP16 *C, unsigned int ldc) override {
-    nntrainer::sgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
-  }
-  void sgemv_fp16(unsigned int o, bool tA, unsigned int M, unsigned int N,
-                  float a, const _FP16 *A, unsigned int lda, const _FP16 *X,
-                  unsigned int iX, float b, _FP16 *Y,
-                  unsigned int iY) override {
-    nntrainer::sgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
-  }
-  _FP16 sdot_fp16(unsigned int N, const _FP16 *X, unsigned int iX,
-                  const _FP16 *Y, unsigned int iY) override {
-    return nntrainer::sdot(N, X, iX, Y, iY);
-  }
-  void saxpy_fp16(unsigned int N, float a, const _FP16 *X, unsigned int iX,
-                  _FP16 *Y, unsigned int iY) override {
-    nntrainer::saxpy(N, a, X, iX, Y, iY);
-  }
-  void scopy_fp16(unsigned int N, const _FP16 *X, unsigned int iX, _FP16 *Y,
-                  unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void scopy_fp32_to_fp16(unsigned int N, const float *X, unsigned int iX,
-                          _FP16 *Y, unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void scopy_fp16_to_fp32(unsigned int N, const _FP16 *X, unsigned int iX,
-                          float *Y, unsigned int iY) override {
-    nntrainer::scopy(N, X, iX, Y, iY);
-  }
-  void sscal_fp16(unsigned int N, float a, _FP16 *X, unsigned int iX) override {
-    nntrainer::sscal(N, a, X, iX);
-  }
-  _FP16 snrm2_fp16(unsigned int N, const _FP16 *X, unsigned int iX) override {
-    return nntrainer::snrm2(N, X, iX);
-  }
-  unsigned int isamax_fp16(unsigned int N, const _FP16 *X,
-                           unsigned int iX) override {
-    return nntrainer::isamax(N, X, iX);
-  }
-
-  void ele_mul_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_mul(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_add_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_add(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_sub_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_sub(N, X, Y, Z, a, b, is, os);
-  }
-  void ele_div_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
-                    float a, float b, unsigned int is,
-                    unsigned int os) override {
-    nntrainer::ele_div(N, X, Y, Z, a, b, is, os);
-  }
-
-  void swiglu_fp16(unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) override {
-    nntrainer::swiglu(N, X, Y, Z);
-  }
-  _FP16 max_val_fp16(unsigned int N, _FP16 *X) override {
-    return nntrainer::max_val(N, X);
-  }
-  void softmax_fp16(unsigned int N, _FP16 *X, _FP16 *Y) override {
-    nntrainer::softmax(N, X, Y);
-  }
-  bool is_valid_fp16(unsigned int N, const _FP16 *X) override {
-    return nntrainer::is_valid(N, X);
-  }
-  void inv_sqrt_inplace_fp16(unsigned int N, _FP16 *X) override {
-    nntrainer::inv_sqrt_inplace(N, X);
-  }
-
-  void transpose_matrix_fp16(unsigned int M, unsigned int N, const _FP16 *s,
-                             unsigned int lds, _FP16 *d,
-                             unsigned int ldd) override {
-    nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
-  }
-
-  void scopy_int4_to_float16(unsigned int N, const uint8_t *X, unsigned int iX,
-                             _FP16 *Y, unsigned int iY) override {
-    nntrainer::scopy_int4_to_float16(N, X, iX, Y, iY);
-  }
-  void scopy_int8_to_float16_u(unsigned int N, const uint8_t *X,
-                               unsigned int iX, _FP16 *Y,
-                               unsigned int iY) override {
-    nntrainer::scopy_int8_to_float16(N, X, iX, Y, iY);
-  }
-  void scopy_int8_to_float16_s(unsigned int N, const int8_t *X, unsigned int iX,
-                               _FP16 *Y, unsigned int iY) override {
-    nntrainer::scopy_int8_to_float16(N, X, iX, Y, iY);
-  }
-
-  void shgemm(unsigned int o, bool tA, bool tB, unsigned int M, unsigned int N,
-              unsigned int K, float a, const float *A, unsigned int lda,
-              const _FP16 *B, unsigned int ldb, float b, float *C,
-              unsigned int ldc) override {
-    nntrainer::shgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
-  }
-  void shgemv(unsigned int o, bool tA, unsigned int M, unsigned int N, float a,
-              const float *A, unsigned int lda, const _FP16 *X, unsigned int iX,
-              float b, float *Y, unsigned int iY) override {
-    nntrainer::shgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
-  }
-  void hsgemm(unsigned int o, bool tA, bool tB, unsigned int M, unsigned int N,
-              unsigned int K, float a, const _FP16 *A, unsigned int lda,
-              const float *B, unsigned int ldb, float b, float *C,
-              unsigned int ldc) override {
-    nntrainer::hsgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
-  }
-  void hsgemv(unsigned int o, bool tA, unsigned int M, unsigned int N, float a,
-              const _FP16 *A, unsigned int lda, const float *X, unsigned int iX,
-              float b, float *Y, unsigned int iY) override {
-    nntrainer::hsgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
-  }
-
-  void gemm_q4_0_fp16(unsigned int M, unsigned int N, unsigned int K,
-                      const _FP16 *A, unsigned int lda, const void *B,
-                      unsigned int ldb, _FP16 *C, unsigned int ldc) override {
-    nntrainer::gemm_q4_0<_FP16>(M, N, K, A, lda, B, ldb, C, ldc);
-  }
-  void gemm_q6_K_fp16(unsigned int M, unsigned int N, unsigned int K,
-                      const _FP16 *A, unsigned int lda, const void *B,
-                      unsigned int ldb, _FP16 *C, unsigned int ldc) override {
-    nntrainer::gemm_q6_K<_FP16>(M, N, K, A, lda, B, ldb, C, ldc);
-  }
-
-  void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
-                                      unsigned int w, _FP16 *in, _FP16 *out,
-                                      float *cos_, float *sin_) override {
-    nntrainer::compute_rotary_embedding_value(dim, half_, w, in, out, cos_,
-                                              sin_);
-  }
-#endif // ENABLE_FP16
-};
 
 ComputeOps *get_cpu_ops() {
   static CpuComputeOps instance;
   return &instance;
+}
+
+namespace {
+// gelu (tanh approximation, gelu_pytorch_tanh) -- same constants as the OpenCL
+// geglu_cl / CUDA geglu kernels, so the host path is numerically consistent.
+inline float gelu_tanh(float x) {
+  const float k = 0.7978845608028654f; // sqrt(2/pi)
+  return 0.5f * x * (1.0f + std::tanh(k * (x + 0.044715f * x * x * x)));
+}
+// silu (numerically stable: x/(1+exp(-x)) == x*sigmoid(x)) -- matches the
+// OpenCL swiglu_cl kernel exactly (avoids the x*exp(x)/(1+exp(x)) overflow).
+inline float silu(float x) { return x / (1.0f + std::exp(-x)); }
+// sigmoid -- matches the OpenCL sigmoid_glu/sigmoid_add kernels and the CUDA
+// ELTWISE_SRC form (1/(1+exp(-x))) so the three backends agree token-for-token.
+inline float sigmoidf(float x) { return 1.0f / (1.0f + std::exp(-x)); }
+} // namespace
+
+// out = gelu_tanh(in1) * in2 over rows [row_offset, row_offset+active_rows).
+// row_offset is 0 on every current caller (the live token is at the buffer
+// base for the host/SVM/UVM paths); the offset is honored for generality.
+void CpuComputeOps::geglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                          unsigned int active_rows, unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = gelu_tanh(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(gelu_tanh((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument("CpuComputeOps::geglu: unsupported data type");
+  }
+}
+
+// out = silu(in1) * in2 over rows [row_offset, row_offset+active_rows).
+void CpuComputeOps::swiglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                           unsigned int active_rows, unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = silu(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(silu((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument("CpuComputeOps::swiglu: unsupported data type");
+  }
+}
+
+// out = sigmoid(in1) * in2 over rows [row_offset, row_offset+active_rows).
+// A sigmoid-gated attention output gate is one example. FP32 accumulation
+// (upcast fp16 -> float) so the LRA-MLP intermediates do not overflow fp16.
+void CpuComputeOps::sigmoid_glu(const Tensor &in1, const Tensor &in2,
+                                Tensor &out, unsigned int active_rows,
+                                unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = sigmoidf(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(sigmoidf((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument(
+      "CpuComputeOps::sigmoid_glu: unsupported data type");
+  }
+}
+
+// out = sigmoid(in1) + in2 over rows [row_offset, row_offset+active_rows).
+// A per-layer-embedding (PLE) mix path (method=1) is one example. FP32
+// accumulation as above.
+void CpuComputeOps::sigmoid_add(const Tensor &in1, const Tensor &in2,
+                                Tensor &out, unsigned int active_rows,
+                                unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = sigmoidf(a[i]) + b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(sigmoidf((float)a[i]) + (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument(
+      "CpuComputeOps::sigmoid_add: unsupported data type");
+  }
+}
+
+// hidden = input (copy) or hidden += input (add) on the host buffer. Mirrors
+// the core AdditionLayer's per-input copy()/add_i() (correct for host and UVM).
+void CpuComputeOps::residual_op(Tensor &hidden, const Tensor &input,
+                                bool accumulate) {
+  if (accumulate)
+    hidden.add_i(input);
+  else
+    hidden.copy(input);
+}
+
+// output = input * weight. Host Tensor::dot (CPU/UVM FC matmul). The CL/CUDA
+// quantized GEMM paths override this in their ComputeOps subclasses.
+void CpuComputeOps::fc(Tensor &input, Tensor &weight, Tensor &output) {
+  input.dot(weight, output, false, false);
+}
+
+// Fused activation epilogue on the host: build the SAME ActiFunc the standalone
+// ActivationLayer would (so the fused result is value-identical), and run it in
+// place when the activation supports it (relu/sigmoid/tanh) or via a temp input
+// copy otherwise — mirroring ActivationLayer::run_fn(input, output) exactly.
+void CpuComputeOps::apply_activation(Tensor &out, int act_type) {
+  const auto at = static_cast<ActivationType>(act_type);
+  if (at == ActivationType::ACT_NONE)
+    return;
+  ActiFunc f;
+  if (out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    f.setActiFunc<_FP16>(at);
+#else
+    throw std::invalid_argument("apply_activation: fp16 needs enable-fp16");
+#endif
+  } else {
+    f.setActiFunc<float>(at);
+  }
+  if (f.supportInPlace()) {
+    f.run_fn(out, out);
+  } else {
+    Tensor in_copy = out.clone();
+    f.run_fn(in_copy, out);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.cpp
@@ -18,11 +18,192 @@
 
 #include <cpu_ops_table.h>
 
+#include <cmath>
+#include <stdexcept>
+
+#include <acti_func.h>
+#include <tensor.h>
+
 namespace nntrainer {
 
 ComputeOps *get_cpu_ops() {
   static CpuComputeOps instance;
   return &instance;
+}
+
+namespace {
+// gelu (tanh approximation, gelu_pytorch_tanh) -- same constants as the OpenCL
+// geglu_cl / CUDA geglu kernels, so the host path is numerically consistent.
+inline float gelu_tanh(float x) {
+  const float k = 0.7978845608028654f; // sqrt(2/pi)
+  return 0.5f * x * (1.0f + std::tanh(k * (x + 0.044715f * x * x * x)));
+}
+// silu (numerically stable: x/(1+exp(-x)) == x*sigmoid(x)) -- matches the
+// OpenCL swiglu_cl kernel exactly (avoids the x*exp(x)/(1+exp(x)) overflow).
+inline float silu(float x) { return x / (1.0f + std::exp(-x)); }
+// sigmoid -- matches the OpenCL sigmoid_glu/sigmoid_add kernels and the CUDA
+// ELTWISE_SRC form (1/(1+exp(-x))) so the three backends agree token-for-token.
+inline float sigmoidf(float x) { return 1.0f / (1.0f + std::exp(-x)); }
+} // namespace
+
+// out = gelu_tanh(in1) * in2 over rows [row_offset, row_offset+active_rows).
+// row_offset is 0 on every current caller (the live token is at the buffer
+// base for the host/SVM/UVM paths); the offset is honored for generality.
+void CpuComputeOps::geglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                          unsigned int active_rows, unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = gelu_tanh(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(gelu_tanh((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument("CpuComputeOps::geglu: unsupported data type");
+  }
+}
+
+// out = silu(in1) * in2 over rows [row_offset, row_offset+active_rows).
+void CpuComputeOps::swiglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                           unsigned int active_rows, unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = silu(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(silu((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument("CpuComputeOps::swiglu: unsupported data type");
+  }
+}
+
+// out = sigmoid(in1) * in2 over rows [row_offset, row_offset+active_rows).
+// A sigmoid-gated attention output gate is one example. FP32 accumulation
+// (upcast fp16 -> float) so the LRA-MLP intermediates do not overflow fp16.
+void CpuComputeOps::sigmoid_glu(const Tensor &in1, const Tensor &in2,
+                                Tensor &out, unsigned int active_rows,
+                                unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = sigmoidf(a[i]) * b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(sigmoidf((float)a[i]) * (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument(
+      "CpuComputeOps::sigmoid_glu: unsupported data type");
+  }
+}
+
+// out = sigmoid(in1) + in2 over rows [row_offset, row_offset+active_rows).
+// A per-layer-embedding (PLE) mix path (method=1) is one example. FP32
+// accumulation as above.
+void CpuComputeOps::sigmoid_add(const Tensor &in1, const Tensor &in2,
+                                Tensor &out, unsigned int active_rows,
+                                unsigned int row_offset) {
+  const unsigned int dim2 = in1.width();
+  const size_t elem_off = (size_t)row_offset * dim2;
+  const size_t n = (size_t)active_rows * dim2;
+  const auto dt = in1.getDataType();
+
+  if (dt == ml::train::TensorDim::DataType::FP32) {
+    const float *a = in1.getData<float>() + elem_off;
+    const float *b = in2.getData<float>() + elem_off;
+    float *o = out.getData<float>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = sigmoidf(a[i]) + b[i];
+#ifdef ENABLE_FP16
+  } else if (dt == ml::train::TensorDim::DataType::FP16) {
+    const _FP16 *a = in1.getData<_FP16>() + elem_off;
+    const _FP16 *b = in2.getData<_FP16>() + elem_off;
+    _FP16 *o = out.getData<_FP16>() + elem_off;
+    for (size_t i = 0; i < n; ++i)
+      o[i] = static_cast<_FP16>(sigmoidf((float)a[i]) + (float)b[i]);
+#endif
+  } else {
+    throw std::invalid_argument(
+      "CpuComputeOps::sigmoid_add: unsupported data type");
+  }
+}
+
+// hidden = input (copy) or hidden += input (add) on the host buffer. Mirrors
+// the core AdditionLayer's per-input copy()/add_i() (correct for host and UVM).
+void CpuComputeOps::residual_op(Tensor &hidden, const Tensor &input,
+                                bool accumulate) {
+  if (accumulate)
+    hidden.add_i(input);
+  else
+    hidden.copy(input);
+}
+
+// output = input * weight. Host Tensor::dot (CPU/UVM FC matmul). The CL/CUDA
+// quantized GEMM paths override this in their ComputeOps subclasses.
+void CpuComputeOps::fc(Tensor &input, Tensor &weight, Tensor &output) {
+  input.dot(weight, output, false, false);
+}
+
+// Fused activation epilogue on the host: build the SAME ActiFunc the standalone
+// ActivationLayer would (so the fused result is value-identical), and run it in
+// place when the activation supports it (relu/sigmoid/tanh) or via a temp input
+// copy otherwise — mirroring ActivationLayer::run_fn(input, output) exactly.
+void CpuComputeOps::apply_activation(Tensor &out, int act_type) {
+  const auto at = static_cast<ActivationType>(act_type);
+  if (at == ActivationType::ACT_NONE)
+    return;
+  ActiFunc f;
+  if (out.getDataType() == ml::train::TensorDim::DataType::FP16) {
+#ifdef ENABLE_FP16
+    f.setActiFunc<_FP16>(at);
+#else
+    throw std::invalid_argument("apply_activation: fp16 needs enable-fp16");
+#endif
+  } else {
+    f.setActiFunc<float>(at);
+  }
+  if (f.supportInPlace()) {
+    f.run_fn(out, out);
+  } else {
+    Tensor in_copy = out.clone();
+    f.run_fn(in_copy, out);
+  }
 }
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.h
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.h
@@ -364,6 +364,28 @@ public:
                                               sin_);
   }
 #endif // ENABLE_FP16
+
+  // Whole-op (Tensor-level). Out-of-line in cpu_ops_table.cpp so this header
+  // stays free of <tensor.h>. Pure host gelu_tanh(gate)*up over the live rows
+  // (correct for host and host-coherent SVM/UVM pointers).
+  void geglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+             unsigned int active_rows, unsigned int row_offset) override;
+  // out = silu(gate) * up over the live rows (numerically stable SiLU).
+  void swiglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+              unsigned int active_rows, unsigned int row_offset) override;
+  // out = sigmoid(gate) * up over the live rows (fp32-accumulated).
+  void sigmoid_glu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                   unsigned int active_rows, unsigned int row_offset) override;
+  // out = sigmoid(gate) + emb over the live rows (fp32-accumulated).
+  void sigmoid_add(const Tensor &in1, const Tensor &in2, Tensor &out,
+                   unsigned int active_rows, unsigned int row_offset) override;
+  // hidden = input (copy) / hidden += input (add) via host Tensor ops.
+  void residual_op(Tensor &hidden, const Tensor &input,
+                   bool accumulate) override;
+  // output = input * weight via host Tensor::dot (the CPU FC matmul).
+  void fc(Tensor &input, Tensor &weight, Tensor &output) override;
+
+  void apply_activation(Tensor &out, int act_type) override;
 };
 
 } // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/cpu_ops_table.h
+++ b/nntrainer/tensor/cpu_backend/cpu_ops_table.h
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   cpu_ops_table.h
+ * @date   29 June 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Unified CPU backend ComputeOps subclass (declaration).
+ *
+ * Extracted from cpu_ops_table.cpp so other backends can inherit it — CUDA
+ * UVM is host-coherent, so CudaComputeOps derives from CpuComputeOps to reuse
+ * the CPU op implementations and only override what it accelerates. The class
+ * is a thin forwarding wrapper (each method calls the arch-dispatched
+ * nntrainer::sgemm etc.), so it stays header-inline.
+ */
+
+#ifndef __NNTRAINER_CPU_OPS_TABLE_H__
+#define __NNTRAINER_CPU_OPS_TABLE_H__
+
+#include <compute_ops.h>
+#include <cpu_backend.h>
+
+namespace nntrainer {
+
+/**
+ * @brief Unified CPU backend implementation of the ComputeOps dispatch
+ * surface; each method forwards to the arch-dispatched nntrainer:: op.
+ */
+class CpuComputeOps : public ComputeOps {
+public:
+  // FP32 BLAS
+  void sgemm_fp32(unsigned int o, bool tA, bool tB, unsigned int M,
+                  unsigned int N, unsigned int K, float a, const float *A,
+                  unsigned int lda, const float *B, unsigned int ldb, float b,
+                  float *C, unsigned int ldc) override {
+    nntrainer::sgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
+  }
+  void sgemv_fp32(unsigned int o, bool tA, unsigned int M, unsigned int N,
+                  float a, const float *A, unsigned int lda, const float *X,
+                  unsigned int iX, float b, float *Y,
+                  unsigned int iY) override {
+    nntrainer::sgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
+  }
+  float sdot_fp32(unsigned int N, const float *X, unsigned int iX,
+                  const float *Y, unsigned int iY) override {
+    return nntrainer::sdot(N, X, iX, Y, iY);
+  }
+  void saxpy_fp32(unsigned int N, float a, const float *X, unsigned int iX,
+                  float *Y, unsigned int iY) override {
+    nntrainer::saxpy(N, a, X, iX, Y, iY);
+  }
+  void scopy_fp32(unsigned int N, const float *X, unsigned int iX, float *Y,
+                  unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void sscal_fp32(unsigned int N, float a, float *X, unsigned int iX) override {
+    nntrainer::sscal(N, a, X, iX);
+  }
+  float snrm2_fp32(unsigned int N, const float *X, unsigned int iX) override {
+    return nntrainer::snrm2(N, X, iX);
+  }
+  unsigned int isamax_fp32(unsigned int N, const float *X,
+                           unsigned int iX) override {
+    return nntrainer::isamax(N, X, iX);
+  }
+
+  // FP32 Element-wise
+  void ele_mul_fp32(unsigned int N, const float *X, const float *Y, float *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_mul(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_add_fp32(unsigned int N, const float *X, const float *Y, float *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_add(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_sub_fp32(unsigned int N, const float *X, const float *Y, float *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_sub(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_div_fp32(unsigned int N, const float *X, const float *Y, float *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_div(N, X, Y, Z, a, b, is, os);
+  }
+
+  // FP32 Activation / Special
+  void swiglu_fp32(unsigned int N, float *X, float *Y, float *Z) override {
+    nntrainer::swiglu(N, X, Y, Z);
+  }
+  void swiglu_alpha_fp32(unsigned int N, float *X, float *Y, float *Z,
+                         float alpha) override {
+    nntrainer::swiglu(N, X, Y, Z, alpha);
+  }
+  void tanh_gelu_fp32(unsigned int N, const float *X, float *Y) override {
+    nntrainer::tanh_gelu(N, X, Y);
+  }
+  void gelu_v2_fp32(unsigned int N, const float *X, float *Y) override {
+    nntrainer::gelu_v2(N, X, Y);
+  }
+  void tanh_gelu_v2_fp32(unsigned int N, const float *X, float *Y) override {
+    nntrainer::tanh_gelu_v2(N, X, Y);
+  }
+  void tanh_gelu_mul_fp32(unsigned int N, float *X, float *Y,
+                          float *Z) override {
+    nntrainer::tanh_gelu_mul(N, X, Y, Z);
+  }
+  void tanh_gelu_v2_mul_fp32(unsigned int N, float *X, float *Y,
+                             float *Z) override {
+    nntrainer::tanh_gelu_v2_mul(N, X, Y, Z);
+  }
+  float max_val_fp32(unsigned int N, float *X) override {
+    return nntrainer::max_val(N, X);
+  }
+  void softmax_fp32(unsigned int N, float *X, float *Y) override {
+    nntrainer::softmax(N, X, Y);
+  }
+  bool is_valid_fp32(unsigned int N, const float *X) override {
+    return nntrainer::is_valid(N, X);
+  }
+
+  // FP32 Matrix
+  void transpose_matrix_fp32(unsigned int M, unsigned int N, const float *s,
+                             unsigned int lds, float *d,
+                             unsigned int ldd) override {
+    nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
+  }
+
+  // FP32 Data conversion / Copy
+  void scopy_u8(unsigned int N, const uint8_t *X, unsigned int iX, uint8_t *Y,
+                unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void scopy_s8(unsigned int N, const int8_t *X, unsigned int iX, int8_t *Y,
+                unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void scopy_int4_to_float32(unsigned int N, const uint8_t *X, unsigned int iX,
+                             float *Y, unsigned int iY) override {
+    nntrainer::scopy_int4_to_float32(N, X, iX, Y, iY);
+  }
+  void copy_s16_fp32(unsigned int N, const int16_t *X, float *Y) override {
+    nntrainer::copy_s16_fp32(N, X, Y);
+  }
+  void copy_u16_fp32(unsigned int N, const uint16_t *X, float *Y) override {
+    nntrainer::copy_u16_fp32(N, X, Y);
+  }
+  void copy_fp32_u32(unsigned int N, const float *X, uint32_t *Y) override {
+    nntrainer::copy_fp32_u32(N, X, Y);
+  }
+  void copy_fp32_u16(unsigned int N, const float *X, uint16_t *Y) override {
+    nntrainer::copy_fp32_u16(N, X, Y);
+  }
+  void copy_fp32_u8(unsigned int N, const float *X, uint8_t *Y) override {
+    nntrainer::copy_fp32_u8(N, X, Y);
+  }
+  void copy_fp32_s16(unsigned int N, const float *X, int16_t *Y) override {
+    nntrainer::copy_fp32_s16(N, X, Y);
+  }
+  void copy_fp32_s8(unsigned int N, const float *X, int8_t *Y) override {
+    nntrainer::copy_fp32_s8(N, X, Y);
+  }
+
+  // Quantized GEMM
+  void gemm_q4_0_fp32(unsigned int M, unsigned int N, unsigned int K,
+                      const float *A, unsigned int lda, const void *B,
+                      unsigned int ldb, float *C, unsigned int ldc) override {
+    nntrainer::gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
+  }
+  void gemm_q4_K_fp32(unsigned int M, unsigned int N, unsigned int K,
+                      const float *A, unsigned int lda, const void *B,
+                      unsigned int ldb, float *C, unsigned int ldc) override {
+    nntrainer::gemm_q4_K(M, N, K, A, lda, B, ldb, C, ldc);
+  }
+  void gemm_q6_K_fp32(unsigned int M, unsigned int N, unsigned int K,
+                      const float *A, unsigned int lda, const void *B,
+                      unsigned int ldb, float *C, unsigned int ldc) override {
+    nntrainer::gemm_q6_K(M, N, K, A, lda, B, ldb, C, ldc);
+  }
+
+  // Quantization / Utility
+  void unpack_q4_0(const void *in, void *out, size_t ds, unsigned int M,
+                   unsigned int N) override {
+    nntrainer::unpack_q4_0(in, out, ds, M, N);
+  }
+  void unpack_q4_0x8_transpose16(const void *src, uint16_t *d_out,
+                                 uint16_t *qs_out, int N, int K) override {
+    nntrainer::unpack_q4_0x8_transpose16(src, d_out, qs_out, N, K);
+  }
+  size_t quantize_q4_0(const float *src, void *dst, int64_t nrow,
+                       int64_t n_per_row, const float *qw) override {
+    return nntrainer::quantize_q4_0(src, dst, nrow, n_per_row, qw);
+  }
+  void dequantize_row_q4_0(const void *x, float *y, int64_t k) override {
+    nntrainer::dequantize_row_q4_0(x, y, k);
+  }
+  void repack_q4_0(void *dst, void *src, size_t ds, unsigned int M,
+                   unsigned int N) override {
+    nntrainer::repack_q4_0(dst, src, ds, M, N);
+  }
+
+  void clamp_fp32(const float *in, float *out, size_t len, float lb,
+                  float ub) override {
+    nntrainer::clamp(in, out, len, lb, ub);
+  }
+
+  void scopy_int8_to_fp32_u(unsigned int N, const uint8_t *X, unsigned int iX,
+                            float *Y, unsigned int iY) override {
+    nntrainer::scopy_int8_to_float32(N, X, iX, Y, iY);
+  }
+  void scopy_int8_to_fp32_s(unsigned int N, const int8_t *X, unsigned int iX,
+                            float *Y, unsigned int iY) override {
+    nntrainer::scopy_int8_to_float32(N, X, iX, Y, iY);
+  }
+
+  // Accelerator-only ops: CPU backends do not implement these — base
+  // class defaults (throw + supports_*() = false) are correct.
+
+#ifdef ENABLE_FP16
+  void sgemm_fp16(unsigned int o, bool tA, bool tB, unsigned int M,
+                  unsigned int N, unsigned int K, float a, const _FP16 *A,
+                  unsigned int lda, const _FP16 *B, unsigned int ldb, float b,
+                  _FP16 *C, unsigned int ldc) override {
+    nntrainer::sgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
+  }
+  void sgemv_fp16(unsigned int o, bool tA, unsigned int M, unsigned int N,
+                  float a, const _FP16 *A, unsigned int lda, const _FP16 *X,
+                  unsigned int iX, float b, _FP16 *Y,
+                  unsigned int iY) override {
+    nntrainer::sgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
+  }
+  _FP16 sdot_fp16(unsigned int N, const _FP16 *X, unsigned int iX,
+                  const _FP16 *Y, unsigned int iY) override {
+    return nntrainer::sdot(N, X, iX, Y, iY);
+  }
+  void saxpy_fp16(unsigned int N, float a, const _FP16 *X, unsigned int iX,
+                  _FP16 *Y, unsigned int iY) override {
+    nntrainer::saxpy(N, a, X, iX, Y, iY);
+  }
+  void scopy_fp16(unsigned int N, const _FP16 *X, unsigned int iX, _FP16 *Y,
+                  unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void scopy_fp32_to_fp16(unsigned int N, const float *X, unsigned int iX,
+                          _FP16 *Y, unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void scopy_fp16_to_fp32(unsigned int N, const _FP16 *X, unsigned int iX,
+                          float *Y, unsigned int iY) override {
+    nntrainer::scopy(N, X, iX, Y, iY);
+  }
+  void sscal_fp16(unsigned int N, float a, _FP16 *X, unsigned int iX) override {
+    nntrainer::sscal(N, a, X, iX);
+  }
+  _FP16 snrm2_fp16(unsigned int N, const _FP16 *X, unsigned int iX) override {
+    return nntrainer::snrm2(N, X, iX);
+  }
+  unsigned int isamax_fp16(unsigned int N, const _FP16 *X,
+                           unsigned int iX) override {
+    return nntrainer::isamax(N, X, iX);
+  }
+
+  void ele_mul_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_mul(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_add_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_add(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_sub_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_sub(N, X, Y, Z, a, b, is, os);
+  }
+  void ele_div_fp16(unsigned int N, const _FP16 *X, const _FP16 *Y, _FP16 *Z,
+                    float a, float b, unsigned int is,
+                    unsigned int os) override {
+    nntrainer::ele_div(N, X, Y, Z, a, b, is, os);
+  }
+
+  void swiglu_fp16(unsigned int N, _FP16 *X, _FP16 *Y, _FP16 *Z) override {
+    nntrainer::swiglu(N, X, Y, Z);
+  }
+  _FP16 max_val_fp16(unsigned int N, _FP16 *X) override {
+    return nntrainer::max_val(N, X);
+  }
+  void softmax_fp16(unsigned int N, _FP16 *X, _FP16 *Y) override {
+    nntrainer::softmax(N, X, Y);
+  }
+  bool is_valid_fp16(unsigned int N, const _FP16 *X) override {
+    return nntrainer::is_valid(N, X);
+  }
+  void inv_sqrt_inplace_fp16(unsigned int N, _FP16 *X) override {
+    nntrainer::inv_sqrt_inplace(N, X);
+  }
+
+  void transpose_matrix_fp16(unsigned int M, unsigned int N, const _FP16 *s,
+                             unsigned int lds, _FP16 *d,
+                             unsigned int ldd) override {
+    nntrainer::transpose_matrix(M, N, s, lds, d, ldd);
+  }
+
+  void scopy_int4_to_float16(unsigned int N, const uint8_t *X, unsigned int iX,
+                             _FP16 *Y, unsigned int iY) override {
+    nntrainer::scopy_int4_to_float16(N, X, iX, Y, iY);
+  }
+  void scopy_int8_to_float16_u(unsigned int N, const uint8_t *X,
+                               unsigned int iX, _FP16 *Y,
+                               unsigned int iY) override {
+    nntrainer::scopy_int8_to_float16(N, X, iX, Y, iY);
+  }
+  void scopy_int8_to_float16_s(unsigned int N, const int8_t *X, unsigned int iX,
+                               _FP16 *Y, unsigned int iY) override {
+    nntrainer::scopy_int8_to_float16(N, X, iX, Y, iY);
+  }
+
+  void shgemm(unsigned int o, bool tA, bool tB, unsigned int M, unsigned int N,
+              unsigned int K, float a, const float *A, unsigned int lda,
+              const _FP16 *B, unsigned int ldb, float b, float *C,
+              unsigned int ldc) override {
+    nntrainer::shgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
+  }
+  void shgemv(unsigned int o, bool tA, unsigned int M, unsigned int N, float a,
+              const float *A, unsigned int lda, const _FP16 *X, unsigned int iX,
+              float b, float *Y, unsigned int iY) override {
+    nntrainer::shgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
+  }
+  void hsgemm(unsigned int o, bool tA, bool tB, unsigned int M, unsigned int N,
+              unsigned int K, float a, const _FP16 *A, unsigned int lda,
+              const float *B, unsigned int ldb, float b, float *C,
+              unsigned int ldc) override {
+    nntrainer::hsgemm(o, tA, tB, M, N, K, a, A, lda, B, ldb, b, C, ldc);
+  }
+  void hsgemv(unsigned int o, bool tA, unsigned int M, unsigned int N, float a,
+              const _FP16 *A, unsigned int lda, const float *X, unsigned int iX,
+              float b, float *Y, unsigned int iY) override {
+    nntrainer::hsgemv(o, tA, M, N, a, A, lda, X, iX, b, Y, iY);
+  }
+
+  void gemm_q4_0_fp16(unsigned int M, unsigned int N, unsigned int K,
+                      const _FP16 *A, unsigned int lda, const void *B,
+                      unsigned int ldb, _FP16 *C, unsigned int ldc) override {
+    nntrainer::gemm_q4_0<_FP16>(M, N, K, A, lda, B, ldb, C, ldc);
+  }
+  void gemm_q6_K_fp16(unsigned int M, unsigned int N, unsigned int K,
+                      const _FP16 *A, unsigned int lda, const void *B,
+                      unsigned int ldb, _FP16 *C, unsigned int ldc) override {
+    nntrainer::gemm_q6_K<_FP16>(M, N, K, A, lda, B, ldb, C, ldc);
+  }
+
+  void compute_rotary_embedding_value(unsigned int dim, unsigned int half_,
+                                      unsigned int w, _FP16 *in, _FP16 *out,
+                                      float *cos_, float *sin_) override {
+    nntrainer::compute_rotary_embedding_value(dim, half_, w, in, out, cos_,
+                                              sin_);
+  }
+#endif // ENABLE_FP16
+
+  // Whole-op (Tensor-level). Out-of-line in cpu_ops_table.cpp so this header
+  // stays free of <tensor.h>. Pure host gelu_tanh(gate)*up over the live rows
+  // (correct for host and host-coherent SVM/UVM pointers).
+  void geglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+             unsigned int active_rows, unsigned int row_offset) override;
+  // out = silu(gate) * up over the live rows (numerically stable SiLU).
+  void swiglu(const Tensor &in1, const Tensor &in2, Tensor &out,
+              unsigned int active_rows, unsigned int row_offset) override;
+  // out = sigmoid(gate) * up over the live rows (fp32-accumulated).
+  void sigmoid_glu(const Tensor &in1, const Tensor &in2, Tensor &out,
+                   unsigned int active_rows, unsigned int row_offset) override;
+  // out = sigmoid(gate) + emb over the live rows (fp32-accumulated).
+  void sigmoid_add(const Tensor &in1, const Tensor &in2, Tensor &out,
+                   unsigned int active_rows, unsigned int row_offset) override;
+  // hidden = input (copy) / hidden += input (add) via host Tensor ops.
+  void residual_op(Tensor &hidden, const Tensor &input,
+                   bool accumulate) override;
+  // output = input * weight via host Tensor::dot (the CPU FC matmul).
+  void fc(Tensor &input, Tensor &weight, Tensor &output) override;
+
+  void apply_activation(Tensor &out, int act_type) override;
+};
+
+} // namespace nntrainer
+
+#endif // __NNTRAINER_CPU_OPS_TABLE_H__

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -2045,6 +2045,16 @@ public:
   }
 
   /**
+   * @brief Get the ComputeOps this tensor dispatches through.
+   *
+   * Priority: attached ContextData (per-vendor ops, e.g. ClComputeOps /
+   * CudaComputeOps) > the global CPU table. This is how a neutral Layer
+   * reaches the right backend's whole-op kernel without an #ifdef: e.g.
+   * `in1.getOps()->geglu(...)`.
+   */
+  ComputeOps *getOps() const { return itensor_->getOps(); }
+
+  /**
    * @brief Propagate this tensor's ContextData to a result tensor.
    *
    * Used by binary/unary ops so that subsequent calls on the result

--- a/nntrainer/tensor/tensor_wrap_specs.h
+++ b/nntrainer/tensor/tensor_wrap_specs.h
@@ -97,6 +97,25 @@ typedef std::tuple<TensorDim, Initializer, bool, const std::string,
   VarGradSpec;
 
 /**
+ * @brief Semantic role of a tensor — a HINT for residency / placement
+ *        decisions (e.g. an attention KV cache wants image2d backing on Adreno;
+ *        weights stay device-resident). `GENERIC` by default; role-bearing
+ *        layers tag their tensors. Currently a FOUNDATION (Mem M3): carried on
+ *        the spec but NOT yet consumed — the residency resolver (M4) will read
+ *        it to replace the env/model-name heuristics. Inert today ⇒
+ *        byte-identical. [docs/ARCHITECTURE_REFACTOR.md §10 T5 / Mem M3]
+ */
+enum class TensorRole {
+  GENERIC, /**< no special role (default) */
+  WEIGHT,  /**< model weight */
+  ACT,     /**< layer-I/O activation */
+  KV,      /**< attention key/value cache */
+  QKV,     /**< q/k/v projection output */
+  EMB,     /**< token embedding */
+  NORM,    /**< normalization (rms/layer) gamma or output */
+};
+
+/**
  * @brief Tensor Specification which describes how this tensor should be
  * allocated and managed
  *
@@ -146,6 +165,16 @@ struct TensorSpecV2 {
   /** ONLY FOR THE GRANULAR CONTROL OF LIFE OUTSIDE OF LAYER NODE */
   /// @todo make this as an opaque information with PIMPL
   std::vector<unsigned> additional_exec_order = {};
+
+  /** compute engine of the producing layer; threaded to TensorPool so the
+   * static residency class (GPU_CLMEM vs SVM/HOST) can be derived at allocation
+   * for layer I/O activations. CPU by default => unchanged for non-GPU layers.
+   */
+  ml::train::LayerComputeEngine engine = ml::train::LayerComputeEngine::CPU;
+
+  /** semantic role hint for residency / placement (Mem M3). GENERIC by default;
+   * inert until the residency resolver (M4) consumes it ⇒ byte-identical. */
+  TensorRole role = TensorRole::GENERIC;
 };
 
 /**

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -811,19 +811,23 @@ public:
  */
 struct ComputeEngineTypeInfo {
   using Enum = ml::train::LayerComputeEngine;
-  static constexpr std::initializer_list<Enum> EnumList = {Enum::CPU, Enum::GPU,
-                                                           Enum::QNN};
-  static constexpr const char *EnumStr[] = {"cpu", "gpu", "qnn"};
+  static constexpr std::initializer_list<Enum> EnumList = {
+    Enum::CPU, Enum::GPU, Enum::QNN, Enum::CUDA};
+  static constexpr const char *EnumStr[] = {"cpu", "gpu", "qnn", "cuda"};
 };
 
 /**
- * @brief ComputeEngine Enumeration Information
- *
+ * @brief ComputeEngine name property — the node's backend as a registered
+ *        Context NAME (registry-open [ARCHITECTURE_REFACTOR.md §10 T3]: any
+ *        Engine-registered name is valid, e.g. "npu", not just the closed
+ *        LayerComputeEngine enum's four). Normalized against the live registry
+ *        in LayerNode::setProperty (lowercased; unknown name -> "cpu"
+ *        fallback, matching Engine::parseComputeEngine). ComputeEngineTypeInfo
+ *        above remains for mapping names onto the residency-plane enum.
  */
-class ComputeEngine final
-  : public EnumProperty<nntrainer::props::ComputeEngineTypeInfo> {
+class ComputeEngine final : public Property<std::string> {
 public:
-  using prop_tag = enum_class_prop_tag;
+  using prop_tag = str_prop_tag;
   static constexpr const char *key = "engine";
 };
 

--- a/nntrainer/utils/base_properties.h
+++ b/nntrainer/utils/base_properties.h
@@ -812,18 +812,22 @@ public:
 struct ComputeEngineTypeInfo {
   using Enum = ml::train::LayerComputeEngine;
   static constexpr std::initializer_list<Enum> EnumList = {
-    Enum::CPU, Enum::GPU, Enum::QNN, Enum::HTP};
-  static constexpr const char *EnumStr[] = {"cpu", "gpu", "qnn", "htp"};
+    Enum::CPU, Enum::GPU, Enum::QNN, Enum::HTP, Enum::CUDA};
+  static constexpr const char *EnumStr[] = {"cpu", "gpu", "qnn", "htp", "cuda"};
 };
 
 /**
- * @brief ComputeEngine Enumeration Information
- *
+ * @brief ComputeEngine name property — the node's backend as a registered
+ *        Context NAME (registry-open [ARCHITECTURE_REFACTOR.md §10 T3]: any
+ *        Engine-registered name is valid, e.g. "npu", not just the closed
+ *        LayerComputeEngine enum's members). Normalized against the live
+ *        registry in LayerNode::setProperty (lowercased; unknown name -> "cpu"
+ *        fallback, matching Engine::parseComputeEngine). ComputeEngineTypeInfo
+ *        above remains for mapping names onto the residency-plane enum.
  */
-class ComputeEngine final
-  : public EnumProperty<nntrainer::props::ComputeEngineTypeInfo> {
+class ComputeEngine final : public Property<std::string> {
 public:
-  using prop_tag = enum_class_prop_tag;
+  using prop_tag = str_prop_tag;
   static constexpr const char *key = "engine";
 };
 

--- a/nntrainer/utils/node_exporter.cpp
+++ b/nntrainer/utils/node_exporter.cpp
@@ -119,8 +119,17 @@ void Exporter::saveTflResult(
 
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha,
+                   props::FusedActivation> &props,
   const FullyConnectedLayer *self) {
+  auto &fused_activation = std::get<props::FusedActivation>(props);
+  if (!fused_activation.empty() &&
+      fused_activation.get() != ActivationType::ACT_NONE) {
+    throw exception::not_supported(
+      "Tflite export does not support a fused activation on "
+      "fully_connected; use a separate activation layer instead.");
+  }
+
   createIfNull(tf_node);
   tf_node->setOpType(tflite::BuiltinOperator_FULLY_CONNECTED);
   auto options = tflite::CreateFullyConnectedOptions(*fbb).Union();
@@ -199,8 +208,17 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, CONV2D_DIM>,
                    std::array<props::Stride, CONV2D_DIM>, props::Padding2D,
-                   std::array<props::Dilation, CONV2D_DIM>> &props,
+                   std::array<props::Dilation, CONV2D_DIM>,
+                   props::FusedActivation> &props,
   const Conv2DLayer *self) {
+  auto &fused_activation = std::get<props::FusedActivation>(props);
+  if (!fused_activation.empty() &&
+      fused_activation.get() != ActivationType::ACT_NONE) {
+    throw exception::not_supported(
+      "Tflite export does not support a fused activation on conv2d; use a "
+      "separate activation layer instead.");
+  }
+
   createIfNull(tf_node);
 
   auto weight_transform = [](std::vector<const Tensor *> &old_weights) {

--- a/nntrainer/utils/node_exporter.h
+++ b/nntrainer/utils/node_exporter.h
@@ -303,7 +303,8 @@ class FullyConnectedLayer;
  */
 template <>
 void Exporter::saveTflResult(
-  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha> &props,
+  const std::tuple<props::Unit, props::LoraRank, props::LoraAlpha,
+                   props::FusedActivation> &props,
   const FullyConnectedLayer *self);
 
 class ActivationLayer;
@@ -333,7 +334,8 @@ template <>
 void Exporter::saveTflResult(
   const std::tuple<props::FilterSize, std::array<props::KernelSize, 2>,
                    std::array<props::Stride, 2>, props::Padding2D,
-                   std::array<props::Dilation, 2>> &props,
+                   std::array<props::Dilation, 2>, props::FusedActivation>
+    &props,
   const Conv2DLayer *self);
 
 class InputLayer;

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -688,6 +688,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # custom layer kits
 %{_includedir}/nntrainer/app_context.h
 %{_includedir}/nntrainer/context.h
+%{_includedir}/nntrainer/model_features.h
 %{_includedir}/nntrainer/engine.h
 # optimizer headers
 %{_includedir}/nntrainer/optimizer_context.h

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -687,6 +687,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 # custom layer kits
 %{_includedir}/nntrainer/app_context.h
 %{_includedir}/nntrainer/context.h
+%{_includedir}/nntrainer/model_features.h
 %{_includedir}/nntrainer/engine.h
 # optimizer headers
 %{_includedir}/nntrainer/optimizer_context.h

--- a/test/unittest/unittest_nntrainer_appcontext.cpp
+++ b/test/unittest/unittest_nntrainer_appcontext.cpp
@@ -263,6 +263,159 @@ TEST(AppContextTest, callingUnknownFactoryOptimizerWithIntKey_n) {
 }
 
 /**
+ * @brief   ExecPlan resolver tests (caps-only overload)
+ *
+ */
+TEST(ExecPlanResolverTest, capsOnly_cpuBackend_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "cpu";
+
+  auto plan = nntrainer::resolveExecPlan(caps);
+  EXPECT_EQ(plan.gemm_path, nntrainer::GemmPath::CPU);
+}
+
+TEST(ExecPlanResolverTest, capsOnly_gpuWithDpas_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = true;
+
+  auto plan = nntrainer::resolveExecPlan(caps);
+  EXPECT_EQ(plan.gemm_path, nntrainer::GemmPath::XMX);
+}
+
+TEST(ExecPlanResolverTest, capsOnly_gpuWithoutDpas_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = false;
+
+  auto plan = nntrainer::resolveExecPlan(caps);
+  EXPECT_EQ(plan.gemm_path, nntrainer::GemmPath::DP4A);
+}
+
+TEST(ExecPlanResolverTest, capsOnly_cudaBackend_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "cuda";
+
+  auto plan = nntrainer::resolveExecPlan(caps);
+  EXPECT_EQ(plan.gemm_path, nntrainer::GemmPath::CUBLAS);
+}
+
+TEST(ExecPlanResolverTest, capsOnly_hostCoherentMirrorsIntegrated_p) {
+  nntrainer::DeviceCaps integrated_caps;
+  integrated_caps.backend = "gpu";
+  integrated_caps.integrated = true;
+  EXPECT_EQ(nntrainer::resolveExecPlan(integrated_caps).host_coherent, true);
+
+  nntrainer::DeviceCaps discrete_caps;
+  discrete_caps.backend = "gpu";
+  discrete_caps.integrated = false;
+  EXPECT_EQ(nntrainer::resolveExecPlan(discrete_caps).host_coherent, false);
+}
+
+TEST(ExecPlanResolverTest, capsOnly_decodeGpuDefaultsFalse_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = true;
+
+  auto plan = nntrainer::resolveExecPlan(caps);
+  EXPECT_EQ(plan.decode_gpu, false);
+}
+
+/**
+ * @brief   ExecPlan resolver tests (caps + ModelFeatures matcher overload)
+ *
+ */
+TEST(ExecPlanResolverTest, matcher_decodeGpuOnGpuBackend_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = true;
+
+  nntrainer::ModelFeatures features;
+  features.decode_gpu = true;
+
+  auto plan = nntrainer::resolveExecPlan(caps, features);
+  EXPECT_EQ(plan.decode_gpu, true);
+}
+
+TEST(ExecPlanResolverTest, matcher_decodeGpuOnCudaBackend_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "cuda";
+
+  nntrainer::ModelFeatures features;
+  features.decode_gpu = true;
+
+  auto plan = nntrainer::resolveExecPlan(caps, features);
+  EXPECT_EQ(plan.decode_gpu, true);
+}
+
+TEST(ExecPlanResolverTest, matcher_decodeGpuGatedOffOnCpuBackend_n) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "cpu";
+
+  nntrainer::ModelFeatures features;
+  features.decode_gpu = true;
+
+  auto plan = nntrainer::resolveExecPlan(caps, features);
+  EXPECT_EQ(plan.decode_gpu, false);
+}
+
+TEST(ExecPlanResolverTest, matcher_decodeGpuFalseStaysFalseOnGpuBackend_n) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = true;
+
+  nntrainer::ModelFeatures features;
+  features.decode_gpu = false;
+
+  auto plan = nntrainer::resolveExecPlan(caps, features);
+  EXPECT_EQ(plan.decode_gpu, false);
+}
+
+TEST(ExecPlanResolverTest, matcher_capsDerivedCellsMatchCapsOnlyOverload_p) {
+  nntrainer::DeviceCaps caps;
+  caps.backend = "gpu";
+  caps.dpas = true;
+  caps.integrated = false;
+
+  nntrainer::ModelFeatures features;
+  features.decode_gpu = true;
+
+  auto caps_only_plan = nntrainer::resolveExecPlan(caps);
+  auto matcher_plan = nntrainer::resolveExecPlan(caps, features);
+
+  EXPECT_EQ(matcher_plan.gemm_path, caps_only_plan.gemm_path);
+  EXPECT_EQ(matcher_plan.host_coherent, caps_only_plan.host_coherent);
+}
+
+/**
+ * @brief   toString() smoke tests for the ExecPlan/ModelFeatures resolver
+ *          types and their enums
+ *
+ */
+TEST(ExecPlanResolverTest, toString_execPlanContainsGemmPathKey_p) {
+  nntrainer::ExecPlan plan;
+  std::string dump = plan.toString();
+
+  EXPECT_FALSE(dump.empty());
+  EXPECT_NE(dump.find("gemm_path="), std::string::npos);
+}
+
+TEST(ExecPlanResolverTest, toString_modelFeaturesContainsQkNormKey_p) {
+  nntrainer::ModelFeatures features;
+  std::string dump = features.toString();
+
+  EXPECT_FALSE(dump.empty());
+  EXPECT_NE(dump.find("qk_norm="), std::string::npos);
+}
+
+TEST(ExecPlanResolverTest, toString_gemmPathEnumLiterals_p) {
+  EXPECT_STREQ(nntrainer::toString(nntrainer::GemmPath::CPU), "CPU");
+  EXPECT_STREQ(nntrainer::toString(nntrainer::GemmPath::DP4A), "DP4A");
+  EXPECT_STREQ(nntrainer::toString(nntrainer::GemmPath::XMX), "XMX");
+  EXPECT_STREQ(nntrainer::toString(nntrainer::GemmPath::CUBLAS), "CUBLAS");
+}
+
+/**
  * @brief Main gtest
  */
 int main(int argc, char **argv) {


### PR DESCRIPTION
The resolver follow-up deferred from the engine-registry change: the single
place where device attributes (and the model's declared features) decide which
kernel families run, replacing scattered NNTR_* env flags and device-name
branches. SHADOW for now: it is resolved and logged once at init, but no
decision site reads it, so behavior is byte-identical.

Resolver (T4):
- GemmPath enum (CPU / DP4A / XMX / CUBLAS): which quantized-FC GEMM family a
  device should run, derived from DeviceCaps attributes only — never from an
  env flag or a device-name string match.
- ExecPlan POD (gemm_path, host_coherent, decode_gpu) with a one-line
  toString() for the shadow log.
- resolveExecPlan(const DeviceCaps &): pure function — cuda -> CUBLAS,
  gpu -> (dpas ? XMX : DP4A), else CPU; host_coherent mirrors caps.integrated.
- Only cleanly caps-derivable cells are resolved. Cells that are NOT a pure
  function of caps (kv backing image2d-vs-buffer — a driver compile quirk with
  no probe; queue-sync coherence overrides — wrong => garbage) deliberately
  stay conservative env overrides and are not shadowed.

Model features (T11):
- ModelFeatures POD: what the model IS, declared by the model itself (qk/v
  norms, MLP kind, norm placement, sliding window, KV-share/skip-prefill, dual
  head_dim, per-layer embedding, softcaps, LM-head scheme, decode-GPU
  eligibility, head_dim) — replaces is_<model> name proxies, so a new model is
  "set the flags" with no backend edit.
- resolveExecPlan(const DeviceCaps &, const ModelFeatures &) matcher overload:
  caps-derived cells come from the caps-only resolver; decode_gpu is granted
  only when the model asks for it AND the backend is a real GPU ("gpu"/"cuda").

AppContext::initialize() logs the caps-only resolution once next to the
existing DeviceCaps line (log-only). The per-backend concrete caps() probes
and the model-side getModelFeatures() declarations that feed the matcher land
in their own follow-up changes; unit tests (ExecPlanResolverTest, 14 cases)
cover both overloads and the toString dumps here.

Depends-on: the engine-registry change ("[engine] Open the backend registry +
neutral device-capability probe") — must merge first.

Verified with a gcc-13 -Werror plain build (enable-fp16=false,
enable-test=true) and the full meson suite: 43/43 test targets pass, including
unittest_nntrainer_appcontext (26 — 14 new ExecPlanResolverTest cases),
unittest_compiler (38), unittest_nntrainer_graph (12), unittest_layers (1020),
unittest_nntrainer_cpu_backend (53), unittest_nntrainer_tensor (267),
unittest_nntrainer_models (125), unittest_models (156).

Repro:
  meson setup build -Denable-transformer=true -Denable-test=true \
    -Denable-tflite-interpreter=false -Denable-tflite-backbone=false \
    -Denable-fp16=false --buildtype=plain
  ninja -C build
  meson test -C build unittest_nntrainer_appcontext
Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>