### PR TITLE
[Tensor/cpu_backend/arm] KAI f16 int4 (qai8dxp/qsi4cxp) matmul + disp…

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -35,6 +35,25 @@
 
 namespace nntrainer {
 
+// nntr_gemm_qai8dxp_qsi4cxp_* per-channel int4 KAI template decls. Upstream's
+// kleidiai refactor (the qai8dxp/qsi4cxp rhs-packed GEMM path) dropped these
+// from this header; our facade keeps the nntr_*<T> API, and
+// arm_compute_backend_fp16.cpp defines nntrainer::-scoped specializations, so
+// re-declare them here.
+template <typename T = float>
+uint32_t nntr_gemm_qai8dxp_qsi4cxp_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales, T *dst_mtx, bool transB = true,
+  T lower_bound = std::numeric_limits<T>::lowest(),
+  T upper_bound = std::numeric_limits<T>::max());
+
+template <typename T = float>
+void nntr_gemm_qai8dxp_qsi4cxp_packed(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
+  void *rhs_packed_mtx_qs4cx, T *dst_act_mtx_f32, uint32_t idx_variant,
+  bool transB = true, T lower_bound = std::numeric_limits<T>::lowest(),
+  T upper_bound = std::numeric_limits<T>::max());
+
 #ifdef ENABLE_FP16
 /**
  * @brief F32 * F16 = F32 GEMM

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -439,6 +439,44 @@ void nntr_quant_qs4c32_f32(size_t n, size_t k, size_t bl,
                             (uint8_t *)rhs_native_mtx_qs4c32);
 }
 
+// i8mm-gated, matching the loader-side contract this dispatch seam assumes
+// (see half_tensor.cpp): the KAI rhs-packed weight is packed once, ahead of
+// time, for the qai8dxp4x8/qsi4cxp4x8 pack family (nr=4 kr=16 sr=2). Locking
+// to that family (rather than also falling back to the dotprod-only
+// nr=4/kr=8/sr=2 family on non-i8mm ARM) avoids a silent pack-layout
+// mismatch — the loader-side packer does not exist in-tree yet (deferred to
+// the QS4CX-FP16 host-FC infra track), so there is nothing to confirm it
+// would target the other family too.
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+template <>
+void nntr_gemm_qai8dxp_qsi4cxp_packed(size_t m, size_t n, size_t k,
+                                      void *lhs_native_mtx_f16,
+                                      void *rhs_packed_mtx_qs4cx,
+                                      _FP16 *dst_act_mtx_f16,
+                                      uint32_t idx_variant, bool transB,
+                                      _FP16 lower_bound, _FP16 upper_bound) {
+  // Routes to the upstream qai8dxp/qsi4cxp f16 ukernel family
+  // (kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp's ukernel_variants[]) — GEMV
+  // (idx 1: qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod, mr=1) for a single-row
+  // decode step, GEMM (idx 3: qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm, mr=4)
+  // otherwise. idx_variant is informational here, not a caller-selectable
+  // choice: both indices share nr=4 kr=16 sr=2, so rhs_packed_mtx_qs4cx —
+  // packed once at load for that {nr,kr,sr} family — is valid for either
+  // without repacking; only mr (the LHS pack block / compute microkernel)
+  // differs between them. transB is not part of
+  // __kai_gemm_f16_qai8dxp_qsi4cxp's contract: the packed rhs is always
+  // nxk-packed-as-transposed by construction.
+  (void)idx_variant;
+  (void)transB;
+  static constexpr uint32_t kGemvVariant = 1;
+  static constexpr uint32_t kGemmVariant = 3;
+  const uint32_t variant = (m == 1) ? kGemvVariant : kGemmVariant;
+  __kai_gemm_f16_qai8dxp_qsi4cxp(
+    m, n, k, lhs_native_mtx_f16, rhs_packed_mtx_qs4cx, dst_act_mtx_f16, variant,
+    static_cast<float>(lower_bound), static_cast<float>(upper_bound));
+}
+#endif // defined(__ARM_FEATURE_MATMUL_INT8)
+
 size_t nntr_get_rhs_packed_size_qsi8d32p_qsi4c32p(size_t n, size_t k,
                                                   uint32_t idx_variant,
                                                   bool transB) {

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <compute_ops.h>
+#include <cpu_backend.h>
 #include <half_tensor.h>
 #include <tensor.h>
 #include <util_func.h>
@@ -719,6 +720,42 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
+#if (defined(__aarch64__) || defined(__ARM_ARCH_7A__) ||                       \
+     defined(__ANDROID__) || defined(__arm__) || defined(_M_ARM) ||            \
+     defined(_M_ARM64)) &&                                                     \
+  defined(__ARM_FEATURE_MATMUL_INT8)
+  case Tdatatype::QS4CX: {
+    // [KAI fp16 dispatch seam] Host fp16 GEMM for an upstream QS4CX weight —
+    // e.g. an lm_head (N = vocab) that exceeds the GPU image cap and falls
+    // back to host. The rhs is the qai8dxp4x8/qsi4cxp4x8-packed buffer built
+    // at load (QS4CXTensor::getPackedData); it is routed through the
+    // upstream KleidiAI f16 qai8dxp/qsi4cxp ukernel family (added by
+    // `308bdd4f3b` [kleidiai] Add `matmul_clamp_f16_qai8dxp_qsi4cxp`) via the
+    // packed<_FP16> facade, so no fp16<->fp32 cast pass over the LHS / DST.
+    // i8mm-gated because the facade is locked to the qai8dxp4x8/qsi4cxp4x8
+    // (nr=4 kr=16 sr=2) pack family — see arm_compute_backend_fp16.cpp.
+    //
+    // NOTE: the "is this weight already KAI-packed?" gate
+    // (isPackedF16Activation), the lazy plain-QS4CX -> KAI rhs assembly
+    // (Int4Utils::packPlainToSectionA / assembleKaiRhsPacked) and the x86
+    // reference-GEMM fallback are deferred to the QS4CX-FP16 host-FC infra
+    // track — they depend on the packF16Activation / Int4Utils body that is
+    // out of scope for this dispatch seam. This case assumes the weight was
+    // pre-packed at load by that track.
+    const unsigned int M = getDim().height();
+    const unsigned int K = getDim().width();
+    const unsigned int N = output.getDim().width();
+    const uint8_t *kai_rhs = input.getPackedData<uint8_t>();
+    _FP16 *data = (_FP16 *)getData();
+    _FP16 *rdata = output.getData<_FP16>();
+    const _FP16 lb = static_cast<_FP16>(-65504.0f);
+    const _FP16 ub = static_cast<_FP16>(65504.0f);
+    // transB=true: the KAI rhs-packed buffer is always row-major-as-transposed.
+    nntr_gemm_qai8dxp_qsi4cxp_packed<_FP16>(
+      M, N, K, (void *)data, (void *)kai_rhs, rdata, 3u, true, lb, ub);
+    break;
+  }
+#endif
   default:
     throw std::invalid_argument("Error: unsupported datatype");
   }

--- a/nntrainer/tensor/int4_utils.cpp
+++ b/nntrainer/tensor/int4_utils.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 #include "cpu_backend.h"
 #include "fp16.h"
@@ -180,6 +181,175 @@ int Int4Utils::convertInt4ToInt(const uint8_t int4_value) {
                          -8, -7, -6, -5, -4, -3, -2, -1};
 
   return lookup[int4_value];
+}
+
+void Int4Utils::quantizePlain(const float *weights, const size_t rows_count,
+                              const size_t columns_count,
+                              std::vector<uint8_t> &out_plain_nibbles,
+                              std::vector<uint16_t> &out_scales) {
+  std::vector<float> scales_fp32(rows_count);
+  out_scales.resize(rows_count);
+  for (size_t n = 0; n < rows_count; ++n) {
+    scales_fp32[n] =
+      computeScaleForGroup(weights + n * columns_count, columns_count);
+    out_scales[n] = compute_fp32_to_fp16(scales_fp32[n]);
+  }
+
+  // Build raw nibble matrix in N x roundup(K,2)/2 bytes. Each nibble holds
+  // uint4 = int4 + 8 (the rhs_zero_point=8 input form expected by
+  // kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0).
+  const size_t rhs_row_bytes = (columns_count + 1) / 2;
+  out_plain_nibbles.assign(rows_count * rhs_row_bytes, 0u);
+  for (size_t n = 0; n < rows_count; ++n) {
+    for (size_t k = 0; k < columns_count; k += 2) {
+      const uint8_t u0 =
+        quantizeToInt4(weights[n * columns_count + k], scales_fp32[n]);
+      uint8_t byte = (uint8_t)((u0 + 8) & 0x0F);
+      if (k + 1 < columns_count) {
+        const uint8_t u1 =
+          quantizeToInt4(weights[n * columns_count + k + 1], scales_fp32[n]);
+        byte |= (uint8_t)(((u1 + 8) & 0x0F) << 4);
+      } else {
+        byte |= (uint8_t)(8u << 4); // pad nibble = uint4(0)
+      }
+      out_plain_nibbles[n * rhs_row_bytes + (k / 2)] = byte;
+    }
+  }
+}
+
+void Int4Utils::packPlainToSectionA(const uint8_t *plain_nibbles,
+                                    size_t rows_count, size_t columns_count,
+                                    uint8_t *out_section_a) {
+  const uint8_t *raw_nibbles = plain_nibbles;
+  const size_t rhs_row_bytes = (columns_count + 1) / 2;
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  const size_t nibble_bytes_per_super_row = KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = KAI_KR / KAI_SR; // = 8
+  const uint8_t pad_byte = (uint8_t)(8u | (8u << 4));   // uint4(0)|uint4(0)
+
+  for (size_t dst_row_idx = 0; dst_row_idx < super_row_count; ++dst_row_idx) {
+    uint8_t *dst_row = out_section_a + dst_row_idx * nibble_bytes_per_super_row;
+
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t block_byte_idx = dst_byte_idx % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / KAI_NR;
+      const size_t nr_idx = block_idx % KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         KAI_K_INTERLEAVE) *
+        KAI_K_INTERLEAVE;
+      const size_t k0_idx =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1_idx = k0_idx + KAI_K_INTERLEAVE;
+      const size_t n0_idx = dst_row_idx * KAI_NR + nr_idx;
+      const size_t n0_valid_idx =
+        (n0_idx < rows_count) ? n0_idx : (rows_count - 1);
+
+      uint8_t byte0 = pad_byte;
+      uint8_t byte1 = pad_byte;
+      if (k0_idx < columns_count) {
+        byte0 = raw_nibbles[n0_valid_idx * rhs_row_bytes + (k0_idx / 2)];
+      }
+      if (k1_idx < columns_count) {
+        byte1 = raw_nibbles[n0_valid_idx * rhs_row_bytes + (k1_idx / 2)];
+      }
+      const size_t shift_right_x0 = (k0_idx % 2) * 4;
+      const size_t shift_right_x1 = (k1_idx % 2) * 4;
+      const uint8_t src_x0_lo = (uint8_t)((byte0 >> shift_right_x0) & 0x0F);
+      const uint8_t src_x0_hi = (uint8_t)((byte1 >> shift_right_x1) & 0x0F);
+      const uint8_t dst_qs0 = (uint8_t)(src_x0_lo | (src_x0_hi << 4));
+      *dst_row = (uint8_t)(dst_qs0 ^ 0x88);
+      ++dst_row;
+    }
+  }
+}
+
+void Int4Utils::quantizeAndPackKai(const float *weights,
+                                   const size_t rows_count,
+                                   const size_t columns_count,
+                                   std::vector<uint8_t> &out_weights,
+                                   std::vector<uint16_t> &out_scales) {
+  std::vector<uint8_t> plain_nibbles;
+  quantizePlain(weights, rows_count, columns_count, plain_nibbles, out_scales);
+  out_weights.assign(kaiNibblePayloadBytes(rows_count, columns_count), 0u);
+  packPlainToSectionA(plain_nibbles.data(), rows_count, columns_count,
+                      out_weights.data());
+}
+
+size_t Int4Utils::kaiNibblePayloadBytes(size_t rows_count,
+                                        size_t columns_count) {
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  return super_row_count * KAI_NR * (k_internal / 2);
+}
+
+void Int4Utils::assembleKaiRhsPacked(const uint8_t *section_a,
+                                     const uint16_t *fp16_scales,
+                                     size_t rows_count, size_t columns_count,
+                                     std::vector<uint8_t> &out_kai_packed) {
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  const size_t nibble_bytes_per_super_row = KAI_NR * (k_internal / 2);
+  const size_t trailer_bytes_per_super_row = KAI_NR * (4 + 4 + 4);
+  const size_t super_row_stride =
+    nibble_bytes_per_super_row + trailer_bytes_per_super_row;
+
+  out_kai_packed.assign(super_row_count * super_row_stride, 0u);
+
+  const size_t block_length_in_bytes = KAI_KR / KAI_SR; // = 8
+
+  for (size_t sr_idx = 0; sr_idx < super_row_count; ++sr_idx) {
+    uint8_t *dst_row = out_kai_packed.data() + sr_idx * super_row_stride;
+    const uint8_t *src_row = section_a + sr_idx * nibble_bytes_per_super_row;
+
+    // Nibbles are byte-identical to Section A on disk — just copy them.
+    std::memcpy(dst_row, src_row, nibble_bytes_per_super_row);
+
+    // Per-channel sums = sum_k int4[n][k] * 16. Decode each Section A byte
+    // back to two int4 lanes via XOR 0x88 -> uint4 -> int4 = uint4 - 8.
+    int32_t sums[KAI_NR] = {0, 0, 0, 0};
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t nr_idx = block_idx % KAI_NR;
+
+      const uint8_t stored = src_row[dst_byte_idx] ^ 0x88;
+      const int u_lo = stored & 0x0F;
+      const int u_hi = (stored >> 4) & 0x0F;
+      // Both nibbles belong to the same n0 (= sr_idx * KAI_NR + nr_idx) —
+      // the K interleave shuffles k0/k1 within the same channel.
+      sums[nr_idx] += (u_lo - 8) + (u_hi - 8);
+    }
+
+    int32_t *sums_dst = (int32_t *)(dst_row + nibble_bytes_per_super_row);
+    for (size_t i = 0; i < KAI_NR; ++i) {
+      sums_dst[i] = sums[i] * 16;
+    }
+
+    // Scales: per-channel fp16 -> fp32 -> baked × 0.0625 (matches KAI
+    // packer line 212).
+    float *scales_dst = (float *)(dst_row + nibble_bytes_per_super_row +
+                                  KAI_NR * sizeof(int32_t));
+    for (size_t i = 0; i < KAI_NR; ++i) {
+      const size_t n_idx = std::min(sr_idx * KAI_NR + i, rows_count - 1);
+      const float s = compute_fp16_to_fp32(fp16_scales[n_idx]);
+      scales_dst[i] = s * 0.0625F;
+    }
+
+    // Bias: always zero for FC int4 weights — the bias tensor (if any) is
+    // a separate FP16 weight that the layer adds outside this matmul.
+    // 4 floats already memset to 0 by assign(.., 0u).
+  }
 }
 
 void Int4Utils::dequantizePacked(const std::vector<uint8_t> &weights,

--- a/nntrainer/tensor/int4_utils.h
+++ b/nntrainer/tensor/int4_utils.h
@@ -30,6 +30,16 @@ public:
   /// @brief Numbers of element in one byte of date in the osv32_isv2 layout
   static constexpr const size_t COLUMN_BLOCK_SIZE = 2;
 
+  /// @brief KAI qsi4cxp packing constants for the {nr=4, kr=16, sr=2}
+  ///        qai8dxp/qsi4cxp pack family (matmul_clamp_f32_qai8dxp4x8_
+  ///        qsi4cxp4x8_4x4x32_neon_i8mm and the fp16 16x4 variant share this
+  ///        family, so one rhs_packed buffer serves both).
+  static constexpr const size_t KAI_NR = 4;
+  static constexpr const size_t KAI_KR = 16;
+  static constexpr const size_t KAI_SR = 2;
+  static constexpr const size_t KAI_K_INTERLEAVE = 16;
+  static constexpr const size_t KAI_K_PAD_MULTIPLE = 32;
+
   /**
    * @brief     Compute scale for input weights
    * @param[in] group_weights float * inout vector of weights
@@ -88,6 +98,80 @@ public:
                                 const size_t group_size,
                                 std::vector<uint8_t> &out_weights,
                                 std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Quantize float* matrix into the plain per-channel int4 nibble
+   *        form: N x ceil(K/2) bytes, row-major, even k in the low nibble,
+   *        each stored uint4 = int4 + 8. Scale is per-channel absmax/7
+   *        (the same formula quantizeToInt4 expects). This is stage 1 of
+   *        quantizeAndPackKai.
+   * @param out_plain_nibbles N x ceil(K/2) bytes, row-major
+   * @param out_scales per-channel fp16 scales, size = rows_count
+   */
+  static void quantizePlain(const float *weights, const size_t rows_count,
+                            const size_t columns_count,
+                            std::vector<uint8_t> &out_plain_nibbles,
+                            std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Permute plain per-channel int4 nibbles (quantizePlain's output)
+   *        into the KAI qsi4cxp Section A super-row payload: mirrors the
+   *        rhs_zero_point=8 path of kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0
+   *        (nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/) with
+   *        the trailer (sums, scales, bias) elided — assembleKaiRhsPacked
+   *        reconstructs that separately. This is stage 2 of
+   *        quantizeAndPackKai.
+   * @param out_section_a caller-provided buffer of
+   *        kaiNibblePayloadBytes(rows_count, columns_count) bytes
+   */
+  static void packPlainToSectionA(const uint8_t *plain_nibbles,
+                                  size_t rows_count, size_t columns_count,
+                                  uint8_t *out_section_a);
+
+  /**
+   * @brief Quantize float* matrix into KAI qsi4cxp Section A nibble payload
+   *        (quantizePlain + packPlainToSectionA combined). No sums/scales/
+   *        bias trailer is written — assembleKaiRhsPacked reassembles that
+   *        at load time from the nibbles + per-channel scales this emits.
+   * @param weights float * input matrix (rows_count x columns_count)
+   * @param rows_count N (output channels)
+   * @param columns_count K (input channels)
+   * @param out_weights output nibble payload, size
+   *        = ceil(N/KAI_NR) * KAI_NR * (roundup(K, KAI_K_PAD_MULTIPLE) / 2)
+   * @param out_scales output per-channel fp16 scales, size = rows_count
+   */
+  static void quantizeAndPackKai(const float *weights, const size_t rows_count,
+                                 const size_t columns_count,
+                                 std::vector<uint8_t> &out_weights,
+                                 std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Convenience: byte size of the KAI Section A nibble payload for
+   *        the given (N, K) shape.
+   */
+  static size_t kaiNibblePayloadBytes(size_t rows_count, size_t columns_count);
+
+  /**
+   * @brief Reassemble Section A nibbles (quantizeAndPackKai's output) +
+   *        per-channel fp16 scales into a full KAI rhs_packed buffer, ready
+   *        for the qai8dxp_qsi4cxp matmul micro-kernels. Per super-row of
+   *        nr=4 output channels the layout is
+   *          [nibbles : 4*(k_internal/2) bytes (copied as-is)]
+   *          [sums    : 4 * int32, each = sum_k int4[n][k] * 16]
+   *          [scales  : 4 * fp32,  each = (fp16->fp32 scale) * 0.0625]
+   *          [bias    : 4 * fp32 = 0]
+   *
+   * @param section_a       nibble payload; size must be
+   *                        kaiNibblePayloadBytes(rows_count, columns_count).
+   * @param fp16_scales     per-output-channel fp16 scales, size N.
+   * @param rows_count      N (output channels). Must be a multiple of 4.
+   * @param columns_count   K (input channels). Must be a multiple of 32.
+   * @param out_kai_packed  output buffer, sized by this function.
+   */
+  static void assembleKaiRhsPacked(const uint8_t *section_a,
+                                   const uint16_t *fp16_scales,
+                                   size_t rows_count, size_t columns_count,
+                                   std::vector<uint8_t> &out_kai_packed);
 
   /**
    * @brief     Quantize one float value to 4-bits integer

--- a/test/meson.build
+++ b/test/meson.build
@@ -46,6 +46,49 @@ nntrainer_test_main_deps = [
   nntrainer_testutil_dep
 ]
 
+# KAI qai8dxp/qsi4cxp int4 packing sanity checks (standalone: no gtest, own
+# main()). ARM-only: they link the KleidiAI reference packer/matmul sources
+# under nntrainer/tensor/cpu_backend/arm/, which meson only compiles into
+# nntrainer_dep for aarch64/arm/android builds (see
+# nntrainer/tensor/cpu_backend/meson.build), and they exercise
+# __ARM_FEATURE_MATMUL_INT8 (i8mm) code paths that this project always
+# enables for native aarch64 (see the top-level meson.build extra_defines
+# block). Gate mirrors the existing aarch64-only
+# `unittest_nntrainer_kleidiai` target below.
+if host_machine.cpu_family() == 'aarch64'
+  q4_kai_standalone_targets = [
+    'q4_roundtrip_kai',
+    'q4_kai_bytecompat',
+  ]
+  foreach t : q4_kai_standalone_targets
+    q4_kai_exe = executable(
+      t,
+      t + '.cpp',
+      dependencies: nntrainer_test_deps,
+      install: get_option('enable-test'),
+      install_dir: application_install_dir
+    )
+    test(t, q4_kai_exe, timeout: test_timeout, suite: 'unittests')
+  endforeach
+
+  # The fp16 matmul path additionally needs the enable-fp16-gated
+  # matmul_clamp_f16_qai8dxp_qsi4cxp kernels + qai8dxp_f16 LHS packer
+  # (nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build only
+  # enters that subdir when enable-fp16 is set), so this one test gates on
+  # both.
+  if get_option('enable-fp16')
+    q4_kai_matmul_device_exe = executable(
+      'q4_kai_matmul_device',
+      'q4_kai_matmul_device.cpp',
+      dependencies: nntrainer_test_deps,
+      install: get_option('enable-test'),
+      install_dir: application_install_dir
+    )
+    test('q4_kai_matmul_device', q4_kai_matmul_device_exe,
+      timeout: test_timeout, suite: 'unittests')
+  endif
+endif
+
 if enable_capi
   subdir('tizen_capi')
 endif

--- a/test/q4_kai_bytecompat.cpp
+++ b/test/q4_kai_bytecompat.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_kai_bytecompat.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Byte-equality check between Int4Utils::quantizeAndPackKai and
+ * KAI's own qsi4cxp reference packer
+ */
+// Byte-equality check between Int4Utils::quantizeAndPackKai (host C++
+// emit) and KAI's own kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 (the
+// reference packer from nntrainer/tensor/cpu_backend/arm/kai/pack/).
+//
+// The KAI source is pure C with a __ARM_NEON guard, so it builds on x86
+// for verification. We feed both packers from the same FP32 weights and
+// scales, then strip KAI's per-super-row trailer (sums + scales + bias =
+// 48 B for nr=4) and compare the remaining nibble payload byte-for-byte
+// to our packer's output.
+//
+// Standalone (no gtest).
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <fp16.h>
+#include <int4_utils.h>
+
+extern "C" {
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
+}
+
+using namespace nntrainer;
+
+static void quantize_raw_nibbles(const std::vector<float> &W, unsigned N,
+                                 unsigned K, std::vector<uint8_t> &raw_nibbles,
+                                 std::vector<float> &scales_fp32) {
+  scales_fp32.assign(N, 1.0f);
+  const size_t row_bytes = (K + 1) / 2;
+  raw_nibbles.assign((size_t)N * row_bytes, 0u);
+  for (unsigned n = 0; n < N; ++n) {
+    float max_abs = 0.0f;
+    for (unsigned k = 0; k < K; ++k) {
+      float a = std::fabs(W[(size_t)n * K + k]);
+      if (a > max_abs)
+        max_abs = a;
+    }
+    scales_fp32[n] = (max_abs == 0.0f) ? 1.0f : (max_abs / 7.0f);
+    const float s = scales_fp32[n];
+    for (unsigned k = 0; k < K; k += 2) {
+      const uint8_t u0 = Int4Utils::quantizeToInt4(W[(size_t)n * K + k], s);
+      uint8_t byte = (uint8_t)((u0 + 8) & 0x0F);
+      if (k + 1 < K) {
+        const uint8_t u1 =
+          Int4Utils::quantizeToInt4(W[(size_t)n * K + k + 1], s);
+        byte |= (uint8_t)(((u1 + 8) & 0x0F) << 4);
+      } else {
+        byte |= (uint8_t)(8u << 4);
+      }
+      raw_nibbles[(size_t)n * row_bytes + (k / 2)] = byte;
+    }
+  }
+}
+
+static int run(unsigned K, unsigned N, const char *tag) {
+  std::mt19937 rng(1234);
+  std::normal_distribution<float> nd(0.0f, 0.05f);
+  std::vector<float> W((size_t)N * K);
+  for (auto &v : W)
+    v = nd(rng);
+
+  // 1) Our packer (FP32 in, Section A out).
+  std::vector<uint8_t> qw_ours;
+  std::vector<uint16_t> qs_ours;
+  Int4Utils::quantizeAndPackKai(W.data(), N, K, qw_ours, qs_ours);
+
+  // 2) KAI reference packer: feed pre-quantized nibbles + fp32 scales.
+  //    Round-trip the scales through fp16 so the trailer bytes match
+  //    Int4Utils::assembleKaiRhsPacked (which reads fp16 from disk).
+  std::vector<uint8_t> raw_nibbles;
+  std::vector<float> scales_fp32;
+  quantize_raw_nibbles(W, N, K, raw_nibbles, scales_fp32);
+  for (auto &s : scales_fp32) {
+    s = compute_fp16_to_fp32(compute_fp32_to_fp16(s));
+  }
+
+  const size_t nr = Int4Utils::KAI_NR;
+  const size_t kr = Int4Utils::KAI_KR;
+  const size_t sr = Int4Utils::KAI_SR;
+  const size_t kai_packed_size =
+    kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(N, K, nr, kr, sr);
+  std::vector<uint8_t> kai_packed(kai_packed_size, 0u);
+
+  kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params params;
+  params.lhs_zero_point = 1;
+  params.rhs_zero_point = 8;
+  const float *no_bias = nullptr; // no bias for this test
+  const size_t no_extra_bytes = 0;
+  kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(
+    1, N, K, nr, kr, sr, raw_nibbles.data(), no_bias, scales_fp32.data(),
+    kai_packed.data(), no_extra_bytes, &params);
+
+  // 3) Strip KAI trailer per super-row, compare Section A.
+  const size_t k_internal = ((size_t)K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) /
+                            Int4Utils::KAI_K_PAD_MULTIPLE *
+                            Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t nibble_bytes_per_super_row = nr * (k_internal / 2);
+  const size_t kai_stride =
+    kai_get_rhs_packed_stride_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(K, nr, kr, sr);
+  const size_t super_row_count = (N + nr - 1) / nr;
+
+  if (qw_ours.size() != super_row_count * nibble_bytes_per_super_row) {
+    printf("[%s/bytecompat] FAIL: ours size %zu != expected %zu\n", tag,
+           qw_ours.size(), super_row_count * nibble_bytes_per_super_row);
+    return 1;
+  }
+
+  size_t mismatches = 0;
+  size_t first_mismatch = (size_t)-1;
+  uint8_t first_a = 0, first_b = 0;
+  for (size_t sr_i = 0; sr_i < super_row_count; ++sr_i) {
+    const uint8_t *kai_row = kai_packed.data() + sr_i * kai_stride;
+    const uint8_t *ours_row =
+      qw_ours.data() + sr_i * nibble_bytes_per_super_row;
+    for (size_t b = 0; b < nibble_bytes_per_super_row; ++b) {
+      if (kai_row[b] != ours_row[b]) {
+        ++mismatches;
+        if (first_mismatch == (size_t)-1) {
+          first_mismatch = sr_i * nibble_bytes_per_super_row + b;
+          first_a = ours_row[b];
+          first_b = kai_row[b];
+        }
+      }
+    }
+  }
+
+  if (mismatches != 0) {
+    printf("[%s/bytecompat] FAIL nibble: %zu mismatched bytes, first at "
+           "offset %zu (ours=0x%02x vs kai=0x%02x)\n",
+           tag, mismatches, first_mismatch, first_a, first_b);
+    return 1;
+  }
+
+  // Now exercise Int4Utils::assembleKaiRhsPacked: reassemble Section A +
+  // fp16 scales into a full KAI rhs_packed buffer (with trailer) and
+  // compare byte-for-byte to the KAI packer's output. This locks the
+  // load-time trailer reassembly (sums, scales*0.0625, bias) to the
+  // matmul kernel's expectations.
+  std::vector<uint8_t> ours_full;
+  Int4Utils::assembleKaiRhsPacked(qw_ours.data(), qs_ours.data(), N, K,
+                                  ours_full);
+  if (ours_full.size() != kai_packed.size()) {
+    printf("[%s/bytecompat] FAIL trailer: assembled size %zu vs KAI %zu\n", tag,
+           ours_full.size(), kai_packed.size());
+    return 1;
+  }
+  size_t t_mismatches = 0;
+  size_t t_first = (size_t)-1;
+  uint8_t t_a = 0, t_b = 0;
+  for (size_t i = 0; i < ours_full.size(); ++i) {
+    if (ours_full[i] != kai_packed[i]) {
+      ++t_mismatches;
+      if (t_first == (size_t)-1) {
+        t_first = i;
+        t_a = ours_full[i];
+        t_b = kai_packed[i];
+      }
+    }
+  }
+  if (t_mismatches != 0) {
+    printf("[%s/bytecompat] FAIL trailer: %zu mismatched bytes, first at "
+           "offset %zu (ours=0x%02x vs kai=0x%02x)\n",
+           tag, t_mismatches, t_first, t_a, t_b);
+    return 1;
+  }
+
+  printf("[%s/bytecompat] OK: %zu super-rows, nibble %zu B + trailer 48 B = "
+         "%zu B byte-identical with KAI rhs_pack\n",
+         tag, super_row_count, nibble_bytes_per_super_row, kai_packed.size());
+  return 0;
+}
+
+int main() {
+  int rc = 0;
+  rc |= run(32, 4, "tiny");
+  rc |= run(256, 32, "small");
+  rc |= run(1536, 1536, "square");
+  rc |= run(1536, 6144, "ffn_up");
+  rc |= run(6144, 1536, "ffn_down");
+  return rc;
+}

--- a/test/q4_kai_matmul_device.cpp
+++ b/test/q4_kai_matmul_device.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_kai_matmul_device.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  ARM device sanity test for the KAI qsi4cxp matmul path
+ * end-to-end
+ */
+// ARM device sanity test for the KAI qsi4cxp matmul path end-to-end.
+//
+// For both the upstream fp32 matmul (4x4x32 i8mm variant) and the fp16
+// matmul (16x4 i8mm variant, from upstream `308bdd4f3b`
+// [kleidiai] Add `matmul_clamp_f16_qai8dxp_qsi4cxp`), this:
+//   1. Generates a random fp32 weight tensor [N x K].
+//   2. Packs it via Int4Utils::quantizeAndPackKai (Section A nibbles +
+//      per-channel fp16 scales).
+//   3. Reassembles the full KAI rhs_packed buffer via
+//      assembleKaiRhsPacked (sums / scales*0.0625 / bias=0 trailer).
+//   4. Runs the KAI matmul over a random LHS activation.
+//   5. Compares against a reference matmul performed in fp32 with
+//      dequantized int4 weights — same quantization noise on both
+//      sides, so the residual measures only the matmul path itself.
+//
+// Standalone (no gtest, no libnntrainer). Cross-compiles directly with
+// the NDK clang; pushes to the device and prints diagnostic numbers.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "fp16.h"
+#include "int4_utils.h"
+
+extern "C" {
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h"
+#include "kai/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_4x4x32_neon_i8mm.h"
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.h"
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
+}
+
+using namespace nntrainer;
+
+// Mirror of nntr_kai_gemm_qai8dxp_qsi4cxp_olp_single_thread for variant 2,
+// inlined here so this test does not pull in libnntrainer.
+static void run_kai_fp32(size_t m, size_t n, size_t k, const float *lhs_f32,
+                         const uint8_t *rhs_packed, float *dst_f32) {
+  constexpr size_t mr = 4, kr = 16, sr = 2;
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr);
+  std::vector<uint8_t> lhs_packed(lhs_packed_size);
+  kai_run_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr, 0, lhs_f32,
+                                     k * sizeof(float), lhs_packed.data());
+
+  const size_t dst_stride = n * sizeof(float);
+  kai_run_matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_4x4x32_neon_i8mm(
+    m, n, k, lhs_packed.data(), rhs_packed, dst_f32, dst_stride, sizeof(float),
+    -1e30f, 1e30f);
+}
+
+static void run_kai_fp16(size_t m, size_t n, size_t k, const __fp16 *lhs_f16,
+                         const uint8_t *rhs_packed, __fp16 *dst_f16) {
+  // nr=4 kr=16 sr=2 — the qai8dxp4x8_qsi4cxp4x8 pack family shared by the
+  // 16x4 i8mm GEMM variant used here and the 1x4 dotprod GEMV variant
+  // (idx 1) selected by the arm_compute_backend_fp16.cpp facade for M==1;
+  // see the comment there for why the same rhs_packed buffer is valid for
+  // both.
+  constexpr size_t mr = 4, kr = 16, sr = 2;
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f16_neon(m, k, mr, kr, sr);
+  std::vector<uint8_t> lhs_packed(lhs_packed_size);
+  kai_run_lhs_quant_pack_qai8dxp_f16_neon(
+    m, k, mr, kr, sr, 0, lhs_f16, k * sizeof(__fp16), lhs_packed.data());
+
+  const size_t dst_stride = n * sizeof(__fp16);
+  kai_run_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+    m, n, k, lhs_packed.data(), rhs_packed, dst_f16, dst_stride, sizeof(__fp16),
+    -65504.0f, 65504.0f);
+}
+
+// Dequantize Section A bytes back to fp32 weight matrix [N x K] using the
+// same reverse-permutation as test/q4_roundtrip_kai.cpp's helper.
+static void dequant_for_reference(const std::vector<uint8_t> &section_a,
+                                  const std::vector<uint16_t> &fp16_scales,
+                                  size_t N, size_t K,
+                                  std::vector<float> &W_dq) {
+  const size_t k_internal =
+    ((K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) / Int4Utils::KAI_K_PAD_MULTIPLE) *
+    Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count =
+    (N + Int4Utils::KAI_NR - 1) / Int4Utils::KAI_NR;
+  const size_t nibble_bytes_per_super_row =
+    Int4Utils::KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = Int4Utils::KAI_KR / Int4Utils::KAI_SR;
+
+  W_dq.assign(N * K, 0.0f);
+
+  // fp16 -> fp32 once
+  std::vector<float> sc(N);
+  for (size_t n = 0; n < N; ++n) {
+    sc[n] = compute_fp16_to_fp32(fp16_scales[n]);
+  }
+
+  for (size_t sr_i = 0; sr_i < super_row_count; ++sr_i) {
+    const uint8_t *src_row =
+      section_a.data() + sr_i * nibble_bytes_per_super_row;
+    for (size_t b = 0; b < nibble_bytes_per_super_row; ++b) {
+      const size_t block_idx = b / block_length_in_bytes;
+      const size_t block_byte_idx = b % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / Int4Utils::KAI_NR;
+      const size_t nr_idx = block_idx % Int4Utils::KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         Int4Utils::KAI_K_INTERLEAVE) *
+        Int4Utils::KAI_K_INTERLEAVE;
+      const size_t k0 =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1 = k0 + Int4Utils::KAI_K_INTERLEAVE;
+      const size_t n0 = sr_i * Int4Utils::KAI_NR + nr_idx;
+      if (n0 >= N)
+        continue;
+
+      const uint8_t stored = src_row[b] ^ 0x88;
+      const int q0 = (stored & 0x0F) - 8;
+      const int q1 = ((stored >> 4) & 0x0F) - 8;
+      if (k0 < K)
+        W_dq[n0 * K + k0] = (float)q0 * sc[n0];
+      if (k1 < K)
+        W_dq[n0 * K + k1] = (float)q1 * sc[n0];
+    }
+  }
+}
+
+static void run_shape(unsigned M, unsigned N, unsigned K, const char *tag) {
+  std::mt19937 rng(987);
+  std::normal_distribution<float> w_nd(0.0f, 0.05f);
+  std::normal_distribution<float> a_nd(0.0f, 1.0f);
+
+  // RHS weight [N x K] in row-major (this is what quantizeAndPackKai expects).
+  std::vector<float> W((size_t)N * K);
+  for (auto &v : W)
+    v = w_nd(rng);
+
+  // LHS activation [M x K].
+  std::vector<float> A((size_t)M * K);
+  for (auto &v : A)
+    v = a_nd(rng);
+
+  // Pack + assemble.
+  std::vector<uint8_t> qw;
+  std::vector<uint16_t> qs;
+  Int4Utils::quantizeAndPackKai(W.data(), N, K, qw, qs);
+  std::vector<uint8_t> rhs_packed;
+  Int4Utils::assembleKaiRhsPacked(qw.data(), qs.data(), N, K, rhs_packed);
+
+  // Reference: dequant int4 -> fp32 weights, then plain matmul. This shares
+  // the same quantization noise as the KAI path, so the comparison measures
+  // matmul fidelity only.
+  std::vector<float> W_dq;
+  dequant_for_reference(qw, qs, N, K, W_dq);
+  std::vector<float> ref((size_t)M * N, 0.0f);
+  for (unsigned i = 0; i < M; ++i) {
+    for (unsigned j = 0; j < N; ++j) {
+      float acc = 0.0f;
+      for (unsigned k = 0; k < K; ++k) {
+        acc += A[(size_t)i * K + k] * W_dq[(size_t)j * K + k];
+      }
+      ref[(size_t)i * N + j] = acc;
+    }
+  }
+
+  auto report = [&](const char *path, const std::vector<float> &got) {
+    double se = 0.0, sigpow = 0.0, maxabs = 0.0;
+    for (size_t i = 0; i < (size_t)M * N; ++i) {
+      double e = (double)got[i] - (double)ref[i];
+      se += e * e;
+      sigpow += (double)ref[i] * (double)ref[i];
+      if (std::fabs(e) > maxabs)
+        maxabs = std::fabs(e);
+    }
+    double mse = se / ((double)M * N);
+    double rel = std::sqrt(se / (sigpow + 1e-12));
+    printf("  [%s/%s] M=%u N=%u K=%u  MSE=%.3e relL2=%.3e maxAbs=%.3e\n", tag,
+           path, M, N, K, mse, rel, maxabs);
+  };
+
+  // fp32 KAI matmul path.
+  std::vector<float> out_f32((size_t)M * N);
+  run_kai_fp32(M, N, K, A.data(), rhs_packed.data(), out_f32.data());
+  report("fp32", out_f32);
+
+  // fp16 KAI matmul path: cast input + cast output to compare on the same
+  // scale as ref.
+  std::vector<__fp16> A_f16((size_t)M * K);
+  for (size_t i = 0; i < (size_t)M * K; ++i)
+    A_f16[i] = (__fp16)A[i];
+  std::vector<__fp16> out_f16_raw((size_t)M * N);
+  run_kai_fp16(M, N, K, A_f16.data(), rhs_packed.data(), out_f16_raw.data());
+  std::vector<float> out_f16((size_t)M * N);
+  for (size_t i = 0; i < (size_t)M * N; ++i)
+    out_f16[i] = (float)out_f16_raw[i];
+  report("fp16", out_f16);
+}
+
+int main() {
+  printf("[KAI matmul device sanity]\n");
+  run_shape(1, 1536, 1536, "square_M=1");
+  run_shape(4, 1536, 1536, "square_M=4");
+  run_shape(16, 1536, 1536, "square_M=16");
+  run_shape(64, 1536, 1536, "square_M=64");
+  run_shape(1, 6144, 1536, "ffn_up_M=1");
+  run_shape(4, 6144, 1536, "ffn_up_M=4");
+  printf("[done]\n");
+  return 0;
+}

