### PR TITLE
[causallm] Inference correctness: FFN gate/up load order, prompt BOS, FP16 activation overflow, loader fail-loud, q4_0 shape gate, factory int_key, softcap, lmhead_untie

### DIFF
--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -35,14 +35,22 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     << "feature size must be a divisor of width";
 
   if (use_gamma) {
-    // gamma follows the model weight dtype (packed=false clamps it to the
-    // activation dtype), matching what the quantizer wrote to the bin.
-    // Hardcoding FP32 misloads/overruns *-FP16 bins whose gammas are FP16;
-    // the multiply site's dtype-cast guard covers either stored dtype.
+    // gamma is never quantized, but a bin stores it at the model's FLOAT
+    // dtype, so an FP16-activation package holds 2 bytes per element. Ask for
+    // the context's weight dtype when that dtype is itself a float type, and
+    // FP32 otherwise -- the same rule as rms_norm.cpp and the core
+    // nntrainer/layers/llm/rms_norm_layer.cpp, which carries the full note.
+    // These q/k/v norms are counted in the same packed weight stream, so a
+    // constant FP32 here shifts every later offset on an FP16 package.
+    const auto norm_w_dtype = context.getWeightDataType();
+    const auto norm_dtype =
+      (norm_w_dtype == nntrainer::TensorDim::DataType::FP32 ||
+       norm_w_dtype == nntrainer::TensorDim::DataType::FP16)
+        ? norm_w_dtype
+        : nntrainer::TensorDim::DataType::FP32;
     nntrainer::TensorDim gamma_dim(
       1, 1, 1, feature_size,
-      nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       context.getWeightDataType()));
+      nntrainer::TensorDim::TensorType(context.getFormat(), norm_dtype));
     wt_idx[RMSParams::gamma] = context.requestWeight(
       gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -35,13 +35,14 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     << "feature size must be a divisor of width";
 
   if (use_gamma) {
-    // gamma is unquantized FP32 on disk; request FP32 regardless of activation
-    // dtype (FP16 would reinterpret the FP32 bytes and corrupt gamma). The FP16
-    // path casts gamma down at the multiply site.
+    // gamma follows the model weight dtype (packed=false clamps it to the
+    // activation dtype), matching what the quantizer wrote to the bin.
+    // Hardcoding FP32 misloads/overruns *-FP16 bins whose gammas are FP16;
+    // the multiply site's dtype-cast guard covers either stored dtype.
     nntrainer::TensorDim gamma_dim(
       1, 1, 1, feature_size,
       nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       nntrainer::TensorDim::DataType::FP32));
+                                       context.getWeightDataType()));
     wt_idx[RMSParams::gamma] = context.requestWeight(
       gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -28,17 +28,29 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  // gamma follows the model weight dtype (packed=false clamps it to the
-  // activation dtype). Quantized *-FP16 bins store the norm weights as FP16;
-  // hardcoding FP32 here positionally misloads every weight after the first
-  // gamma AND overruns the mmap'd file by 2 bytes/element (SIGSEGV in the
-  // parallel load worker). The multiply site carries a dtype-cast guard, so
-  // FP32-gamma bins (upstream's own layout) still load when the model weight
-  // dtype is FP32.
+  // gamma is never quantized, but it is not unconditionally FP32 either: a bin
+  // stores it at the model's FLOAT dtype, so an FP16-activation package holds
+  // 2 bytes per element. Ask for the context's weight dtype when that dtype is
+  // itself a float type, and FP32 otherwise -- see the note in the core
+  // nntrainer/layers/llm/rms_norm_layer.cpp, which this layer mirrors:
+  //   - a hard FP32 over-requests on an FP16 package and, because weights are
+  //     a packed stream in graph order, shifts every later offset until the
+  //     loader rejects the layout;
+  //   - a bare getWeightDataType() is only safe while every caller passes
+  //     packed=false (LayerNode::finalize() then sets tensor_type[1] =
+  //     tensor_type[2] before InitLayerContext exists); the float-type test
+  //     keeps a caller that forgets it from requesting a block-quantized
+  //     gamma.
+  // The FP16 forward path casts gamma down at the multiply site either way.
+  const auto norm_w_dtype = context.getWeightDataType();
+  const auto norm_dtype =
+    (norm_w_dtype == nntrainer::TensorDim::DataType::FP32 ||
+     norm_w_dtype == nntrainer::TensorDim::DataType::FP16)
+      ? norm_w_dtype
+      : nntrainer::TensorDim::DataType::FP32;
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()));
+    nntrainer::TensorDim::TensorType(context.getFormat(), norm_dtype));
   wt_idx[RMSParams::gamma] = context.requestWeight(
     gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -28,14 +28,17 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  // gamma is unquantized and stored as FP32 in the bin. Request it as FP32
-  // regardless of the activation dtype; declaring it FP16 reinterprets the
-  // on-disk FP32 bytes as FP16 and corrupts gamma (≈FP16-max garbage). The
-  // FP16 forward path casts gamma down to FP16 at the multiply site.
+  // gamma follows the model weight dtype (packed=false clamps it to the
+  // activation dtype). Quantized *-FP16 bins store the norm weights as FP16;
+  // hardcoding FP32 here positionally misloads every weight after the first
+  // gamma AND overruns the mmap'd file by 2 bytes/element (SIGSEGV in the
+  // parallel load worker). The multiply site carries a dtype-cast guard, so
+  // FP32-gamma bins (upstream's own layout) still load when the model weight
+  // dtype is FP32.
   nntrainer::TensorDim gamma_dim(
     1, 1, 1, dim[0].width(),
     nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     nntrainer::TensorDim::DataType::FP32));
+                                     context.getWeightDataType()));
   wt_idx[RMSParams::gamma] = context.requestWeight(
     gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -284,6 +284,28 @@ if get_option('enable-test')
     suite: 'unittests'
   )
 
