### PR TITLE
[causallm] Report peak private commit alongside peak working set

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -673,6 +673,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   auto total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
     finish_total - start_total);
   size_t peak_memory = getPeakMemoryKb();
+  size_t peak_commit = getPeakCommitKb();
 
   if (log_output) {
 
@@ -687,7 +688,9 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
               << ((double)generation_cnt / generation_duration.count() * 1000)
               << " TPS\n";
     std::cout << "total: " << total_duration.count() << " ms\n";
-    std::cout << "peak memory: " << peak_memory << " KB\n";
+    std::cout << "peak memory: " << peak_memory << " KB (working set)\n";
+    if (peak_commit)
+      std::cout << "peak commit: " << peak_commit << " KB (private)\n";
     std::cout << "==========================================================\n";
   }
 

--- a/Applications/CausalLM/models/performance_metrics.h
+++ b/Applications/CausalLM/models/performance_metrics.h
@@ -68,6 +68,33 @@ inline size_t getPeakMemoryKb() {
 #endif
 }
 
+/**
+ * @brief Peak private commit (pagefile-backed) in KB, or 0 if unavailable.
+ * @note Complements getPeakMemoryKb() (peak working set). Working set counts
+ *  physically-resident pages INCLUDING shareable file-backed ones (mmap'd
+ *  weights, DLLs) and is trimmed by the OS under pressure; peak commit counts
+ *  only this process's private, committed VA and is what the system commit
+ *  limit charges. For memory-footprint questions (capacity sizing, leak
+ *  detection, KV-quantization savings) commit is the honest number -- large
+ *  coarse GPU-SVM/UVM slabs are only fractionally charged to working set, so
+ *  a KV-cache halving can be invisible in WS yet visible in commit. On
+ *  non-Windows peak commit is not exposed via getrusage -> returns 0.
+ */
+inline size_t getPeakCommitKb() {
+#if defined(_WIN32)
+  PROCESS_MEMORY_COUNTERS_EX pmcx;
+  pmcx.cb = sizeof(pmcx);
+  if (GetProcessMemoryInfo(GetCurrentProcess(),
+                           reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&pmcx),
+                           sizeof(pmcx))) {
+    return (size_t)(pmcx.PeakPagefileUsage / 1024);
+  }
+  return 0;
+#else
+  return 0; // getrusage exposes peak RSS only, not peak commit
+#endif
+}
+
 #endif // __cplusplus
 
 #endif // __CAUSAL_LM_PERFORMANCE_METRICS_H__

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,9 @@ if cxx_compiler_id == 'clang'
   warning_flags += '-Wno-format-nonliteral'
   warning_flags += '-Wno-varargs'
   warning_flags += '-Wno-missing-braces'
+  # -march=native on newer AVX10.1-capable CPUs conflicts with the explicit
+  # -mavx2/-mfma below; clang treats that as a hard error under -Werror.
+  warning_flags += '-Wno-error=invalid-feature-combination'
 else
   warning_flags += '-Wno-maybe-uninitialized'
 endif


### PR DESCRIPTION
On Windows the peak working set alone under-describes a run's memory: WDDM folds GPU allocations into the process WS, and paged-out private pages leave it entirely. The commit charge (peak private commit) is the stable host-private footprint, so the CausalLM perf summary now reports both.

On POSIX the new getPeakCommitKb() returns 0 and the print is suppressed — Linux output is unchanged apart from the existing peak line gaining a "(working set)" label. No behavior change anywhere else; metrics only.

Repro:
  meson setup build -Denable-transformer=true --buildtype=plain
  ninja -C build && meson test -C build unittest_causallm_models

---
Note: this branch also carries the one-line `-Wno-error=invalid-feature-combination` clang guard from #4075 — the clang meson_test cells fail on any AVX10.1-capable runner (`-march=native` + explicit `-mavx2/-mfma` collision, a runner-pool regression also hitting main since 2026-07-14) and this PR happened to land on such a runner. Identical content to #4075's fix; whichever lands second rebases clean.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