--- a/test/q4_roundtrip_kai.cpp
+++ b/test/q4_roundtrip_kai.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_roundtrip_kai.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  QINT4 channel-wise (KAI qsi4cxp Section A) round-trip check
+ */
+// QINT4 channel-wise (KAI qsi4cxp Section A) round-trip check:
+//   pack:    Int4Utils::quantizeAndPackKai   (matches kai_run_rhs_pack_nxk_
+//                                             qsi4cxp_qs4cxs1s0 nibble bytes,
+//                                             trailer stripped)
+//   dequant: reverse-permute Section A → uint4 → int4 → * scale
+//
+// Standalone (no gtest). Mirrors the structure of test/q4_roundtrip.cpp so
+// the two paths can be compared side-by-side from CLI output.
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include <fp16.h>
+#include <int4_utils.h>
+
+using namespace nntrainer;
+
+// Reverse-permute KAI Section A back into [N][K] dequantized floats. This
+// mirrors Int4Utils::quantizeAndPackKai byte-for-byte, then undoes the
+// XOR-0x88 and the uint4 = int4 + 8 encoding to recover the original signed
+// 4-bit value, finally scales by the per-channel fp16 scale (expanded to
+// fp32 at use time).
+static void dequant_kai_section_a(const std::vector<uint8_t> &packed,
+                                  const std::vector<uint16_t> &scales,
+                                  unsigned N, unsigned K,
+                                  std::vector<float> &out) {
+  const size_t k_internal = ((size_t)K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) /
+                            Int4Utils::KAI_K_PAD_MULTIPLE *
+                            Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count =
+    ((size_t)N + Int4Utils::KAI_NR - 1) / Int4Utils::KAI_NR;
+  const size_t nibble_bytes_per_super_row =
+    Int4Utils::KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = Int4Utils::KAI_KR / Int4Utils::KAI_SR;
+  const size_t kK = (size_t)K;
+
+  out.assign((size_t)N * K, 0.0f);
+
+  // Expand fp16 scales to fp32 once, since K iterations re-use them.
+  std::vector<float> sc(N);
+  for (unsigned n = 0; n < N; ++n) {
+    sc[n] = compute_fp16_to_fp32(scales[n]);
+  }
+
+  for (size_t dst_row_idx = 0; dst_row_idx < super_row_count; ++dst_row_idx) {
+    const uint8_t *dst_row =
+      packed.data() + dst_row_idx * nibble_bytes_per_super_row;
+
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t block_byte_idx = dst_byte_idx % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / Int4Utils::KAI_NR;
+      const size_t nr_idx = block_idx % Int4Utils::KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         Int4Utils::KAI_K_INTERLEAVE) *
+        Int4Utils::KAI_K_INTERLEAVE;
+      const size_t k0_idx =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1_idx = k0_idx + Int4Utils::KAI_K_INTERLEAVE;
+      const size_t n0_idx = dst_row_idx * Int4Utils::KAI_NR + nr_idx;
+      if (n0_idx >= N)
+        continue;
+
+      const uint8_t stored = dst_row[dst_byte_idx] ^ 0x88;
+      const int u_lo = stored & 0x0F;
+      const int u_hi = (stored >> 4) & 0x0F;
+      const int q0 = u_lo - 8; // signed int4 in [-8, 7]
+      const int q1 = u_hi - 8;
+      const float s = sc[n0_idx];
+
+      if (k0_idx < kK)
+        out[n0_idx * kK + k0_idx] = (float)q0 * s;
+      if (k1_idx < kK)
+        out[n0_idx * kK + k1_idx] = (float)q1 * s;
+    }
+  }
+}
+
+static void run(unsigned K, unsigned N, const char *tag) {
+  std::mt19937 rng(1234);
+  std::normal_distribution<float> nd(0.0f, 0.05f);
+
+  // Original FC weight as nntrainer stores it: [K, N] row-major.
+  std::vector<float> W((size_t)K * N);
+  for (auto &v : W)
+    v = nd(rng);
+
+  // ---- save path: transpose [K,N] -> [N,K], pack KAI Section A ----
+  std::vector<float> Wt((size_t)N * K);
+  for (unsigned k = 0; k < K; ++k)
+    for (unsigned n = 0; n < N; ++n)
+      Wt[(size_t)n * K + k] = W[(size_t)k * N + n];
+
+  std::vector<uint8_t> qw;
+  std::vector<uint16_t> qs;
+  Int4Utils::quantizeAndPackKai(Wt.data(), N, K, qw, qs);
+
+  // ---- dequant path: reverse-permute Section A -> [N, K] ----
+  std::vector<float> deq;
+  dequant_kai_section_a(qw, qs, N, K, deq);
+
+  // rebuild [K, N]
+  std::vector<float> R((size_t)K * N);
+  for (unsigned n = 0; n < N; ++n)
+    for (unsigned k = 0; k < K; ++k)
+      R[(size_t)k * N + n] = deq[(size_t)n * K + k];
+
+  // Expected packed size for sanity:
+  const size_t expected = Int4Utils::kaiNibblePayloadBytes(N, K);
+
+  double se = 0.0, maxabs = 0.0, sigpow = 0.0;
+  for (size_t i = 0; i < (size_t)K * N; ++i) {
+    double e = (double)R[i] - (double)W[i];
+    se += e * e;
+    sigpow += (double)W[i] * (double)W[i];
+    if (std::fabs(e) > maxabs)
+      maxabs = std::fabs(e);
+  }
+  double mse = se / ((double)K * N);
+  double rel = se / (sigpow + 1e-12);
+  printf("[%s/KAI] K=%u N=%u  qw=%zuB (exp %zuB) qs=%zu  MSE=%.3e relErr=%.3e "
+         "maxAbs=%.3e\n  W[0..4]  =",
+         tag, K, N, qw.size(), expected, qs.size(), mse, rel, maxabs);
+  for (int i = 0; i < 5; ++i)
+    printf(" % .5f", W[i]);
+  printf("\n  R[0..4]  =");
+  for (int i = 0; i < 5; ++i)
+    printf(" % .5f", R[i]);
+  printf("\n");
+}
+
+int main() {
+  run(1536, 1536, "square");
+  run(1536, 6144, "ffn_up");
+  run(6144, 1536, "ffn_down");
+  run(256, 1536, "ple_proj");
+  return 0;
+}


