### PR TITLE
[CausalLM] Clean up CachedSlim MoE layer: remove unused expert mask and skip redundant decode input allocation

### DIFF
--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -55,8 +55,7 @@ CachedSlimGptOssMoELayer::CachedSlimGptOssMoELayer() :
   gate_bias_idx(std::numeric_limits<unsigned>::max()),
   loaded_expert_deque({}),
   need_load({}),
-  router_logits_idx(std::numeric_limits<unsigned>::max()),
-  expert_mask_idx(std::numeric_limits<unsigned>::max()) {}
+  router_logits_idx(std::numeric_limits<unsigned>::max()) {}
 
 void CachedSlimGptOssMoELayer::finalize(nntrainer::InitLayerContext &context) {
 
@@ -190,12 +189,6 @@ void CachedSlimGptOssMoELayer::finalize(nntrainer::InitLayerContext &context) {
   router_logits_idx =
     context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
                           nntrainer::Initializer::NONE, false,
-                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
-
-  // Expert mask: [num_experts, batch*seq]
-  expert_mask_idx =
-    context.requestTensor({num_experts, 1, topk, total_tokens}, "expert_mask",
-                          nntrainer::Initializer::ZEROS, false,
                           nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 }
 

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.cpp
@@ -470,11 +470,12 @@ inline void CachedSlimGptOssMoELayer::compute_expert_forward(
   nntrainer::Tensor gate_out(intermediate_dim);
   nntrainer::Tensor acti_out(intermediate_dim);
   nntrainer::Tensor up_out(intermediate_dim);
-  nntrainer::Tensor token_input(token_input_dim);
+  nntrainer::Tensor token_input;
   const unsigned token_idx = token_assignments[0].first;
 
   if (num_tokens > 1) {
     /** if prefill, copy data to make a batch */
+    token_input = nntrainer::Tensor(token_input_dim);
     {
       auto &tm = nntrainer::ThreadManager::Global();
       tm.parallel_for(0, static_cast<size_t>(num_tokens), [&](size_t i) {

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gpt_oss_moe_layer_cached.h
@@ -138,7 +138,6 @@ private:
 
   // Intermediate tensor indices
   unsigned int router_logits_idx;
-  unsigned int expert_mask_idx;
   bool enable_bias = false;
   std::mutex cache_mutex;
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -53,8 +53,7 @@ CachedSlimMoELayer::CachedSlimMoELayer() :
   loaded_expert_deque({}),
   need_load({}),
   gate_idx(std::numeric_limits<unsigned>::max()),
-  router_logits_idx(std::numeric_limits<unsigned>::max()),
-  expert_mask_idx(std::numeric_limits<unsigned>::max()) {}
+  router_logits_idx(std::numeric_limits<unsigned>::max()) {}
 
 void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
 
@@ -159,12 +158,6 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
   router_logits_idx =
     context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
                           nntrainer::Initializer::NONE, false,
-                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
-
-  // Expert mask: [num_experts, batch*seq]
-  expert_mask_idx =
-    context.requestTensor({num_experts, 1, topk, total_tokens}, "expert_mask",
-                          nntrainer::Initializer::ZEROS, false,
                           nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 }
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -187,11 +187,12 @@ inline void CachedSlimMoELayer::compute_expert_forward(
   nntrainer::Tensor gate_out(intermediate_dim);
   nntrainer::Tensor acti_out(intermediate_dim);
   nntrainer::Tensor up_out(intermediate_dim);
-  nntrainer::Tensor token_input(token_input_dim);
+  nntrainer::Tensor token_input;
   const unsigned token_idx = token_assignments[0].first;
 
   if (num_tokens > 1) {
     /** if prefill, copy data to make a batch */
+    token_input = nntrainer::Tensor(token_input_dim);
     {
       auto &tm = nntrainer::ThreadManager::Global();
       tm.parallel_for(0, static_cast<size_t>(num_tokens), [&](size_t i) {

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -146,7 +146,6 @@ private:
 
   // Intermediate tensor indices
   unsigned int router_logits_idx;
-  unsigned int expert_mask_idx;
   /**
    * @brief expert forward computation without memory copies
    * @param input Input tensor (reshaped to [total_tokens, 1, 1, hidden_size])


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR


<details><summary>e35e5196 — [CausalLM] Remove unused CachedSlim expert mask</summary><br />

[CausalLM] Remove unused CachedSlim expert mask

Stop requesting and tracking the expert-mask scratch tensor because CachedSlim dispatch builds assignments directly from router indices and never reads the mask.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>



<details><summary>44bdb13c — [CausalLM] Skip CachedSlim decode input allocation</summary><br />

[CausalLM] Skip CachedSlim decode input allocation

Allocate the gathered expert input only for multi-token batches. Single-token decode now uses the shared input view without first allocating and discarding a temporary tensor.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Remove the unused expert-mask scratch tensor from CachedSlim MoE layer, since dispatch builds assignments directly from router indices and never reads the mask.
- Skip the redundant temporary input allocation during single-token decode; use the shared input view directly, allocating only for multi-token batches.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>