### PR TITLE
[tensor] Support runtime page size for virtual tensor mmap

### DIFF
--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1663,7 +1663,11 @@ void Tensor::activate() {
 #else
 
   auto file_offset = getFileOffset();
-  size_t off = (file_offset / 4096) * 4096;
+  const long system_page_size = sysconf(_SC_PAGESIZE);
+  NNTR_THROW_IF(system_page_size <= 0, std::runtime_error)
+    << "[activate] failed to query the system page size";
+  const size_t page_size = static_cast<size_t>(system_page_size);
+  size_t off = (file_offset / page_size) * page_size;
   size_t diff = file_offset - off;
   size_t len = getMemoryBytes() + diff;
 
@@ -1675,14 +1679,15 @@ void Tensor::activate() {
     << "' has no backing fd; the model file fd was not propagated at "
        "read-time";
 
-  mapped_ptr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, this->fd, off);
-#ifdef __ANDROID__
-  if (mapped_ptr != MAP_FAILED)
-    madvise(mapped_ptr, len, MADV_WILLNEED);
+  void *new_mapped_ptr = mmap(NULL, len, PROT_READ, MAP_PRIVATE, this->fd, off);
+#if defined(__ANDROID__) || defined(__linux__)
+  if (new_mapped_ptr != MAP_FAILED)
+    madvise(new_mapped_ptr, len, MADV_WILLNEED);
 #endif
-  NNTR_THROW_IF(mapped_ptr == MAP_FAILED, std::runtime_error)
+  NNTR_THROW_IF(new_mapped_ptr == MAP_FAILED, std::runtime_error)
     << "[activate] mmap failed for virtual tensor '" << getName()
     << "': " << strerror(errno);
+  mapped_ptr = new_mapped_ptr;
   itensor_->activate((void *)&((uint8_t *)mapped_ptr)[diff]);
 #endif
 }
@@ -1701,7 +1706,11 @@ void Tensor::deactivate() {
   };
 
   auto file_offset = getFileOffset();
-  size_t off = (file_offset / 4096) * 4096;
+  const long system_page_size = sysconf(_SC_PAGESIZE);
+  NNTR_THROW_IF(system_page_size <= 0, std::runtime_error)
+    << "[deactivate] failed to query the system page size";
+  const size_t page_size = static_cast<size_t>(system_page_size);
+  size_t off = (file_offset / page_size) * page_size;
   size_t diff = file_offset - off;
   size_t len = getMemoryBytes() + diff;
 

--- a/test/unittest/unittest_nntrainer_tensor.cpp
+++ b/test/unittest/unittest_nntrainer_tensor.cpp
@@ -13,8 +13,10 @@
 
 #include "nntrainer_test_util.h"
 #include "util_func.h"
+#include <array>
 #include <cmath>
 #include <cpu_backend.h>
+#include <cstdio>
 #include <float_tensor.h>
 #include <fp16.h>
 #include <fstream>
@@ -23,6 +25,10 @@
 #include <tensor.h>
 #include <tensor_dim.h>
 #include <thread_manager.h>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 
 TEST(nntrainer_TensorDim, ctor_initializer_p) {
   unsigned int b = 3;
@@ -224,6 +230,38 @@ TEST(nntrainer_Tensor, Tensor_04_p) {
 
   EXPECT_EQ(status, ML_ERROR_NONE);
 }
+
+#if !defined(_WIN32)
+TEST(nntrainer_Tensor, virtual_tensor_unaligned_offset_lifecycle_p) {
+  FILE *backing_file = tmpfile();
+  ASSERT_NE(backing_file, nullptr);
+  const int fd = fileno(backing_file);
+  ASSERT_NE(fd, -1);
+
+  const long system_page_size = sysconf(_SC_PAGESIZE);
+  ASSERT_GT(system_page_size, 0);
+  const size_t file_offset = static_cast<size_t>(system_page_size) +
+                             static_cast<size_t>(system_page_size) / 2 +
+                             sizeof(float);
+  const std::array<float, 4> expected = {1.0f, -2.0f, 3.5f, 4.25f};
+  ASSERT_EQ(pwrite(fd, expected.data(), sizeof(expected), file_offset),
+            static_cast<ssize_t>(sizeof(expected)));
+
+  nntrainer::Tensor tensor(nntrainer::TensorDim({1, 1, 1, 4}), false,
+                           nntrainer::Initializer::NONE, "virtual_unaligned",
+                           nntrainer::QScheme::PER_TENSOR_AFFINE, true);
+  tensor.setFileOffset(file_offset);
+  std::ifstream unused_stream;
+  tensor.read(unused_stream, file_offset, true, fd);
+
+  tensor.activate();
+  for (size_t i = 0; i < expected.size(); ++i)
+    EXPECT_FLOAT_EQ(tensor.getValue<float>(0, 0, 0, i), expected[i]);
+  tensor.deactivate();
+
+  EXPECT_EQ(fclose(backing_file), 0);
+}
+#endif
 
 TEST(nntrainer_Tensor, Tensor_07_n) {
   int status = ML_ERROR_NONE;


### PR DESCRIPTION
## Dependency of the PR

None

## Commits to be reviewed in this PR


<details><summary>[tensor] Support runtime page size for virtual tensor mmap</summary><br />

[tensor] Support runtime page size for virtual tensor mmap

Virtual tensors aligned model-file offsets to a hard-coded 4 KiB boundary before calling mmap. This fails with EINVAL on systems using larger pages, such as 16 KiB Android configurations, because mmap requires its file offset to be aligned to the runtime page size.

Query _SC_PAGESIZE during activation and deactivation and use it to calculate the aligned mapping offset and length. Keep the mmap result local until the mapping succeeds so a failed mapping does not leave MAP_FAILED in tensor state, and request MADV_WILLNEED on Linux as well as Android.

Add a virtual tensor lifecycle test with an unaligned file offset to verify that activation reads the expected values and deactivation releases the mapping.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>


### Summary

- Align virtual tensor mmap offsets to the runtime system page size instead of assuming 4 KiB pages.
- Keep failed mmap results out of tensor state and cover unaligned virtual tensor activation and deactivation.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>