+  # Prompt special-token policy: no model, no graph, no external assets -- the
+  # test builds its own BOS-prepending tokenizer.json blob, so it only needs the
+  # tokenizer backend.
+  unittest_prompt_special_tokens = executable(
+    'unittest_prompt_special_tokens',
+    [
+      meson.current_source_dir() / 'models' / 'unittest_prompt_special_tokens.cpp',
+      meson.current_source_dir() / 'huggingface_tokenizer.cpp',
+    ],
+    dependencies: [gtest_main_dep],
+    include_directories: causallm_inc,
+    link_args: tokenizer_link_args,
+    build_by_default: true,
+    install: false,
+  )
+
+  test('unittest_prompt_special_tokens', unittest_prompt_special_tokens,
+    args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_prompt_special_tokens'),
+    timeout: 60,
+    suite: 'unittests'
+  )
+
   unittest_cancel_api = executable(
     'unittest_cancel_api',
     [

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -220,26 +220,43 @@ void CausalLM::advanceKVCachePosition(unsigned int step_size) {
   kv_cache.advance(step_size);
 }
 
-std::pair<Tensor, Tensor> CausalLM::constructModel() {
-
-  // base transformer (input, output_norm)
-  auto [x, h] = Transformer::constructModel();
-
+/**
+ * [lmhead-untie] When nntr_config.json sets lmhead_untie, build
+ * output_of_causallm as an independent fully_connected layer with its own
+ * weight even for a tied-embedding model, so the lm_head can carry a
+ * different dtype than the embedding (untied-serialized packages such as
+ * gemma4_qs4cx_fp16 ship a separate transposed [hidden, vocab] head record
+ * that a tied graph cannot load). Untie is the config flag, NOT derived from
+ * LMHEAD_DTYPE: a quantizer constructs this same untied graph from the FP32
+ * source and quantizes output_of_causallm via the dtype map on save.
+ * skip_prefill keeps the FC lm_head decode-only, the same contract the tied
+ * lm_head types implement internally. Flag off = byte-identical graph.
+ */
+Tensor CausalLM::buildLmHeadOutput(Tensor h, bool add_skip_prefill) {
+  const bool lmhead_untied = LMHEAD_UNTIE;
   const std::string lmhead_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head";
-
+    lmhead_untied ? "fully_connected"
+                  : (TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head");
   std::vector<std::string> lmhead_prop = {
     withKey("name", "output_of_causallm"),
     withKey("unit", NUM_VOCAB),
     withKey("disable_bias", "true"),
     withKey("weight_dtype", LMHEAD_DTYPE),
   };
-
-  if (TIE_WORD_EMBEDDINGS)
+  if (add_skip_prefill)
+    lmhead_prop.emplace_back(withKey("skip_prefill", "true"));
+  if (TIE_WORD_EMBEDDINGS && !lmhead_untied)
     lmhead_prop.emplace_back(withKey("shared_from", "embedding0"));
-
   LayerHandle lmhead(createLayer(lmhead_type, lmhead_prop));
-  Tensor y = lmhead(h);
+  return lmhead(h);
+}
+
+std::pair<Tensor, Tensor> CausalLM::constructModel() {
+
+  // base transformer (input, output_norm)
+  auto [x, h] = Transformer::constructModel();
+
+  Tensor y = buildLmHeadOutput(h, LMHEAD_UNTIE && SKIP_PREFILL);
 
   return {x, y};
 }

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -428,9 +428,18 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   if (USE_KVCACHE && !SAVE_KVCACHE && SYS_PROMP_LEN == 0)
     SYS_PROMP_LEN = tokenizer->Encode(system_prompt).size();
 
-  auto _input = tokenizer->Encode(prompt_);
-  ///@note insert bos token at the beginning of the input
-  // _input.insert(_input.begin(), BOS_TOKEN_ID);
+  ///@note add_special_tokens=true lets each model's OWN tokenizer decide
+  /// whether
+  /// to prepend a BOS, rather than hard-coding it. The 1-arg Encode skips
+  /// special tokens, so the leading BOS that Gemma2 (TemplateProcessing,
+  /// add_bos_token= true) needs was dropped -> short prompts degenerated into
+  /// pure repetition
+  /// ("The capital of France is" -> "is is is..."); long prompts masked it.
+  /// Verified to match HF add_special_tokens=True per model: Gemma2 gains its
+  /// BOS(2); models whose tokenizer adds no BOS (e.g. Qwen3 — ByteLevel post-
+  /// processor, add_bos_token=false) are byte-identical to the old behavior, so
+  /// they are unaffected. (sentence_transformer.cpp already encodes this way.)
+  auto _input = tokenizer->Encode(prompt_, /*add_special_tokens=*/true);
 
   // | <------------------- MAX_SEQ_LEN -------------------> |
   //                       ||             ||

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -477,7 +477,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   unsigned int init_len = init_input.size();
   float *input_sample =
-    (float *)malloc(sizeof(float) * BATCH_SIZE * MAX_SEQ_LEN);
+    (float *)calloc(BATCH_SIZE * MAX_SEQ_LEN, sizeof(float));
   std::vector<bool> eos_list(BATCH_SIZE, false);
 
   unsigned int input_len = init_len;

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -425,10 +425,44 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     prompt_ = system_prompt + prompt + tail_prompt;
   }
 
-  if (USE_KVCACHE && !SAVE_KVCACHE && SYS_PROMP_LEN == 0)
-    SYS_PROMP_LEN = tokenizer->Encode(system_prompt).size();
+  ///@note This fallback has to count the cached rows with the SAME tokenization
+  /// the save pass used to produce them: below, SAVE_KVCACHE encodes
+  /// prompt_ == system_prompt with add_special_tokens=true and then stores
+  /// SYS_PROMP_LEN = input_len. The 1-arg Encode drops the specials, so on a
+  /// BOS-prepending tokenizer this counted one row less than the cache
+  /// actually holds, and every absolute KV write derived from it
+  /// (prefill_from = SYS_PROMP_LEN + global_token_len) landed one slot early --
+  /// clobbering the last cached row and shifting every RoPE position by one.
+  ///
+  /// An EMPTY system prompt must not reach it either: Encode("", true) returns
+  /// the lone BOS on a BOS-prepending tokenizer (Gemma2: size 1), so deriving a
+  /// length from it fabricates a one-row prefix the cache never described --
+  /// load_kvcache() then restores one stale row, setKVCachePosition(1) shifts
+  /// every later position by one, and the prompt that really does open the
+  /// sequence loses its BOS at the same time. With no system prompt there is no
+  /// cached prefix to count, so the length stays 0 and load_kvcache(path, 0)
+  /// keeps failing loudly (TensorDim rejects a zero-height slice) on the
+  /// configuration that cannot be resolved here: sys_prompt_token_size unset,
+  /// a cache file present, and an empty system prompt.
+  if (USE_KVCACHE && !SAVE_KVCACHE && SYS_PROMP_LEN == 0 &&
+      !system_prompt.empty())
+    SYS_PROMP_LEN =
+      tokenizer->Encode(system_prompt, /*add_special_tokens=*/true).size();
 
-  ///@note add_special_tokens=true lets each model's OWN tokenizer decide
+  ///@note Special tokens belong at sequence position 0 and nowhere else. This
+  /// encode produces the first tokens of the sequence when the cache is being
+  /// built from scratch (SAVE_KVCACHE) or when nothing has been written yet; it
+  /// is a CONTINUATION when a precomputed cache already supplies the first
+  /// SYS_PROMP_LEN rows, or when an earlier run() on this object wrote
+  /// global_token_len rows. Encoding a continuation with add_special_tokens
+  /// splices a mid-sequence BOS into the prompt for BOS-prepending tokenizers
+  /// (Gemma2: TemplateProcessing, add_bos_token=true) -- a token sequence the
+  /// model never saw in training, which also consumes one KV slot that real
+  /// prompt content needed.
+  const bool prompt_starts_sequence =
+    SAVE_KVCACHE || (SYS_PROMP_LEN + global_token_len) == 0;
+
+  ///@note add_special_tokens lets each model's OWN tokenizer decide
   /// whether
   /// to prepend a BOS, rather than hard-coding it. The 1-arg Encode skips
   /// special tokens, so the leading BOS that Gemma2 (TemplateProcessing,
@@ -439,7 +473,7 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   /// BOS(2); models whose tokenizer adds no BOS (e.g. Qwen3 — ByteLevel post-
   /// processor, add_bos_token=false) are byte-identical to the old behavior, so
   /// they are unaffected. (sentence_transformer.cpp already encodes this way.)
-  auto _input = tokenizer->Encode(prompt_, /*add_special_tokens=*/true);
+  auto _input = tokenizer->Encode(prompt_, prompt_starts_sequence);
 
   // | <------------------- MAX_SEQ_LEN -------------------> |
   //                       ||             ||

--- a/Applications/CausalLM/models/causal_lm.h
+++ b/Applications/CausalLM/models/causal_lm.h
@@ -139,6 +139,15 @@ protected:
   virtual std::pair<Tensor, Tensor> constructModel() override;
 
   /**
+   * @brief Build the output_of_causallm lm_head from the transformer hidden
+   *        state @p h. Shared by the generic and the model-override
+   *        constructModel paths. The skip_prefill decision differs per path
+   *        (generic gates on SKIP_PREFILL; Gemma4 on ENABLE_SKIP_PREFILL_OPT),
+   *        so it is passed in rather than recomputed here.
+   */
+  Tensor buildLmHeadOutput(Tensor h, bool add_skip_prefill);
+
+  /**
    * @brief register Outputs
    */
   virtual void

--- a/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
+++ b/Applications/CausalLM/models/gemma3/gemma3_causallm.cpp
@@ -70,10 +70,7 @@ void Gemma3Transformer::setupParameters(json &cfg, json &generation_cfg,
   if (cfg.contains("layer_types")) {
     layer_types = cfg["layer_types"].get<std::vector<std::string>>();
   }
-  if (cfg.contains("attn_logit_softcapping") &&
-      !cfg["attn_logit_softcapping"].is_null()) {
-    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
-  }
+  // attn_logit_softcapping now parsed in Transformer::setupParameters (base).
 }
 
 Tensor Gemma3Transformer::createTransformerDecoderBlock(const int layer_id,

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -115,10 +115,8 @@ void Gemma4Transformer::setupParameters(json &cfg, json &generation_cfg,
     layer_types = cfg["layer_types"].get<std::vector<std::string>>();
   }
 
-  if (cfg.contains("attn_logit_softcapping") &&
-      !cfg["attn_logit_softcapping"].is_null()) {
-    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
-  }
+  // attn_logit_softcapping now parsed in Transformer::setupParameters (base);
+  // final_logit_softcapping stays here (gemma4-specific member).
   if (cfg.contains("final_logit_softcapping") &&
       !cfg["final_logit_softcapping"].is_null()) {
     FINAL_LOGIT_SOFTCAPPING = cfg["final_logit_softcapping"].get<float>();

--- a/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
+++ b/Applications/CausalLM/models/gemma4/gemma4_causallm.cpp
@@ -247,10 +247,16 @@ std::pair<Tensor, Tensor> Gemma4Transformer::constructModel() {
   Tensor x =
     Tensor({1, 1, 1, static_cast<unsigned int>(INIT_SEQ_LEN)}, "input0");
 
+  // TieWordEmbedding exists to share the table with a tied lm_head. With
+  // LMHEAD_UNTIE the head is a separate FC, so embedding0 is a plain
+  // embedding_layer — lookup-identical (same weight record) and it unlocks
+  // the mmap'd sidecar (embedding_file_name) that TieWordEmbedding
+  // structurally lacks.
+  const bool embedding_tied = TIE_WORD_EMBEDDINGS && !LMHEAD_UNTIE;
   const std::string embedding_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "embedding_layer";
+    embedding_tied ? "tie_word_embeddings" : "embedding_layer";
 
-  NNTR_THROW_IF(TIE_WORD_EMBEDDINGS && !EMBEDDING_FILE_NAME.empty(),
+  NNTR_THROW_IF(embedding_tied && !EMBEDDING_FILE_NAME.empty(),
                 std::invalid_argument)
     << "embedding_file_name requires untied embedding_layer";
   LayerHandle embedding(createLayer(
@@ -808,24 +814,11 @@ void Gemma4CausalLM::registerCustomLayers() {
 std::pair<Tensor, Tensor> Gemma4CausalLM::constructModel() {
   auto [x, h] = Gemma4Transformer::constructModel();
 
-  // create lm_head layer (using fully_connected option)
-  const std::string lmhead_type =
-    TIE_WORD_EMBEDDINGS ? "tie_word_embeddings" : "lm_head";
-
-  // add lmhead
-  std::vector<std::string> lmhead_prop = {
-    withKey("name", "output_of_causallm"),
-    withKey("unit", NUM_VOCAB),
-    withKey("disable_bias", "true"),
-    withKey("weight_dtype", LMHEAD_DTYPE),
-  };
-  appendSkipPrefillIfNeeded(lmhead_prop, true);
-
-  if (TIE_WORD_EMBEDDINGS)
-    lmhead_prop.emplace_back(withKey("shared_from", "embedding0"));
-
-  LayerHandle lmhead(createLayer(lmhead_type, lmhead_prop));
-  Tensor y = lmhead(h);
+  // lm_head: shares CausalLM::buildLmHeadOutput, which honors LMHEAD_UNTIE
+  // (untied FC head with its own weight record — the layout the
+  // gemma4_qs4cx_fp16 packagings serialize). skip_prefill gates on
+  // ENABLE_SKIP_PREFILL_OPT here, matching every other Gemma4 layer.
+  Tensor y = buildLmHeadOutput(h, ENABLE_SKIP_PREFILL_OPT);
 
   if (FINAL_LOGIT_SOFTCAPPING > 0.0f) {
     std::vector<std::string> final_softcap_props = {

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -198,6 +198,17 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
     cfg.contains("rms_norm_eps") ? cfg["rms_norm_eps"].get<float>() : 1e-5;
   GQA_SIZE = NUM_HEADS / NUM_KEY_VALUE_HEADS;
 
+  // Attention-logit soft-capping (Gemma family). Parsed here -- the one
+  // setupParameters the base constructors provably reach -- so it cannot be
+  // stranded in a derived override that never runs. Gated on cfg presence, so
+  // a model without the key keeps the 0.0f default (no soft-cap). Consolidated
+  // from the per-model setupParameters (gemma3/gemma4 held byte-identical
+  // copies of this block).
+  if (cfg.contains("attn_logit_softcapping") &&
+      !cfg["attn_logit_softcapping"].is_null()) {
+    ATTN_LOGIT_SOFTCAPPING = cfg["attn_logit_softcapping"].get<float>();
+  }
+
   return;
 };
 

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -370,7 +370,17 @@ void Transformer::repack_weight() {
       for (auto &w : weights) {
         if (w->getVariableRef().getDataType() ==
             ml::train::TensorDim::DataType::QS4CX) {
-          w->getVariableRef().pack();
+          // KAI rhs-pack is the ARM (i8mm) CPU GEMM's in-memory derivation;
+          // on x86 it is NYI and the x86 CPU GEMM + the GPU v8c path consume
+          // the plain on-disk QS4CX (nibbles + fp32 scales) directly.
+          // Skip-on-NYI so a single QS4CX weight set loads on every backend
+          // (ARM packs, x86/GPU use the plain blob).
+          try {
+            w->getVariableRef().pack();
+          } catch (const std::exception &e) {
+            ml_logd("QS4CX pack skipped (engine consumes plain blob): %s",
+                    e.what());
+          }
         }
       }
     };

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -144,6 +144,8 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
   FC_LAYER_DTYPE = nntr_cfg["fc_layer_dtype"];
   EMBEDDING_FILE_NAME = nntr_cfg.value("embedding_file_name", std::string());
   PLE_FILE_NAME = nntr_cfg.value("ple_file_name", std::string());
+  LMHEAD_UNTIE =
+    nntr_cfg.contains("lmhead_untie") && nntr_cfg["lmhead_untie"].get<bool>();
 
   if (cfg.contains("is_causal")) {
     IS_CAUSAL = cfg["is_causal"].get<bool>();

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -547,13 +547,13 @@ Tensor Transformer::createAttention(const int layer_id, int seq_len,
 Tensor Transformer::createMlp(const int layer_id, int dim, int hidden_dim,
                               Tensor input) {
 
-  LayerHandle ffn_up(createLayer(
-    "fully_connected",
-    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_up"),
-     withKey("unit", hidden_dim), withKey("disable_bias", "true"),
-     withKey("weight_initializer", "ones")}));
-  Tensor up = ffn_up(input);
-
+  // Create gate BEFORE up: the model loader assigns file offsets in graph
+  // creation order (positional, not by name), and the converters write the
+  // FFN weights gate_proj -> up_proj -> down_proj (the HF convention). If up
+  // is created first, ffn_up loads the gate_proj bytes and ffn_gate loads the
+  // up_proj bytes, so swiglu computes silu(up)*gate instead of silu(gate)*up
+  // -- coherent-looking but wrong (the global gate/up swap; Gemma2/3/4 avoided
+  // it by overriding createMlp gate-first).
   LayerHandle ffn_gate(createLayer(
     "fully_connected",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_gate"),
@@ -561,15 +561,17 @@ Tensor Transformer::createMlp(const int layer_id, int dim, int hidden_dim,
      withKey("weight_initializer", "ones")}));
   Tensor gate = ffn_gate(input);
 
-  /// @note nntrainer binary stores mlp weights in up, gate order.
-  /// For backward compatibility,
-  /// * layers are in up, gate order
-  /// * swiglu input[0] = gate
-  /// * swiglu input[1] = up
+  LayerHandle ffn_up(createLayer(
+    "fully_connected",
+    {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_up"),
+     withKey("unit", hidden_dim), withKey("disable_bias", "true"),
+     withKey("weight_initializer", "ones")}));
+  Tensor up = ffn_up(input);
+
   LayerHandle swiglu(createLayer(
     "swiglu",
     {withKey("name", "layer" + std::to_string(layer_id) + "_ffn_swiglu")}));
-  Tensor act = swiglu({up, gate}, {1, 0});
+  Tensor act = swiglu({gate, up});
 
   LayerHandle ffn_down(createLayer(
     "fully_connected",

--- a/Applications/CausalLM/models/transformer.h
+++ b/Applications/CausalLM/models/transformer.h
@@ -375,6 +375,15 @@ protected:
   std::string EMBEDDING_FILE_NAME;
   std::string PLE_FILE_NAME;
 
+  /** untie lm_head from the input embedding (separate FC weight, not shared
+   *  with the embedding table). Lives here (not CausalLM) because embedding0's
+   *  layer-type choice — tied TieWordEmbedding vs untied embedding_layer —
+   *  happens in <model>Transformer::constructModel scope. A dedicated flag
+   *  (not derived from LMHEAD_DTYPE) so a quantizer can build the same untied
+   *  graph from FP32 source weights while the dtype map quantizes
+   *  output_of_causallm on save. */
+  bool LMHEAD_UNTIE = false;
+
   unsigned int SLIDING_WINDOW = UINT_MAX;
   unsigned int SLIDING_WINDOW_PATTERN = 5;
   unsigned int ROPE_THETA = 10000; /**< RoPE theta value */

--- a/Applications/CausalLM/models/unittest_prompt_special_tokens.cpp
+++ b/Applications/CausalLM/models/unittest_prompt_special_tokens.cpp
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file    unittest_prompt_special_tokens.cpp
+ * @brief   Pins the special-token policy CausalLM::run() applies to a prompt:
+ *          the tokenizer's special tokens belong at sequence position 0 and
+ *          nowhere else, and no prefix length may be derived from an empty
+ *          system prompt.
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#include <tokenizers_cpp.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+/**
+ * @brief A minimal BOS-prepending tokenizer, self-contained so the test needs
+ * no model assets. It reproduces the only tokenizer property these tests care
+ * about, and the one that makes the bugs below observable: a
+ * `TemplateProcessing` post-processor whose `single` template puts a special
+ * token in front of the sequence. Gemma2's tokenizer.json is shaped exactly
+ * this way, with `<bos>` = id 2.
+ */
+constexpr const char *kBosTokenizerJson = R"json({
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {"id": 2, "content": "<bos>", "single_word": false, "lstrip": false,
+     "rstrip": false, "normalized": false, "special": true}
+  ],
+  "normalizer": null,
+  "pre_tokenizer": {"type": "Whitespace"},
+  "post_processor": {
+    "type": "TemplateProcessing",
+    "single": [{"SpecialToken": {"id": "<bos>", "type_id": 0}},
+               {"Sequence": {"id": "A", "type_id": 0}}],
+    "pair": [{"Sequence": {"id": "A", "type_id": 0}},
+             {"Sequence": {"id": "B", "type_id": 0}}],
+    "special_tokens": {
+      "<bos>": {"id": "<bos>", "ids": [2], "tokens": ["<bos>"]}
+    }
+  },
+  "decoder": null,
+  "model": {
+    "type": "WordLevel",
+    "vocab": {"<unk>": 0, "<bos>": 2, "you": 3, "are": 4, "helpful": 5,
+              "the": 6, "capital": 7, "of": 8, "france": 9, "is": 10,
+              "and": 11, "germany": 12},
+    "unk_token": "<unk>"
+  }
+})json";
+
+constexpr int kBosTokenId = 2;
+
+/**
+ * @brief Mirror of the `prompt_starts_sequence` predicate in CausalLM::run()
+ * (Applications/CausalLM/models/causal_lm.cpp).
+ *
+ * It is deliberately a copy and not a call into the model: the point of these
+ * tests is to pin the POLICY, so changing the predicate in run() has to be a
+ * conscious edit here as well.
+ */
+bool promptStartsSequence(bool save_kvcache, unsigned int sys_promp_len,
+                          unsigned int global_token_len) {
+  return save_kvcache || (sys_promp_len + global_token_len) == 0;
+}
+
+/**
+ * @brief Mirror of the SYS_PROMP_LEN fallback in CausalLM::run(), which
+ * re-derives the length of an already-cached system-prompt prefix when the
+ * `sys_prompt_token_size` config key is absent.
+ */
+unsigned int resolveSysPrompLen(tokenizers::Tokenizer *tokenizer,
+                                bool use_kvcache, bool save_kvcache,
+                                unsigned int preset,
+                                const std::string &system_prompt) {
+  unsigned int sys_promp_len = preset;
+  if (use_kvcache && !save_kvcache && sys_promp_len == 0 &&
+      !system_prompt.empty())
+    sys_promp_len = static_cast<unsigned int>(
+      tokenizer->Encode(system_prompt, /*add_special_tokens=*/true).size());
+  return sys_promp_len;
+}
+
+/** @brief Test fixture owning the tokenizer. */
+class PromptSpecialTokens : public ::testing::Test {
+protected:
+  void SetUp() override {
+    tokenizer = tokenizers::Tokenizer::FromBlobJSON(kBosTokenizerJson);
+    ASSERT_NE(tokenizer, nullptr);
+  }
+
+  std::unique_ptr<tokenizers::Tokenizer> tokenizer;
+};
+
+/**
+ * @brief The fixture really does prepend a BOS, and -- the reason the empty
+ * prompt needs a guard -- it prepends one to the EMPTY string too, so
+ * `Encode("", true).size()` is 1, not 0.
+ */
+TEST_F(PromptSpecialTokens, bos_tokenizer_fixture_p) {
+  const auto with_specials =
+    tokenizer->Encode(std::string("the capital"), true);
+  const auto without = tokenizer->Encode(std::string("the capital"), false);
+
+  ASSERT_FALSE(with_specials.empty());
+  ASSERT_FALSE(without.empty());
+  EXPECT_EQ(with_specials.front(), kBosTokenId);
+  EXPECT_EQ(with_specials.size(), without.size() + 1);
+  EXPECT_NE(without.front(), kBosTokenId);
+
+  /// the empty string is not empty once the specials are added
+  EXPECT_EQ(tokenizer->Encode(std::string(""), true).size(), 1u);
+  EXPECT_EQ(tokenizer->Encode(std::string(""), false).size(), 0u);
+}
+
+/**
+ * @brief No prefix length may be derived from an empty system prompt. Doing so
+ * fabricates a one-row prefix that no cache ever described, which then restores
+ * a stale KV row and shifts every later position by one.
+ */
+TEST_F(PromptSpecialTokens, empty_system_prompt_yields_no_prefix_length_p) {
+  /// resume shape (use_kvcache && !save_kvcache), no preset, empty prompt
+  EXPECT_EQ(resolveSysPrompLen(tokenizer.get(), true, false, 0, ""), 0u);
+
+  /// a real system prompt is still counted, and counted WITH the specials so it
+  /// agrees with what the save pass stored
+  const std::string system_prompt = "you are helpful";
+  const unsigned int save_pass_len = static_cast<unsigned int>(
+    tokenizer->Encode(system_prompt, /*add_special_tokens=*/true).size());
+  EXPECT_EQ(resolveSysPrompLen(tokenizer.get(), true, false, 0, system_prompt),
+            save_pass_len);
+  EXPECT_GT(
+    save_pass_len,
+    static_cast<unsigned int>(
+      tokenizer->Encode(system_prompt, /*add_special_tokens=*/false).size()));
+
+  /// an explicit sys_prompt_token_size always wins, empty prompt or not
+  EXPECT_EQ(resolveSysPrompLen(tokenizer.get(), true, false, 7, ""), 7u);
+  EXPECT_EQ(resolveSysPrompLen(tokenizer.get(), true, false, 7, system_prompt),
+            7u);
+}
+
+/**
+ * @brief The first prompt of a freshly constructed model opens the sequence and
+ * must keep its BOS.
+ */
+TEST_F(PromptSpecialTokens, first_prompt_of_a_fresh_model_keeps_the_bos_p) {
+  const unsigned int sys_promp_len = 0;    /// no kvcache configured
+  const unsigned int global_token_len = 0; /// set by setupParameters()
+  const bool starts =
+    promptStartsSequence(false, sys_promp_len, global_token_len);
+  EXPECT_TRUE(starts);
+
+  const auto ids =
+    tokenizer->Encode(std::string("the capital of france is"), starts);
+  ASSERT_FALSE(ids.empty());
+  EXPECT_EQ(ids.front(), kBosTokenId);
+}
+
+/**
+ * @brief Two consecutive run()-equivalent encodings on ONE model object must
+ * not both begin with the BOS: the second call continues a sequence whose rows
+ * are already accounted for in global_token_len. No kvcache configuration is
+ * needed to reach this -- the shipped C API `runModel()` can be called
+ * repeatedly on one loaded model, and only `global_token_len` remembers the
+ * earlier turn.
+ */
+TEST_F(PromptSpecialTokens, second_run_does_not_splice_a_second_bos_p) {
+  const bool use_kvcache = false;
+  const bool save_kvcache = false; /// USE_KVCACHE && ... -> false
+  const unsigned int sys_promp_len =
+    resolveSysPrompLen(tokenizer.get(), use_kvcache, save_kvcache, 0, "");
+  unsigned int global_token_len = 0;
+
+  /// turn 1: opens the sequence
+  const bool starts_first =
+    promptStartsSequence(save_kvcache, sys_promp_len, global_token_len);
+  const auto first =
+    tokenizer->Encode(std::string("the capital of france is"), starts_first);
+  ASSERT_FALSE(first.empty());
+  EXPECT_TRUE(starts_first);
+  EXPECT_EQ(first.front(), kBosTokenId);
+
+  /// end of run(): global_token_len += (generation_cnt + init_len)
+  const unsigned int generated = 3;
+  global_token_len += generated + static_cast<unsigned int>(first.size());
+  ASSERT_GT(global_token_len, 0u);
+
+  /// turn 2: continues it
+  const bool starts_second =
+    promptStartsSequence(save_kvcache, sys_promp_len, global_token_len);
+  const auto second =
+    tokenizer->Encode(std::string("and of germany"), starts_second);
+  ASSERT_FALSE(second.empty());
+  EXPECT_FALSE(starts_second);
+  EXPECT_NE(second.front(), kBosTokenId);
+
+  /// the property the model actually needs: exactly one BOS in the stream
+  EXPECT_FALSE(first.front() == kBosTokenId && second.front() == kBosTokenId);
+}
+
+/**
+ * @brief The KV-resume continuation must not carry specials, while the save
+ * pass that builds the cache must.
+ */
+TEST_F(PromptSpecialTokens, kvcache_save_opens_and_resume_continues_p) {
+  const std::string system_prompt = "you are helpful";
+  const std::string continuation = "the capital of france is";
+
+  /// save pass: SAVE_KVCACHE is true, prompt_ == system_prompt
+  EXPECT_TRUE(promptStartsSequence(true, 0, 0));
+  const auto saved = tokenizer->Encode(system_prompt, true);
+  ASSERT_FALSE(saved.empty());
+  EXPECT_EQ(saved.front(), kBosTokenId);
+  const unsigned int cached_rows = static_cast<unsigned int>(saved.size());
+
+  /// SAVE_KVCACHE stays true even when sys_prompt_token_size is preset, so the
+  /// save run keeps its specials
+  EXPECT_TRUE(promptStartsSequence(true, cached_rows, 0));
+
+  /// resume pass: the cache supplies the first cached_rows rows
+  const unsigned int resumed =
+    resolveSysPrompLen(tokenizer.get(), true, false, 0, system_prompt);
+  EXPECT_EQ(resumed, cached_rows);
+  const bool starts = promptStartsSequence(false, resumed, 0);
+  EXPECT_FALSE(starts);
+  const auto tail = tokenizer->Encode(continuation, starts);
+  ASSERT_FALSE(tail.empty());
+  EXPECT_NE(tail.front(), kBosTokenId);
+}
+
+/**
+ * @brief The predicate over the whole (SAVE_KVCACHE, SYS_PROMP_LEN,
+ * global_token_len) space: specials exactly when this encode produces the
+ * sequence's first tokens.
+ */
+TEST_F(PromptSpecialTokens, predicate_truth_table_p) {
+  /// nothing written yet -> opens the sequence
+  EXPECT_TRUE(promptStartsSequence(false, 0, 0));
+  /// the save run always opens it, whatever the counters say
+  EXPECT_TRUE(promptStartsSequence(true, 0, 0));
+  EXPECT_TRUE(promptStartsSequence(true, 9, 0));
+  EXPECT_TRUE(promptStartsSequence(true, 0, 9));
+  /// a cached prefix, or an earlier turn, or both -> continuation
+  EXPECT_FALSE(promptStartsSequence(false, 9, 0));
+  EXPECT_FALSE(promptStartsSequence(false, 0, 9));
+  EXPECT_FALSE(promptStartsSequence(false, 9, 9));
+}
+
+} // namespace

--- a/nntrainer/app_context.cpp
+++ b/nntrainer/app_context.cpp
@@ -679,7 +679,13 @@ const int AppContext::registerFactory(const FactoryType<T> factory,
     return int_key;
   }
 
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto key from max(existing) + 1, not from the registration COUNT: a
+  // count-derived key shifts when a registration is inserted mid-list and can
+  // walk onto an explicitly-requested LayerType value, which the assignment
+  // below would then silently rebind. AppContext keeps its pr/3963 "duplicate
+  // explicit key is a no-op, reuse it" policy above; this only removes the
+  // position dependence of the auto path.
+  int assigned_int_key = int_key == -1 ? nextAutoIntKey(int_map) : int_key;
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;

--- a/nntrainer/cl_context.cpp
+++ b/nntrainer/cl_context.cpp
@@ -82,12 +82,21 @@ void ClContext::initialize() noexcept {
 
     initBlasClKernels();
     initAttentionClKernels();
-    add_default_object();
+
     // SVM-backed allocator so MemoryPool buffers are device-visible
     // without an explicit copy. Falls back to host memory inside
     // ClSVMAllocator when the driver lacks SVM support.
+    //
+    // Installed BEFORE add_default_object() (matching AppContext::initialize),
+    // and not after: every throw inside add_default_object() is swallowed by
+    // the catch below, so with the old order a single bad registration left
+    // this context with a null MemAllocator and crashed the TensorPool ctor
+    // for EVERY model. The allocator does not depend on any registration, so
+    // ordering it first bounds a registration failure to the registrations.
     setMemAllocator(
       std::make_shared<ClSVMAllocator>(opencl::ContextManager::Global()));
+
+    add_default_object();
 
     // Install the OpenCL ComputeOps subclass so tensors created from
     // this Context dispatch their accelerator-only ops (Q4_0/INT4
@@ -167,14 +176,11 @@ const int ClContext::registerFactory(const FactoryType<T> factory,
     throw std::invalid_argument(ss.str().c_str());
   }
 
-  if (int_key != -1 && int_map.find(int_key) != int_map.end()) {
-    std::stringstream ss;
-    ss << "cl_context: cannot register factory with already taken int key: "
-       << int_key;
-    throw std::invalid_argument(ss.str().c_str());
-  }
-
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto keys come from max(existing) + 1 and are therefore independent of
+  // where in add_default_object() the registration sits; an explicit key that
+  // is already bound throws here, naming both colliding types.
+  const int assigned_int_key =
+    resolveIntKey(int_map, int_key, assigned_key, "cl_context");
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;

--- a/nntrainer/context.h
+++ b/nntrainer/context.h
@@ -74,6 +74,76 @@ public:
   template <typename... Ts> using FactoryMap = std::tuple<IndexType<Ts>...>;
 
   /**
+   * @brief   Next int_key that no registration in @a int_map can already hold.
+   *
+   * Every Context used to derive an auto-assigned int_key as
+   * `str_map.size() + 1`, i.e. from a COUNT. That makes the key a function of
+   * how many registrations precede it, so inserting one registration mid-list
+   * walks every later auto key up by one until one lands on a key that was
+   * requested EXPLICITLY (an ml::train::LayerType enum value). Nothing checked
+   * the auto key, so `int_map[k] = type` silently rebound an existing entry,
+   * and the damage surfaced later - as a throw from an unrelated registration,
+   * or as a lookup returning the wrong layer type. The only defence was a
+   * comment asking contributors to append new registrations at the end.
+   *
+   * Deriving the key from max(existing) + 1 instead makes it independent of
+   * insertion position: it cannot collide with anything already registered,
+   * in any order. Explicit keys are still checked (see resolveIntKey).
+   *
+   * @param int_map the context's int -> type-string index
+   * @return an int_key not present in @a int_map
+   */
+  static int nextAutoIntKey(const IntIndexType &int_map) {
+    int next = static_cast<int>(int_map.size()) + 1;
+    for (const auto &entry : int_map) {
+      if (entry.first >= next)
+        next = entry.first + 1;
+    }
+    return next;
+  }
+
+  /**
+   * @brief   Resolve and validate the int_key a factory registration binds.
+   *
+   * @note Failing here is deliberate and must stay loud. The collision this
+   *       replaces used to abort a Context's initialize() from inside
+   *       add_default_object(), which is wrapped in a catch-and-log; the
+   *       context then finished initialisation with NO MemAllocator installed
+   *       and every model crashed later in TensorPool with a null allocator -
+   *       a symptom with no visible connection to the registration that caused
+   *       it. Contexts now install their allocator BEFORE registering, so a
+   *       registration failure can only ever be this message. Both colliding
+   *       type names are named so the message identifies the mistake by
+   *       itself.
+   *
+   * @param int_map      the context's int -> type-string index
+   * @param int_key      requested key, or -1 to auto-assign
+   * @param assigned_key the (lowercased) type string being registered
+   * @param ctx_name     context name, used as the message prefix
+   * @return the int_key to bind
+   * @throw std::invalid_argument if the requested key is already bound
+   */
+  static int resolveIntKey(const IntIndexType &int_map, const int int_key,
+                           const std::string &assigned_key,
+                           const char *ctx_name) {
+    const int assigned_int_key =
+      int_key == -1 ? nextAutoIntKey(int_map) : int_key;
+
+    auto taken = int_map.find(assigned_int_key);
+    if (taken != int_map.end()) {
+      std::stringstream ss;
+      ss << ctx_name << ": cannot register factory '" << assigned_key
+         << "' with int_key " << assigned_int_key
+         << ": that key is already registered to '" << taken->second
+         << "'. Explicit int_keys must be unique within one context; pass "
+            "int_key = -1 to have a free key assigned instead.";
+      throw std::invalid_argument(ss.str());
+    }
+
+    return assigned_int_key;
+  }
+
+  /**
    * @brief   Default constructor
    */
   Context(std::shared_ptr<ContextData> data_ = nullptr) : data(data_) {}

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -19,10 +19,8 @@
 #include <common_properties.h>
 #include <cpu_backend.h>
 
-#if defined(_WIN32)
-#define _USE_MATH_DEFINES
-#include <math.h>
-#endif
+#include <cmath>
+#include <type_traits>
 
 namespace nntrainer {
 
@@ -36,6 +34,19 @@ class ActiFunc {
 
 public:
   constexpr static inline float NEGATIVE_SLOPE = 0.01f;
+
+  /**
+   * @brief pi, as a plain constant of this header.
+   * @note  M_PI is not standard C++. The MSVC CRT only defines it when
+   *        _USE_MATH_DEFINES is defined *before* the first math header of the
+   *        translation unit is pulled in, and a header cannot guarantee that
+   *        for its consumers: <cmath> (here, or in any .cpp that includes this
+   *        file earlier) already brought in the include-guarded CRT math
+   *        header, so a later _USE_MATH_DEFINES has no effect. Carrying the
+   *        value here makes this header independent of include order. The
+   *        value is the same as the CRT/glibc M_PI, so results are unchanged.
+   */
+  constexpr static inline double PI = 3.14159265358979323846;
 
   /**
    * @brief     Constructor of ActiFunc
@@ -436,8 +447,24 @@ public:
    */
   template <typename T = float>
   static Tensor &gelu(Tensor const &t_in, Tensor &t_out) {
-    nntrainer::gelu_v2(t_in.size(), t_in.getData<float>(),
-                       t_out.getData<float>());
+    if constexpr (std::is_same_v<T, float>) {
+      nntrainer::gelu_v2(t_in.size(), t_in.getData<float>(),
+                         t_out.getData<float>());
+    } else {
+      /// @note cpu_backend exposes gelu_v2 for fp32 only, and getData<float>()
+      /// is an unchecked cast -- calling it for a non-fp32 activation would
+      /// read/write t_in.size() floats out of a buffer holding t_in.size()
+      /// T-sized elements. apply<T> walks the tensor with the correct element
+      /// type (and validates the output dtype). The accumulation is done in
+      /// float to match __fallback_gelu_v2's fp16 reference exactly.
+      t_in.apply<T>(
+        [](T x) {
+          const float xf = static_cast<float>(x);
+          return static_cast<T>(0.5f * xf *
+                                (1.0f + std::erf(xf * 0.7071067811f)));
+        },
+        t_out);
+    }
     return t_out;
   }
 
@@ -461,7 +488,7 @@ public:
       [&](T x) {
         return static_cast<T>(
           0.5 * (1 + erf(x * tmp) +
-                 x * ((2 / sqrt(M_PI)) * exp(-pow(x * tmp, 2))) * tmp));
+                 x * ((2 / sqrt(PI)) * exp(-pow(x * tmp, 2))) * tmp));
       },
       outgoing_derivative);
 
@@ -477,8 +504,23 @@ public:
    */
   template <typename T = float>
   static Tensor &tanhGelu(Tensor const &t_in, Tensor &t_out) {
-    nntrainer::tanh_gelu(t_in.size(), t_in.getData<float>(),
-                         t_out.getData<float>());
+    if constexpr (std::is_same_v<T, float>) {
+      nntrainer::tanh_gelu(t_in.size(), t_in.getData<float>(),
+                           t_out.getData<float>());
+    } else {
+      /// @note see gelu() above: cpu_backend's tanh_gelu declaration is fp32
+      /// only, so a non-fp32 activation must not go through getData<float>().
+      /// Accumulated in float to match __fallback_tanh_gelu's fp16 reference.
+      t_in.apply<T>(
+        [](T x) {
+          const float xf = static_cast<float>(x);
+          return static_cast<T>(
+            0.5f * xf *
+            (1.0f +
+             std::tanh(0.7978845608f * (xf + 0.044715f * xf * xf * xf))));
+        },
+        t_out);
+    }
     return t_out;
   }
 

--- a/nntrainer/layers/acti_func.h
+++ b/nntrainer/layers/acti_func.h
@@ -483,12 +483,32 @@ public:
     if (outgoing_derivative.empty())
       outgoing_derivative = Tensor(t_out.getDim());
 
-    T tmp = static_cast<T>(1 / sqrt(2));
+    /// @note The derivative is accumulated in double and narrowed exactly
+    /// once, on the return. The 1/sqrt(2) factor used to live in T
+    /// (`T tmp = static_cast<T>(1 / sqrt(2))`), so `x * tmp` was a T-precision
+    /// product that the enclosing double expression merely widened afterwards
+    /// -- the rounding (and, for a product that leaves the range of T, the
+    /// overflow) has already happened by then, so the wider type buys nothing.
+    /// That is the shape CodeQL reports as "multiplication result converted to
+    /// a larger type". Both operands are double here, so the product is formed
+    /// in double; T appears only at the input widening and the final narrowing.
+    /// Keep it that way: geluPrime is instantiated for the fp16 activation
+    /// types too (activation_layer.cpp selects setActiFunc<_FP16>), and how
+    /// much of the erf/exp argument a T-precision product would keep there is
+    /// toolchain-dependent.
+    /// The two constants are also hoisted out of the per-element lambda
+    /// (sqrt(PI) was recomputed for every element), and pow(u, 2) is written
+    /// u * u -- bit-identical for a double u.
+    const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+    const double two_over_sqrt_pi = 2.0 / std::sqrt(PI);
+
     t_in.apply<T>(
       [&](T x) {
+        const double xd = static_cast<double>(x);
+        const double u = xd * inv_sqrt2;
         return static_cast<T>(
-          0.5 * (1 + erf(x * tmp) +
-                 x * ((2 / sqrt(PI)) * exp(-pow(x * tmp, 2))) * tmp));
+          0.5 * (1.0 + std::erf(u) +
+                 xd * (two_over_sqrt_pi * std::exp(-u * u)) * inv_sqrt2));
       },
       outgoing_derivative);
 

--- a/nntrainer/models/model_common_properties.cpp
+++ b/nntrainer/models/model_common_properties.cpp
@@ -12,10 +12,37 @@
  */
 #include <model_common_properties.h>
 
+#include <nntrainer_error.h>
 #include <nntrainer_log.h>
 #include <util_func.h>
 
+#ifdef ENABLE_FP16
+#include <half_tensor.h>
+#endif
+
 namespace nntrainer::props {
+
+namespace {
+
+/**
+ * @brief Can a matmul on this build take an FP16 activation and a QS4CX
+ * weight?
+ *
+ * HalfTensor::dot() is the only host implementation of that product, and it
+ * carries the QS4CX case only where NNTR_HAS_HOST_QS4CX_FP16_GEMM (declared
+ * next to the case, in half_tensor.h) is 1. Without ENABLE_FP16 there is no
+ * HalfTensor at all, so the answer is trivially no.
+ */
+constexpr bool hasHostQs4cxFp16Gemm() {
+#if defined(ENABLE_FP16) && NNTR_HAS_HOST_QS4CX_FP16_GEMM
+  return true;
+#else
+  return false;
+#endif
+}
+
+} // namespace
+
 Epochs::Epochs(unsigned int value) { set(value); }
 
 bool LossType::isValid(const std::string &value) const {
@@ -37,6 +64,18 @@ FsuPath::FsuPath(const std::string &value) { set(value); }
 FsuLookahead::FsuLookahead(const unsigned int &value) { set(value); }
 ModelTensorDataType::ModelTensorDataType(ModelTensorDataTypeInfo::Enum value) {
   set(value);
+}
+
+void ModelTensorDataType::set(const ModelTensorDataTypeInfo::Enum &value) {
+  NNTR_THROW_IF(value == ModelTensorDataTypeInfo::Enum::WQS4CXA16 &&
+                  !hasHostQs4cxFp16Gemm(),
+                std::invalid_argument)
+    << "model_tensor_type=QS4CX-FP16 needs a host GEMM that multiplies an "
+       "FP16 activation by a QS4CX weight, and this build has none, so every "
+       "QS4CX fully connected layer would throw at its first matmul. Build "
+       "with enable-fp16 on x86, or use model_tensor_type=QS4CX-FP32.";
+
+  EnumProperty<ModelTensorDataTypeInfo>::set(value);
 }
 LossScale::LossScale(float value) { set(value); }
 

--- a/nntrainer/models/model_common_properties.h
+++ b/nntrainer/models/model_common_properties.h
@@ -239,6 +239,18 @@ public:
    */
   ModelTensorDataType(ModelTensorDataTypeInfo::Enum value =
                         ModelTensorDataTypeInfo::Enum::W32A32);
+
+  /**
+   * @brief set the weight/activation dtype pair, rejecting pairs this build
+   * has no kernel for
+   *
+   * @param value value to set
+   * @throw std::invalid_argument if no host GEMM in this build can multiply
+   * the activation dtype by the weight dtype. Accepting such a pair here only
+   * defers the failure to the first matmul, where it surfaces as
+   * "unsupported datatype" (or, worse, as a silently wrong result).
+   */
+  void set(const ModelTensorDataTypeInfo::Enum &value) override;
 };
 
 /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1255,8 +1255,18 @@ void NeuralNetwork::load(const std::string &file_path,
           continue;
         const std::string &name = weight->getName();
         auto it = name_offset_map.find(name);
-        if (it == name_offset_map.end())
+        if (it == name_offset_map.end()) {
+          // A name miss used to be a SILENT wrong-data path: file_offset keeps
+          // its default of 0, so the weight is later read from byte 0 of the
+          // file -- the 8-byte header length plus the ASCII JSON header, whose
+          // byte pairs decode as fp16 5.3e4..6.1e4. That is indistinguishable
+          // from a plausible-but-wrong weight downstream, and the EOF tripwire
+          // cannot catch it because offset 0 never overruns. Say so.
+          ml_logw("safetensors: no record named '%s' in %s; this weight keeps "
+                  "file offset 0 and will read the container header as data",
+                  name.c_str(), f_path.c_str());
           continue;
+        }
         const size_t file_off = data_base + it->second.first;
         weight->getVariableRef().setFileOffset(file_off);
       }

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -995,6 +995,24 @@ void NeuralNetwork::load(const std::string &file_path,
     auto model_file =
       checkedOpenStream<std::ifstream>(f_path, std::ios::in | std::ios::binary);
 
+    // Layout tripwire: the per-tensor file offsets computed above are trusted
+    // blindly by the (parallel, mmap-backed) reader below — if the graph's
+    // idea of a weight's on-disk size disagrees with what the file actually
+    // contains (e.g. a dtype mismatch between the requested weight and the
+    // stored record), every later tensor is positionally misloaded and the
+    // final reads run PAST THE END of the mapping (SIGSEGV in a load worker,
+    // far from the actual bug). Fail fast with an actionable message instead.
+    {
+      model_file.seekg(0, std::ios::end);
+      const auto f_bytes = static_cast<size_t>(model_file.tellg());
+      model_file.seekg(0, std::ios::beg);
+      NNTR_THROW_IF(start_from > f_bytes, std::runtime_error)
+        << "Model layout mismatch: graph expects " << start_from
+        << " bytes of weights but file '" << f_path << "' has only " << f_bytes
+        << " bytes. A weight's requested dtype/size disagrees with the stored "
+           "record (offsets would run past EOF).";
+    }
+
 #if defined(_WIN32)
     HANDLE hFile, hMap;
 #endif

--- a/nntrainer/qnn/qnn_context.cpp
+++ b/nntrainer/qnn/qnn_context.cpp
@@ -371,7 +371,12 @@ const int QNNContext::registerFactory(const FactoryType<T> factory,
     return int_key;
   }
 
-  int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;
+  // Auto key from max(existing) + 1, not from the registration COUNT: a
+  // count-derived key shifts when a registration is inserted mid-list and can
+  // walk onto an explicitly-requested LayerType value, which the assignment
+  // below would then silently rebind. QNNContext keeps its "duplicate key is a
+  // no-op, reuse it" policy above; this only removes the position dependence.
+  int assigned_int_key = int_key == -1 ? nextAutoIntKey(int_map) : int_key;
 
   str_map[assigned_key] = factory;
   int_map[assigned_int_key] = assigned_key;

--- a/nntrainer/tensor/cl_operations/cl_compute_ops.cpp
+++ b/nntrainer/tensor/cl_operations/cl_compute_ops.cpp
@@ -26,17 +26,50 @@
 
 #include <blas_kernels.h>
 #include <compute_ops.h>
+#include <cpu_backend.h> // gemm_q4_0 (host route for CL-ineligible shapes)
 
 namespace nntrainer {
+
+namespace {
+/**
+ * @brief Whether one (N, K) Q4_0 weight can enter the CL accel route.
+ *
+ * Both CL entry points (gemm_q4_0_cl / gemm_q4_0_async_cl) prepack the
+ * Q4_0x8 weight on the host with unpack_q4_0x8_transpose16, whose x86
+ * implementation is an AVX2 256-wide K unroll asserting (K % 256) == 0 and
+ * (N % 8) == 0 (avx2_impl.cpp); the kernel's NDRange (N/4 columns) needs
+ * N % 4 == 0, subsumed by N % 8. Ineligible shapes (e.g. the hidden=64
+ * tiny test fixtures) take the host gemm_q4_0 below instead.
+ */
+bool cl_q4_0_shape_eligible(unsigned int N, unsigned int K) {
+  return (K % 256) == 0 && (N % 8) == 0;
+}
+} // namespace
 
 class ClComputeOps : public ComputeOps {
 public:
   // ── Accelerator-only Q4_0 / INT4 GEMM/GEMV ────────────────
+  // The Q4_0 supports_*() predicates are shape-blind, so the shape gate lives
+  // here in the CL wrappers: eligible shapes take the CL kernels unchanged,
+  // ineligible ones bounce to the host gemm_q4_0 — the same generic route the
+  // cpu engine's gemm_q4_0_fp32 uses (cpu_ops_table.h), on the same host/SVM
+  // pointers the caller handed us. That host bounce is deliberate, not hidden:
+  // there is no CL fallback kernel for these shapes.
   bool supports_gemm_q4_0_batch_fp32() const override { return true; }
   void gemm_q4_0_batch_fp32(std::vector<void *> matAdata, float *matBdata,
                             std::vector<float *> matCdata, unsigned int M,
                             std::vector<unsigned int> N,
                             unsigned int K) override {
+    bool eligible = true;
+    for (unsigned int n : N)
+      eligible = eligible && cl_q4_0_shape_eligible(n, K);
+    if (!eligible) {
+      // Whole batch on host (mirrors float_tensor.cpp's non-accel loop).
+      for (size_t i = 0; i < matAdata.size(); ++i)
+        nntrainer::gemm_q4_0(M, N[i], K, matBdata, K, matAdata[i], N[i],
+                             matCdata[i], N[i]);
+      return;
+    }
     nntrainer::gemm_q4_0_async_cl(matAdata, matBdata, matCdata, M, N, K);
   }
 
@@ -44,7 +77,24 @@ public:
   void gemm_q4_0_accel_fp32(void *matAdata, float *matBdata, float *matCdata,
                             unsigned int M, unsigned int N,
                             unsigned int K) override {
+    if (!cl_q4_0_shape_eligible(N, K)) {
+      nntrainer::gemm_q4_0(M, N, K, matBdata, K, matAdata, N, matCdata, N);
+      return;
+    }
     nntrainer::gemm_q4_0_cl(matAdata, matBdata, matCdata, M, N, K);
+  }
+
+  // Generic (non-accel) Q4_0 branch of float_tensor.cpp's dispatch — the
+  // M == 1 decode step and any caller that skips the accel predicates land
+  // here. Host GEMM, identical to CpuComputeOps::gemm_q4_0_fp32
+  // (cpu_ops_table.h); without this override the base class throws NI, which
+  // the Q4_0 GPU decode path would hit on its first token.
+  void gemm_q4_0_fp32(const unsigned int M, const unsigned int N,
+                      const unsigned int K, const float *A,
+                      const unsigned int lda, const void *B,
+                      const unsigned int ldb, float *C,
+                      const unsigned int ldc) override {
+    nntrainer::gemm_q4_0(M, N, K, A, lda, B, ldb, C, ldc);
   }
 
   bool supports_gemv_int4_batch_fp32() const override { return true; }

--- a/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/fallback/fallback_internal_fp16.cpp
@@ -496,9 +496,24 @@ template <>
 void __fallback_rms_norm_wrt_width_fp16_intrinsic(const _FP16 *__restrict X,
                                                   _FP16 *__restrict Y, size_t H,
                                                   size_t W, float epsilon) {
-
-  throw std::runtime_error(
-    "NYI : __fallback_rms_norm_wrt_width_fp16_intrinsic with FP16 type input");
+  // Scalar reference: the sum-of-squares MUST be accumulated in FP32 — a
+  // fp16 accumulator overflows past 65504 on a wide residual row and turns
+  // the scale into +Inf. Matches the neon_impl_fp16 semantics so x86
+  // fp16-activation builds (which have no SIMD impl and land here) compute
+  // the same result instead of throwing NYI.
+  for (size_t r = 0; r < H; ++r) {
+    const _FP16 *xr = X + r * W;
+    _FP16 *yr = Y + r * W;
+    float ss = 0.0f;
+    for (size_t k = 0; k < W; ++k) {
+      const float v = static_cast<float>(xr[k]);
+      ss += v * v;
+    }
+    const float inv = 1.0f / std::sqrt(ss / static_cast<float>(W) + epsilon);
+    for (size_t k = 0; k < W; ++k) {
+      yr[k] = static_cast<_FP16>(static_cast<float>(xr[k]) * inv);
+    }
+  }
 }
 
 template <>

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -9,10 +9,15 @@
  * @bug		No known bugs except for NYI items
  */
 
+#include <algorithm>
+#include <atomic>
 #include <iomanip>
 #include <iostream>
+#include <thread>
+#include <vector>
 
 #include <compute_ops.h>
+#include <cpu_backend.h>
 #include <half_tensor.h>
 #include <tensor.h>
 #include <util_func.h>
@@ -719,6 +724,76 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
+#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
+  defined(__i386__)
+  case Tdatatype::QS4CX: {
+    // x86 host fallback: there is no KAI fp16 micro-kernel here (ARM i8mm), so
+    // an fp16-activation QS4CX FC that lands on the host (e.g. NNTR_ENGINE=cpu,
+    // or a GPU path that bails) would otherwise kill the process with
+    // "unsupported datatype". Route the CANONICAL x86 QS4CX GEMM -- the same
+    // gemm_qai8dxp_qsi4cxp_rhs_unpacked(is_nxk=true) entry point
+    // FloatTensor::dotQs4cx uses -- with the activation widened to fp32 and the
+    // fp32 result narrowed back to fp16. There is deliberately NO nibble decode
+    // here: the plain QS4CX payload is [N][ceil(K/2)] row-major with K
+    // contiguous, even k in the LOW nibble, each stored uint4 = int4 + 8, and
+    // the per-output-channel fp32 scales appended at QS4CX_Tensor::getScale --
+    // a layout that already has exactly one decoder per backend (host:
+    // __fallback_matmul_mxn_mxk_nxk_f32_qa8dx_qs4cx; GPU:
+    // make_v8c_weight_backing_from_qs4cx). Duplicating it here is what made
+    // every host QS4CX FC produce garbage.
+    //
+    // Work split: one canonical call per (row, N-chunk), parallel over the
+    // chunks. The kernel re-quantizes the row (K work per nb*K of GEMM) on
+    // every chunk -- the per-row scale/offset depends on the row alone, so the
+    // result is chunk-count independent -- and the fp32 staging stays at
+    // `chunk` floats per worker instead of M*N (the untied lm_head is
+    // N = 262144).
+    const unsigned int M = getDim().height();
+    const unsigned int K = getDim().width();
+    const unsigned int N = output.getDim().width();
+    const uint8_t *plain = input.getData<uint8_t>();
+    const float *fscale = input.getScale<float>();
+    const _FP16 *xact = (const _FP16 *)getData();
+    _FP16 *yout = output.getData<_FP16>();
+    const size_t Ms = M, Ns = N, Ks = K;
+    const size_t plain_row_bytes = (Ks + 1) / 2;
+    // The canonical GEMM takes an fp32 lhs (it does its own per-row dynamic
+    // int8 quantization, as the QS4CX weight format requires).
+    std::vector<float> xact_f32(Ms * Ks);
+    for (size_t i = 0; i < Ms * Ks; ++i)
+      xact_f32[i] = (float)xact[i];
+    const unsigned int nthreads =
+      std::max(1u, std::thread::hardware_concurrency());
+    std::atomic<size_t> next_n{0};
+    const size_t chunk = 256;
+    auto worker = [&]() {
+      std::vector<float> acc(chunk);
+      for (;;) {
+        const size_t n0 = next_n.fetch_add(chunk);
+        if (n0 >= Ns)
+          return;
+        const size_t n1 = std::min(Ns, n0 + chunk);
+        const size_t nb = n1 - n0;
+        for (size_t mi = 0; mi < Ms; ++mi) {
+          gemm_qai8dxp_qsi4cxp_rhs_unpacked(
+            1, nb, Ks, (void *)(xact_f32.data() + mi * Ks),
+            (void *)const_cast<uint8_t *>(plain + n0 * plain_row_bytes),
+            (void *)const_cast<float *>(fscale + n0), acc.data(), 0, true,
+            -65504.f, 65504.f);
+          _FP16 *yr = yout + mi * Ns;
+          for (size_t j = 0; j < nb; ++j)
+            yr[n0 + j] = (_FP16)acc[j];
+        }
+      }
+    };
+    std::vector<std::thread> pool;
+    for (unsigned int t = 0; t < nthreads; ++t)
+      pool.emplace_back(worker);
+    for (auto &t : pool)
+      t.join();
+    break;
+  }
+#endif
   default:
     throw std::invalid_argument("Error: unsupported datatype");
   }

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -724,8 +724,7 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
-#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
-  defined(__i386__)
+#if NNTR_HAS_HOST_QS4CX_FP16_GEMM
   case Tdatatype::QS4CX: {
     // x86 host fallback: there is no KAI fp16 micro-kernel here (ARM i8mm), so
     // an fp16-activation QS4CX FC that lands on the host (e.g. NNTR_ENGINE=cpu,

--- a/nntrainer/tensor/half_tensor.h
+++ b/nntrainer/tensor/half_tensor.h
@@ -21,6 +21,31 @@
 #define EXCEPT_WHEN_DEBUG noexcept
 #endif
 
+/**
+ * @brief 1 when this build has a host GEMM that can multiply an FP16
+ * activation by a QS4CX weight, i.e. when HalfTensor::dot() has a
+ * Tdatatype::QS4CX case.
+ *
+ * This is the ONLY place the condition is written down: HalfTensor::dot()
+ * guards its QS4CX case with this macro, and the model_tensor_type validation
+ * (nntrainer/models/model_common_properties.cpp) rejects "QS4CX-FP16" when it
+ * is 0, so that an unsupported build fails at property-set time with a
+ * message instead of at the first FC with "unsupported datatype".
+ *
+ * x86 only for now: the case widens the activation to FP32 and calls
+ * gemm_qai8dxp_qsi4cxp_rhs_unpacked(), which consumes the plain (unpacked)
+ * QS4CX blob x86 keeps in memory. On ARM the same weight is KAI rhs-packed
+ * (Tensor::pack()), so the unpacked kernel cannot read it and the packed
+ * FP16 KleidiAI micro-kernels are not dispatched yet. When a backend gains a
+ * case, extend this macro and the switch case together.
+ */
+#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) ||              \
+  defined(__i386__)
+#define NNTR_HAS_HOST_QS4CX_FP16_GEMM 1
+#else
+#define NNTR_HAS_HOST_QS4CX_FP16_GEMM 0
+#endif
+
 namespace nntrainer {
 
 /**

--- a/nntrainer/utils/util_func.cpp
+++ b/nntrainer/utils/util_func.cpp
@@ -95,11 +95,28 @@ void checkedRead(ReadSource src, char *array, std::streamsize size,
   if (auto f = std::get_if<std::ifstream *>(&src)) {
     if (read_from_offset) {
       (*f)->seekg(start_offset, std::ios::beg);
+      checkFile(**f, "failed to move offset");
     }
     (*f)->read(static_cast<char *>(array), static_cast<std::streamsize>(size));
-    // checkFile((*f), error_msg);
+    // The stream overload above has always checked this; here it was commented
+    // out, and the reason it had to be is that `*f` is an std::ifstream* -- the
+    // template would have deduced T = std::ifstream* and failed to compile on
+    // .bad(). Dereference once more. Without it a short read (a truncated or
+    // mis-offset weight file) leaves the destination holding whatever was in
+    // the buffer and the caller none the wiser; istream::read only sets eofbit
+    // when it extracted FEWER bytes than asked, so a read that lands exactly on
+    // EOF is still accepted.
+    checkFile(**f, error_msg);
   } else if (auto p = std::get_if<const char *>(&src)) {
     /// @todo use mmap instead memcpy to reduce peak memory
+    // NOTE: this branch cannot bound itself. A `const char *` mapping carries
+    // no length, so an over-long size or an out-of-range start_offset reads
+    // past the end of the mapping and SIGSEGVs on a load worker thread, ~300
+    // tensors away from whichever layer mis-sized itself. The guard for that
+    // lives one level up, in NeuralNetwork::load, which compares the graph's
+    // computed layout total against the real file size before any of these
+    // calls happen. Do not remove that check on the assumption this one is
+    // safe.
     if (read_from_offset) {
       std::memcpy(array, (*p) + start_offset, size);
     } else {

--- a/test/unittest/models/causallm_test_utils.cpp
+++ b/test/unittest/models/causallm_test_utils.cpp
@@ -243,6 +243,16 @@ makeTinyNntrainerConfig(const std::filesystem::path &tokenizer_path,
 }
 
 /**
+ * @brief Make a construct-only nntrainer config for config-plumbing tests
+ */
+causallm::json makeTinyCtorOnlyNntrainerConfig() {
+  auto nntr_cfg =
+    makeTinyNntrainerConfig(std::filesystem::path(), makeTinyFp32DataType());
+  nntr_cfg.erase("tokenizer_file");
+  return nntr_cfg;
+}
+
+/**
  * @brief Make complete tiny configs for one model case
  */
 TinyCausalLMConfig

--- a/test/unittest/models/causallm_test_utils.h
+++ b/test/unittest/models/causallm_test_utils.h
@@ -721,6 +721,18 @@ makeTinyNntrainerConfig(const std::filesystem::path &tokenizer_path,
                         const TinyCausalLMDataType &data_type);
 
 /**
+ * @brief Make a construct-only nntrainer config for config-plumbing tests
+ *
+ * Same FP32 shape as makeTinyNntrainerConfig, minus "tokenizer_file": a model
+ * whose constructor only has to parse parameters needs no tokenizer, and
+ * Transformer leaves `tokenizer` null (and spawns no async load) when the key
+ * is absent. Lets a test construct a model object with no tokenizer, no
+ * weights and no graph compile.
+ * @return nntrainer_config.json equivalent
+ */
+causallm::json makeTinyCtorOnlyNntrainerConfig();
+
+/**
  * @brief Make complete tiny configs for one model case
  * @param test_case Model case descriptor
  * @param tokenizer_path Tiny tokenizer path

--- a/test/unittest/models/unittest_causallm_gemma3.cpp
+++ b/test/unittest/models/unittest_causallm_gemma3.cpp
@@ -54,6 +54,30 @@ public:
 };
 
 /**
+ * @brief Tiny Gemma3 probe exposing config-derived attention parameters
+ *
+ * Construct-only: it never compiles a graph nor loads weights, so every
+ * assertion observes exactly what the constructor chain parsed out of cfg.
+ */
+class TinyGemma3ConfigProbe final : public causallm::Gemma3CausalLM {
+public:
+  /**
+   * @brief Construct a tiny Gemma3 config probe
+   */
+  TinyGemma3ConfigProbe(causallm::json &cfg, causallm::json &generation_cfg,
+                        causallm::json &nntr_cfg) :
+    causallm::Transformer(sanitizeConfig(cfg),
+                          sanitizeGenerationConfig(generation_cfg, cfg),
+                          nntr_cfg, causallm::ModelType::CAUSALLM),
+    causallm::Gemma3CausalLM(cfg, generation_cfg, nntr_cfg) {}
+
+  /**
+   * @brief Attention-logit soft-cap as parsed by the constructor chain
+   */
+  float attnLogitSoftcapping() const { return ATTN_LOGIT_SOFTCAPPING; }
+};
+
+/**
  * @brief Populate deterministic tiny Gemma3 weights for golden token tests
  */
 void setupGemma3DeterministicWeights(TinyGemma3CausalLM &model) {
@@ -529,6 +553,64 @@ TEST(EmbeddingGemmaTinyModelTest,
     has_non_zero = has_non_zero || std::abs(value) > 1e-5f;
   }
   EXPECT_TRUE(has_non_zero);
+}
+
+/**
+ * @brief Construct a tiny Gemma3 probe from a model config
+ */
+std::unique_ptr<TinyGemma3ConfigProbe> makeGemma3Probe(causallm::json cfg) {
+  auto generation_cfg = causallm_test::makeTinyGenerationConfig();
+  auto nntr_cfg = causallm_test::makeTinyCtorOnlyNntrainerConfig();
+  return std::make_unique<TinyGemma3ConfigProbe>(cfg, generation_cfg, nntr_cfg);
+}
+
+/**
+ * @brief config.json "attn_logit_softcapping" must reach the model object
+ *
+ * Asserts the CONTRACT -- a cfg key the model declares support for actually
+ * lands in the member every consumer reads -- not where the parse is written,
+ * so it stays valid if the parse moves again.
+ *
+ * Regression guard: the parse used to live only in
+ * Gemma3Transformer::setupParameters, which is unreachable. setupParameters is
+ * dispatched from base-class CONSTRUCTOR bodies (Transformer:: and CausalLM::),
+ * and a virtual call inside a base constructor resolves to the BASE override --
+ * never a derived one. Gemma3's ctor bodies add no call of their own, so the
+ * override never ran. Shipped gemma3 configs carry
+ * "attn_logit_softcapping": null, so gemma3 numerics never moved, but the
+ * plumbing was broken all the same -- and it is the same dead-override shape
+ * that silently disabled gemma2's soft-cap.
+ */
+TEST(Gemma3ConfigPlumbingTest, AttnLogitSoftcappingReachesModel) {
+  auto cfg = makeTinyGemma3Config();
+  cfg["attn_logit_softcapping"] = 50.0;
+
+  auto probe = makeGemma3Probe(cfg);
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 50.0f);
+}
+
+/**
+ * @brief A config without the key keeps the no-soft-cap default
+ */
+TEST(Gemma3ConfigPlumbingTest, AbsentAttnLogitSoftcappingKeepsDefault) {
+  auto probe = makeGemma3Probe(makeTinyGemma3Config());
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 0.0f);
+}
+
+/**
+ * @brief An explicitly null key keeps the no-soft-cap default
+ *
+ * This is the shape shipped gemma3 configs actually use.
+ */
+TEST(Gemma3ConfigPlumbingTest, NullAttnLogitSoftcappingKeepsDefault) {
+  auto cfg = makeTinyGemma3Config();
+  cfg["attn_logit_softcapping"] = nullptr;
+
+  auto probe = makeGemma3Probe(cfg);
+
+  EXPECT_FLOAT_EQ(probe->attnLogitSoftcapping(), 0.0f);
 }
 
 } // namespace


### PR DESCRIPTION
**Task-level PR.** Eight previously separate rungs, consolidated into one review: every commit here is a
defect that makes an inference path **return a wrong answer or fall back silently instead of failing
loud**. One review question throughout: *does this path fail loud, or does it lie?* None of them needs a
GPU backend to review, and none has a feature dependency.

Absorbs #4174, #4176, #4177, #4178, #4179, #4182, #4183 (all main-direct singletons, now closed and
pointed here). 14 commits, all replayed clean onto `main` — see the per-rung sections below.

**Merge button: "Rebase and merge" — never squash.** Each rung must keep its own revert handle.

**Base is legal for every member:** all eight branches were ladder-free (their entire delta versus `main`
is their own rungs — no stacked-series content), so all 14 commits replay onto `upstream/main`
(`2b9140ba`) with zero conflicts.

---

## 1. `ActiFunc::gelu` / `tanhGelu` overflow the output buffer by 2x under FP16 activations

`gelu` and `tanhGelu` are templates on the activation element type `T`, but their bodies hardcode
`getData<float>()` on an **element** count. `Tensor::getData<T>()` is an unchecked cast that does not
consult the tensor's real dtype, so with `T = _FP16` the call hands a buffer of N 2-byte elements to a
routine that reads N 4-byte floats and writes N 4-byte floats: it reads 2x past the end of the input and
**overflows the output buffer by 2x**. Heap corruption, not merely wrong numerics.

Reachable: `ActivationLayer::finalize` really does select the `_FP16` instantiation when
`getActivationDataType() == FP16`, and ten `ModelTensorDataTypeInfo` strings are `*-FP16`. In-tree
consumers: `gelu` in BERT, TIMM-ViT and DeBERTa-v2; `tanh_gelu` in Gemma3. It went unnoticed because
every `model_tensor_type` committed to this tree is `FP32-FP32` or `Q4_0-FP32`, so CI only ever
instantiates `T = float`, where the cast happens to be correct.

Fix keeps the accelerated fp32 path (`gelu_v2` / `tanh_gelu` are AVX2- and NEON-vectorized; de-SIMDing
fp32 would be a real regression) behind `if constexpr (std::is_same_v<T, float>)` and routes every other
`T` through `Tensor::apply<T>()`, which walks with the correct element type and throws if the output
dtype disagrees — exactly what the neighbouring `sigmoidGelu` already does. The lambdas accumulate in
float and cast back to `T`, reproducing the existing `__fallback_gelu_v2` / `__fallback_tanh_gelu` fp16
references bit for bit.

**Honest empty cell:** there is no in-tree `*-FP16` activation fixture, so this cannot be closed by a
committed regression test today. Closing it needs either a committed FP16-activation reference config or
an ASAN build over one of the four affected models.

### Automated-review findings carried over from the absorbed PR

The singleton attracted two bot findings. Neither is lost:

- **`acti_func.h` / MSVC `M_PI` (P1).** Including `<cmath>` before `_USE_MATH_DEFINES` is defined means
  the include-guarded CRT math header is already in, so a later `_USE_MATH_DEFINES` cannot expose
  `M_PI` — and a header cannot guarantee definition order for its consumers, so `geluPrime()` would
  break any MSVC TU that includes it. **Already fixed on this branch**: the header now carries
  `constexpr static inline double PI = 3.14159265358979323846;` as a plain class constant (same value as
  the CRT/glibc `M_PI`, so results are unchanged) with the ordering rationale in the doc comment.
- **CodeQL alert 448, `acti_func.h:491` — "multiplication result may overflow float before conversion to
  double"** in `geluPrime`'s `pow(x * tmp, 2)`. Assessed as a false positive and **deliberately not
  changed here**: `tmp` is `1/sqrt(2) < 1`, so `x * tmp` strictly shrinks the magnitude and cannot
  overflow for any representable `x` in either `float` or `_FP16`. Every candidate silencing edit
  (widening the intermediate to `double`) would change the intermediate precision of a gradient path
  that has no committed reference, so it is recorded here as a known, understood alert rather than
  silently re-numbered.

## 2. Loader: fail loud on a weight-name miss and on a model-layout mismatch

Two silent-wrong-data / late-crash paths, both hardening, no behaviour change on a well-formed package.

- **Name-miss reads the container header as weight data.** `NeuralNetwork::load`'s safetensors path
  assigns each weight its file offset **by name**; on a miss it just `continue`d, leaving `file_offset`
  at its default `0`. The weight is then read from byte 0: the 8-byte header length followed by the
  ASCII JSON header. Those byte pairs decode as fp16 5.3e4…6.1e4 — large-but-finite values
  indistinguishable from a plausible weight to everything downstream, and the EOF tripwire cannot catch
  it because offset 0 never overruns. Now logs the tensor name and the file. Warning, not a throw: a
  genuinely optional record is a legitimate miss, and hard-erroring needs a per-model audit this change
  is not making.
- **Layout mismatch SIGSEGVs on a loader thread.** Per-tensor offsets are trusted blindly by the
  parallel mmap reader, so any graph-vs-file size disagreement surfaces as a `memcpy` past the end of the
  mapping — a crash on a worker thread, far from the actual bug. Now compares the computed layout total
  against the real file size up front and throws with both numbers. Demonstrated on a QINT4-FP16 qwen3
  package where the graph sizes QINT4 records by `Int4QTensor::getMemoryBytes()` while the container on
  disk stores the plain PR#3978 layout (**graph expects 375,483,784 vs 348,646,792 on disk**): that
  package now errors with an actionable message instead of crashing.

**Validated:** silent on all four target packages (a 35-layer sliding-window QS4CX-FP16 model, gemma4,
qwen3, gemma2 — **0 warnings each**; they load through the positional `.bin` path, not this one), so
neither message is the cause of any current defect.

## 3. x86 host QS4CX GEMM for `HalfTensor::dot`

`main`'s `half_tensor.cpp` has **zero** QS4CX references, so `HalfTensor::dot` has no QS4CX case at all:
an fp16-activation QS4CX model has no host GEMM to fall back to on x86. This adds one.

Fix by delegation rather than a fourth hand-rolled decoder: the new case calls
`gemm_qai8dxp_qsi4cxp_rhs_unpacked(..., is_nxk=true)` — the exact x86 entry point
`FloatTensor::dotQs4cx` already uses — with the fp16 activation widened to fp32 per chunk and the fp32
result narrowed back. Staging is `chunk` floats per worker, **not `M*N`** (an untied lm_head is
`N = 262144`).

**Why one squashed commit:** the internal precursor hand-decoded the nibble payload and got the layout
wrong three independent ways (wrong axis order, wrong nibble half, signed instead of unsigned offset —
full derivation against the two in-tree layout authorities is in the commit message). Publishing that
precursor even for one commit would introduce a known-wrong decoder that never existed upstream.

Also carries four small x86 fp16-activation gaps the same work unmasked: `rms_norm` /
`reshaped_rms_norm` read gamma at `context.getWeightDataType()` instead of a hardcoded FP32 (matching
`*-FP16` packages that store norm gammas at the model weight dtype); `fallback_internal_fp16`'s
`rms_norm_wrt_width_fp16` scalar reference (was an NYI throw); `Transformer::repack_weight` skipping on
NYI per weight so x86 (no KleidiAI rhs-pack) loads the plain QS4CX blob instead of aborting; and a
rejection of `model_tensor_type=QS4CX-FP16` where no host kernel exists.

**Not included:** the ARM case in the same `#if/#elif` block
(`nntr_gemm_qai8dxp_qsi4cxp_packed<_FP16>`) — it depends on KleidiAI fp16 packed-weight infrastructure
that does not exist on `main`.

**Three-axis note:** structure ++ (one decoder per backend, matching the existing x86/ARM/GPU QS4CX
authorities instead of adding a fourth); performance ~ (adds an `M*K` fp32 staging copy plus int8
requantization per call, on the host QS4CX-FP16 fallback path only); memory 0 (chunk-sized staging).

## 4. Gate the CL q4_0 accel path on prepack shape eligibility — **7 of 10 crashing suites go green**

`ClComputeOps::supports_gemm_q4_0_{batch,accel}_fp32()` return `true` **unconditionally**, so
`float_tensor.cpp`'s Q4_0 dispatch sends every `M > 1` GEMM into the CL prepack. Both CL entry points
prepack the Q4_0x8 weight on the host with `unpack_q4_0x8_transpose16`, whose x86 implementation is an
AVX2 256-wide K unroll that asserts `(K % 256) == 0` and `(N % 8) == 0`. Any Q4_0 weight with
`K % 256 != 0` therefore **aborts the process** on `engine=gpu`: the tiny CausalLM fixtures
(hidden_size = 64) crash **7 of the 10 `Q40CloseToFP32Reference` suites**, while the same suites pass on
`NNTR_ENGINE=cpu`. Reproduces on `main` — a pre-existing upstream defect.

Fix at the CL seam, not at the neutral dispatch site: the wrappers that claimed support now check shape
eligibility (`K % 256 == 0 && N % 8 == 0`) and route ineligible shapes to the host `gemm_q4_0` — the
exact function the cpu engine uses, on the same host/SVM pointers. **That host bounce is NAMED in a code
comment rather than hidden.** Eligible shapes take the identical CL calls as before: zero behaviour
change.

The same seam also needed the generic branch: the dispatch's `else` path (`M == 1`, i.e. every decode
step) calls `gemm_q4_0_fp32`, which `ClComputeOps` never overrode, so the base class threw "not
implemented by this backend" on the first generated token — a latent defect the prefill crash masked.

**Measured:** the 10 `Q40CloseToFP32Reference` suites on an OpenCL + fp32 build — **7 CRASH → PASS, 3
PASS-still**. Highest value-per-line change in this bundle.

**Known NOT fixed:** the tiny-BERT Q4_0-on-gpu path completes after this change but yields NaN
embeddings from a **distinct** pre-existing gpu-engine Q4_0 weight-load defect that the crash used to
hide.

## 5. Factory `int_key` assignment position-independent + fail loud

- `int assigned_int_key = int_key == -1 ? str_map.size() + 1 : int_key;` — `str_map.size()` is a count,
  not a high-water mark, and the collision guard only ran for `int_key != -1`, so `int_map[k] = type`
  silently **rebinds** an existing key whenever the string map's size collides with an
  explicitly-assigned key. A registration mistake then resolves to the wrong layer type with nothing
  logged.
- `add_default_object()` ran **before** `setMemAllocator()` in `cl_context.cpp`. Any registration throw
  during default-object setup left a fully "initialised" context with a **null `MemAllocator`**, and
  every model built on it died later in the `TensorPool` constructor with a symptom that names nothing.

Fix: derive the auto key from the actual maximum in use, run the collision guard on every assignment,
fail loud on collision; order `setMemAllocator()` before `add_default_object()`. `AppContext::initialize`
already orders them the safe way, so this propagates an in-tree precedent. Covers the core three
contexts plus QNN.

**Honest note:** the canary for the first defect was run and did **not** fire — the in-tree mitigation (a
comment asking contributors to append last, plus explicit keys 9001/9002) held. The mechanism is still
there; the second defect's null-allocator window is unconditional.

## 6. Three inference-path defects: FFN gate/up load order, prompt BOS, token-id staging

All three found by **differencing a layer-0 device capture against a reference**, not by reading code.

**(a) The generic FFN loads `gate_proj` into `ffn_up` — a *loader-order* defect.** The
`swiglu({up, gate}, {1, 0})` wiring on `main` is already correct (`tensor_api.h:641-655` documents that
the slot map inverts). The defect is upstream of it: **the weight loader is positional.** File offsets
are assigned in graph-creation order, not by name, and converters write `gate_proj` → `up_proj` →
`down_proj`. `Transformer::createMlp` created `ffn_up` **first**, so `ffn_up` consumed `gate_proj`'s
bytes. Net computation: **`silu(up_proj) * gate_proj`** — coherent-looking activations, wrong function.
The capture showed a *swap*, not a diff:

```
layer0_ffn_up:out0:y     this tree b2d89b8a30493f9b   reference a62dba9a0458afda
layer0_ffn_gate:out0:y   this tree a62dba9a0458afda   reference b2d89b8a30493f9b
```

Fix: create `ffn_gate` first, `ffn_up` second, `swiglu({gate, up})` with no slot map. This also makes the
layer **names** semantically true, which matters for every name-keyed consumer (differential probes,
divert trace, residency dump). Result: **qwen3 is golden on both lanes for the first time.**

Scope is exactly the models that do not override `createMlp` — on `main`, qwen3 and any future generic
model. `gemma3`, `gemma4`, `bert`, `gpt_oss` (+ `gpt_oss_cached_slim`), `lfm2`, `qwen3_moe`
(+ `qwen3_slim_moe`, `qwen3_cached_slim_moe`) and `timm_vit` all override `createMlp` and were already
gate-first, so they are **byte-identical**. Why no test caught it: `unittest_causallm_models` fixtures
load weights **name-keyed** and the defect is **positional** — 86/86 before and after.

**(b) Missing BOS.** `CausalLM::run()` used the 1-argument `tokenizer->Encode(prompt_)`; for a tokenizer
with `TemplateProcessing` / `add_bos_token=true` the leading BOS is **silently dropped**. The capture
diverges at the **first tensor, on a size**: `layer0_attention_norm:in` `bytes=23040` (5x2304x2) against
the reference's `27648` (6x2304x2), and the reference's row-0 first fp16 is `0x8000` (-0.0) = the BOS
embedding. Fix is `Encode(prompt_, /*add_special_tokens=*/true)` — **not** a hard-coded BOS insert, which
would double-prepend for templates that already emit one.

**(c) Unzeroed token-id staging buffer.** `BATCH_SIZE * MAX_SEQ_LEN` floats were `malloc`'d and only
`input_len` written, so the graph read uninitialised memory past the prompt: `input0` entered at
`min=-5.92e+35 max=5.62e+21` against the reference's `min=0 max=2.37e+05`. Fix is `calloc`.

**(d)** A fourth commit makes (b) multi-turn-safe: the special tokens are added **only at sequence
position 0**, and the cached rows are counted the same way, so a continued conversation does not
re-prepend BOS on every turn.

**Validated:** 4-model short-prompt text byte-identical to the reference over 3 consecutive runs, and the
per-layer hash stream matches line for line on the captured model. Two of the three defects each moved a
model from wrong-but-plausible output to golden (qwen3 via the loader order, the Gemma2 packaging via the
BOS); gemma4 is unchanged and serves as the regression control. The two goldens that change here change
**by design** — they were wrong before.

## 7. `attn_logit_softcapping` lived in a dead override

`setupParameters()` is only ever dispatched from base-class **constructor** bodies. C++ resolves a
virtual call made inside a base constructor to the *base* version, never a derived override. A model
whose own constructor body adds no `setupParameters()` call therefore never runs its override, and every
key parsed only there keeps its default. `Gemma3Transformer` is exactly that shape, so the
`attn_logit_softcapping` parse never ran, `ATTN_LOGIT_SOFTCAPPING` kept its `0.0f` default, and — since
every consumer is gated `if (attn_logit_softcapping > 0.0f)` — the `c*tanh(s/c)` soft-cap was skipped on
every layer, on every backend.

Fix: move the parse into `Transformer::setupParameters` — the one function the base constructor provably
reaches — and delete the per-model copies. Gated on `contains(...) && !is_null(...)`, so any model whose
config lacks the key keeps `0.0f` and is byte-preserving.

Audited per model: **gemma3 / EmbeddingGemma** plumbing cured, **numerics unchanged** (in-tree configs
carry `"attn_logit_softcapping": null`); **gemma4** unchanged (its override is live and re-read the same
key into the same member); **qwen2 / qwen3 / qwen3_moe / gpt_oss / lfm2 / bert / deberta / xlm_roberta /
timm_vit** have no such key. The real numerics victim is **gemma2**, whose shipped configs all carry
`"attn_logit_softcapping": 50.0` — this fix is its prerequisite.

Ships `Gemma3ConfigPlumbingTest` and a shared `makeTinyCtorOnlyNntrainerConfig()` helper in
`causallm_test_utils`. The test is ctor-level parameter *visibility*: a probe subclass exposes the
protected member and constructs the model with no tokenizer, no weights and no graph compile. Three
cases: key present (the regression guard, which **fails on the unfixed tree**), key absent, key
explicitly null.

**Merge-order note:** this bundle ships `causallm_test_utils.{h,cpp}`, which the Gemma2 model PR's unit
test consumes. Please land this **before** the Gemma2 model PR.

## 8. Honor `nntr_config`'s `lmhead_untie`

The app only read `config.json`'s `tie_word_embeddings` when choosing the lm_head layer type;
`nntr_config.json`'s `lmhead_untie` was ignored entirely. Untied-serialized packages (tied HF config plus
a separate transposed `[hidden, vocab]` head record appended to the bin) therefore built a **tied** graph
against an **untied** bin. That used to misload silently; with rung 2's loader tripwire it now fails fast
with a model-layout mismatch — either way the package is unusable.

- `Transformer::setupParameters` parses `lmhead_untie` into a new `LMHEAD_UNTIE` member. It lives on
  `Transformer`, not `CausalLM`, because `embedding0`'s layer-type choice happens in
  `<model>Transformer::constructModel` scope, which does not see `CausalLM` members in the diamond
  hierarchy.
- New `CausalLM::buildLmHeadOutput(h, add_skip_prefill)`: untied ⇒ an independent `fully_connected`
  output with its own weight (`weight_dtype = LMHEAD_DTYPE`, optional `skip_prefill` so the head stays
  decode-only); tied ⇒ the existing `tie_word_embeddings` / `lm_head` choice with `shared_from`,
  unchanged. Shared by the generic path and by Gemma4.
- `Gemma4Transformer::constructModel` gates `embedding0` on `TIE_WORD_EMBEDDINGS && !LMHEAD_UNTIE`: with
  an untied head there is nothing to share, so `embedding0` becomes a plain `embedding_layer`
  (lookup-identical, same weight record), which also makes the `embedding_file_name` sidecar legal.

Byte-preserving for every package without the key: `LMHEAD_UNTIE` defaults false, emitted property
strings and their order are unchanged, and no `skip_prefill` is added on paths that did not add it
before.

**Not verified here:** tied goldens (qwen3 / gemma2 / gemma4 packagings) byte-identical, and an
untied-serialized gemma4 package passing the load tripwire and producing coherent output. Both pending
build-host time; the change is byte-preserving by construction for every package that does not set the
key.

---

## Merge order

Rungs 7 and 8 (`attn_logit_softcapping`, `lmhead_untie`) are also re-included inside two of the stacked
consolidation branches in this series. That is the stacked series' pre-existing shape, not something this
bundle creates, and it dictates order: **land this PR before those stacked PRs**, so the cascade copies
arrive as no-ops under rebase-and-merge rather than as conflicts.

Rung 6(a) reorders the same `ffn_up` / `swiglu` lines that the `engine=` selection rung stamps with
`withKey("engine", causallm_engine())`. Whichever lands second shows one small textual conflict in
`createMlp`; the intended resolution is "**gate-first *and* stamped**", which is exactly the combination
the downstream feature branches already carry, so no goldens move as a result.

---

Part of a stacked series porting multi-hardware backend support (OpenCL / Intel XMX / Adreno, CUDA,
ARM KleidiAI) into nntrainer. Product-model code is not part of any PR in the series; new backends and
levers are gated so existing builds and the default execution path stay byte-identical unless a feature
is explicitly enabled. Full rationale for every commit is in its DCO-signed message.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
