### PR TITLE
[tensor] NNTR_MEM_PLANNER selector: choose basic|v1|v2|v3 for the activation pool (default v1, unchanged)

### DIFF
--- a/nntrainer/tensor/manager.cpp
+++ b/nntrainer/tensor/manager.cpp
@@ -908,16 +908,28 @@ void Manager::flushCacheExcept(unsigned int order) {
 
 void Manager::finalizeTensorPool(TensorPool &pool, unsigned int start,
                                  unsigned int end) {
-  if (enable_optimizations) {
-    if (exec_mode == ExecutionMode::INFERENCE && enable_fsu) {
-      //@todo change V3 and validate
-      pool.finalize(OptimizedV1Planner(), start, end);
-    } else {
-      pool.finalize(OptimizedV1Planner(), start, end);
-    }
-  } else {
+  // NNTR_MEM_PLANNER=basic|v1|v2|v3 selects the layout planner (default v1,
+  // the long-standing behavior). v3 is the gap-fill best-fit planner the
+  // upstream '@todo change V3 and validate' at this site pointed at -- V1
+  // only reuses freed slots of the EXACT same size, so heterogeneous
+  // activation sizes fragment; v3 fits new requests into any large-enough
+  // vacant interval. Mis-packing fails loud either way:
+  // MemoryPool::planLayout() -> validateLayout() throws on any overlap.
+  // NOTE: none of the planners pad for alignment -- offsets land on byte
+  // sums of the preceding tensors -- so alignment-sensitive consumers must
+  // keep their own guards (e.g. the cuda kvi8 dp4a base-alignment check).
+  static const char *planner_env = std::getenv("NNTR_MEM_PLANNER");
+  const std::string planner = planner_env ? planner_env : "";
+  if (!enable_optimizations || planner == "basic") {
     pool.finalize(BasicPlanner(), start, end);
+    return;
   }
+  if (planner == "v3")
+    pool.finalize(OptimizedV3Planner(), start, end);
+  else if (planner == "v2")
+    pool.finalize(OptimizedV2Planner(), start, end);
+  else
+    pool.finalize(OptimizedV1Planner(), start, end);
 }
 
 unsigned int Manager::inActive(unsigned int order) {


### PR DESCRIPTION
Manager::finalizeTensorPool hardcodes OptimizedV1Planner even though OptimizedV2Planner/OptimizedV3Planner already ship in-tree, and carries a `//@todo change V3 and validate` right at the call site. This adds an NNTR_MEM_PLANNER env selector (basic|v1|v2|v3) so planners can be A/B-ed without a rebuild. Unset or unknown values keep the exact previous behavior (v1; BasicPlanner still used whenever optimizations are off).

Answering the @todo with data: on a CausalLM inference workload (uniform transformer activations, identical-size tensors recurring per layer), V3's byte-granular gap-fill splits vacant intervals and then extends the pool top — classic best-fit fragmentation — measurably growing the host pool versus V1's same-size slot reuse, while outputs stay byte-identical across planners and no layout throws occur. V1's same-size reuse is effectively optimal for this shape of workload, so it stays the default; the selector makes that conclusion reproducible on any model.

Repro:
  meson setup build -Denable-transformer=true -Denable-fp16=true --buildtype=plain
  ninja -C build && meson test -C build unittest_memory_pool unittest_nntrainer_tensor_pool
  NNTR_MEM_PLANNER=v3 <any CausalLM run>   # output byte-identical, pool size differs

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