### PR DESCRIPTION
Add an ARM KleidiAI f16-in / f16-out int4 matmul path for the qai8dxp / qsi4cxp (per-channel int4 = QS4CX) family, so QS4CX-FP16 FCs and the untied QS4CX lm_head run without an fp16<->fp32 cast pass over the LHS/DST tensors. The QS4CX ARM base (qs4cx_tensor, KAI rhs packing, the f32 gemm_qai8dxp_qsi4cxp path, getPackedData) is already upstream; this adds the fp16 variant on top.

Kernel + pack:
- kai/matmul_clamp_f16_qai8dxp_qsi4cxp/...4x4x32_neon_i8mm.{c,h}: forked 4x4x32 NEON i8mm micro-kernel that does the fcvtn to fp16 just before the store (i8mm-gated, __ARM_FEATURE_MATMUL_INT8).
- kai/pack/kai_lhs_quant_pack_qai8dxp_f16.{c,h}: forked LHS quant-packer that reads __fp16 directly (pure NEON, no i8mm dependency).
- kleidiai_interface{.h,_qai8dxp_qsi4cxp.cpp}: the additive public entry nntr_kai_gemm_qai8dxp_qsi4cxp_olp_f16() (packs the LHS from fp16, parallelizes the matmul over N via ThreadManager). i8mm-gated to match the f32 entries.
- meson: register the new f16 matmul subdir + f16 pack source.
- tests: q4_kai_bytecompat / q4_roundtrip_kai / q4_kai_matmul_device.

Dispatch:
- arm_compute_backend_fp16.cpp: the nntr_gemm_qai8dxp_qsi4cxp_packed<_FP16>
  facade that packs the LHS and calls the kernel above.
- arm_compute_backend.h: the paired packed/_unpacked template decls.
- half_tensor.cpp: a QS4CX case that routes a QS4CX-FP16 FC through the facade, taking the pre-packed KAI weight via the existing getPackedData.
- avx2_impl.{h,cpp}: retype the x86 AVX2 fp16 signatures _Float16* -> _FP16* (a no-op on native, needed so those files compile under the MSVC Half wrapper).

Validated: cross-compiled clean for AArch64 NEON i8mm (Android NDK r27.2, -march=armv8.2-a+i8mm+fp16); the f16 matmul + packer + interface run correctly on real i8mm silicon (Galaxy S26 Ultra golden). The three q4_kai tests need the Int4Utils KAI helpers (a separate concern) to build; runtime lives on an i8mm device.

Signed-off-by:Jijoong Moon <jijoong.moon@samsung.com>

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>