### PR TITLE
[CausalLM] Stream Qwen3 CachedSlim expert outputs

### DIFF
--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -181,8 +181,6 @@ inline void CachedSlimMoELayer::compute_expert_forward(
                                        input.getTensorType());
   nntrainer::TensorDim intermediate_dim({1, 1, num_tokens, intermediate_size},
                                         input.getTensorType());
-  nntrainer::TensorDim out_step_dim({1, 1, 1, hidden_size},
-                                    input.getTensorType());
   // Create intermediate tensors for this token
   nntrainer::Tensor gate_out(intermediate_dim);
   nntrainer::Tensor acti_out(intermediate_dim);
@@ -233,13 +231,6 @@ inline void CachedSlimMoELayer::compute_expert_forward(
   }
 
   acti_out.dot(down_proj, output);
-
-  // Apply routing weights to the compact expert output.
-  for (size_t i = 0; i < num_tokens; ++i) {
-    nntrainer::Tensor expert_token_output =
-      output.getSharedDataTensor(out_step_dim, i * hidden_size, true);
-    expert_token_output.multiply_i(token_assignments[i].second);
-  }
 }
 
 void CachedSlimMoELayer::incremental_forwarding(
@@ -327,7 +318,6 @@ void CachedSlimMoELayer::incremental_forwarding(
       }
     }
 
-    std::vector<nntrainer::Tensor> expert_outputs(num_experts);
     std::vector<int> target_idx_vector;
     target_idx_vector.reserve(num_experts);
 
@@ -338,13 +328,12 @@ void CachedSlimMoELayer::incremental_forwarding(
         continue;
 
       target_idx_vector.push_back(expert_idx);
-      expert_outputs[expert_idx] =
-        nntrainer::Tensor(static_cast<unsigned int>(assignments.size()), 1, 1,
-                          hidden_size, output.getTensorType());
     }
 
     int hit_count = 0;
     int miss_count = 0;
+    nntrainer::TensorDim token_step_dim({1, 1, 1, hidden_size},
+                                        output.getTensorType());
 
 #ifdef DEBUG
     auto t1_miss = high_resolution_clock::now();
@@ -359,6 +348,9 @@ void CachedSlimMoELayer::incremental_forwarding(
     // execution_mutex_.
     for (int expert_idx : target_idx_vector) {
       const auto &assignments = expert_assignments[expert_idx];
+      nntrainer::Tensor expert_output(
+        static_cast<unsigned int>(assignments.size()), 1, 1, hidden_size,
+        output.getTensorType());
       if (need_load[expert_idx]) {
 
 #ifdef DEBUG
@@ -378,7 +370,7 @@ void CachedSlimMoELayer::incremental_forwarding(
         }
 
         compute_expert_forward(
-          input, expert_outputs[expert_idx], assignments,
+          input, expert_output, assignments,
           context.getWeight(expert_gate_proj_indices[expert_idx]),
           context.getWeight(expert_up_proj_indices[expert_idx]),
           context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
@@ -396,7 +388,7 @@ void CachedSlimMoELayer::incremental_forwarding(
         }
 
         compute_expert_forward(
-          input, expert_outputs[expert_idx], assignments,
+          input, expert_output, assignments,
           context.getWeight(expert_gate_proj_indices[expert_idx]),
           context.getWeight(expert_up_proj_indices[expert_idx]),
           context.getWeight(expert_down_proj_indices[expert_idx]), hidden_size);
@@ -404,6 +396,20 @@ void CachedSlimMoELayer::incremental_forwarding(
 #ifdef DEBUG
         t2_hit = high_resolution_clock::now();
 #endif
+      }
+
+      // Accumulate each compact expert output immediately so only one expert's
+      // output is resident at a time. The serial, ascending expert loop
+      // preserves the existing accumulation order.
+      for (size_t i = 0; i < assignments.size(); ++i) {
+        nntrainer::Tensor token_output = output.getSharedDataTensor(
+          token_step_dim, assignments[i].first * hidden_size, true);
+        nntrainer::Tensor expert_token_output =
+          expert_output.getSharedDataTensor(token_step_dim, i * hidden_size,
+                                            true);
+        // Preserve the original FP32 rounding order while streaming outputs.
+        expert_token_output.multiply_i(assignments[i].second);
+        token_output.add_i(expert_token_output);
       }
     }
 
@@ -439,21 +445,6 @@ void CachedSlimMoELayer::incremental_forwarding(
 #ifdef DEBUG
     auto t2_evict = high_resolution_clock::now();
 #endif
-
-    // Combine expert outputs
-    nntrainer::TensorDim token_step_dim({1, 1, 1, hidden_size},
-                                        output.getTensorType());
-    for (int expert_idx : target_idx_vector) {
-      const auto &assignments = expert_assignments[expert_idx];
-      for (size_t i = 0; i < assignments.size(); ++i) {
-        nntrainer::Tensor token_output = output.getSharedDataTensor(
-          token_step_dim, assignments[i].first * hidden_size, true);
-        nntrainer::Tensor expert_token_output =
-          expert_outputs[expert_idx].getSharedDataTensor(token_step_dim,
-                                                         i * hidden_size, true);
-        token_output.add_i(expert_token_output);
-      }
-    }
 
     // reshape output: [B*S,1,1,H] -> [B,1,S,H]
     output.reshape({batch_size, 1, seq_len, hidden_size});


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR

<details><summary>[CausalLM] Stream Qwen3 CachedSlim expert outputs</summary><br />

[CausalLM] Stream Qwen3 CachedSlim expert outputs

Accumulate each active expert output into the final MoE output as soon as its projection completes. This keeps only one compact expert output tensor resident at a time instead of retaining outputs for every active expert until the combine phase.

Keep the serial ascending expert traversal so the accumulation order remains unchanged. Preserve the original numerical behavior while streaming the outputs.

This reduces peak temporary output memory while retaining the existing routing, cache management, and numerical behavior.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [X]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Qwen3 CachedSlim MoE previously retained a compact output tensor for every active expert until the final combine phase. Its temporary output memory therefore grew with the total number of routed token-expert assignments.
- This additional peak memory competes with model weights, the expert cache, and the KV cache on memory-constrained devices, reducing the practical benefit of the CachedSlim execution path.
- Accumulate each expert output immediately and release its temporary tensor before computing the next expert. Peak temporary output storage is reduced to one active expert while the existing expert traversal, routing, and cache behavior remain unchanged.

### Qwen3-30BA3B x86 Result

```
# Before
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 6026 ms, 72.5191 TPS
generation: 401 tokens, 22131 ms, 18.1194 TPS
total: 28159 ms
peak memory: 5463292 KB
==========================================================
[e2e time]: 28838 ms 
Max Resident Set Size: 5463292 KB
```

```
# After
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 5781 ms, 75.5925 TPS
generation: 401 tokens, 21570 ms, 18.5906 TPS
total: 27353 ms
peak memory: 5441668 KB
==========================================================
[e2e time]: 27960 ms 
Max Resident Set Size: 5441668 KB
```


Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>