### PR TITLE
[tensor] Load legacy per-channel int4 (QINT4) weight records as QS4CX

### DIFF
--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -82,8 +82,21 @@ public:
    * @return Tensor DataType of the the Weight
    */
   TensorDim::DataType getWeightDataType() {
-    return str_converter<enum_class_prop_tag, nntrainer::TensorDataTypeInfo>::
-      from_string(tensor_type[1]);
+    auto dt =
+      str_converter<enum_class_prop_tag,
+                    nntrainer::TensorDataTypeInfo>::from_string(tensor_type[1]);
+    // A QINT4 weight dtype -- whether inherited from a "QINT4-*"
+    // model_tensor_type graph default or set per layer -- is materialised as
+    // the canonical QS4CX class: both are the same KleidiAI qsi4cxp
+    // per-output-channel int4 format, and QS4CX is the one every compute path
+    // in this tree consumes. The on-disk bytes stay the legacy QINT4 record and
+    // are transcoded at read time (NeuralNetwork::load flags the tensor,
+    // QS4CX_Tensor::read does the re-layout), so existing QINT4 packages keep
+    // loading unchanged. This is the single point that makes the mapping
+    // universal across every model.
+    if (dt == TensorDim::DataType::QINT4)
+      return TensorDim::DataType::QS4CX;
+    return dt;
   };
 
   /**

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -45,6 +45,7 @@
 #include <ini_interpreter.h>
 #include <ini_wrapper.h>
 #include <input_realizer.h>
+#include <int4_utils.h>
 #include <model_loader.h>
 #include <multiout_realizer.h>
 #include <neuralnet.h>
@@ -55,6 +56,7 @@
 #include <optional>
 #include <previous_input_realizer.h>
 #include <profiler.h>
+#include <quantizer.h>
 #include <recurrent_realizer.h>
 #include <remap_realizer.h>
 #include <safetensors_util.h>
@@ -947,6 +949,21 @@ void NeuralNetwork::load(const std::string &file_path,
   size_t start_from = 0;
   std::vector<std::pair<size_t, size_t>> file_offset;
   std::unordered_set<const Tensor *> visited_weights;
+  // A QINT4 record's on-disk size depends on its container: the shared plain
+  // container (qscheme PER_CHANNEL_AFFINE at the record head; the PR#3978 form)
+  // carries fp32 scales plus KAI pad and is NOT the in-memory Section A size
+  // that getMemoryBytes() reports. Peek each QINT4 record's qscheme so the
+  // running offset matches the actual file layout.
+  std::ifstream qint4_peek_stream;
+  bool qint4_peek_tried = false;
+  // A legacy QINT4 model (model_tensor_type "QINT4-*") now
+  // builds QS4CX weights; its int4 records are still the legacy on-disk form
+  // (u16 header + Section A fp16 scales, or plain container) whose size differs
+  // from the QS4CX in-memory getMemoryBytes(). Size them explicitly and flag
+  // the tensors so QS4CX_Tensor::read() transcodes.
+  const std::string model_tensor_type_str =
+    to_string(std::get<props::ModelTensorDataType>(model_flex_props));
+  const bool legacy_int4_model = model_tensor_type_str.rfind("QINT4", 0) == 0;
   for (auto iter = model_graph.cbegin(); iter != model_graph.cend(); iter++) {
     auto weights = (*iter)->getRunContext().getWeights();
     for (auto weight : weights) {
@@ -974,6 +991,47 @@ void NeuralNetwork::load(const std::string &file_path,
           tensor_data_type != TensorDim::DataType::QS4CX) {
         // for tensor with qparam
         size += sizeof(uint16_t);
+      }
+      auto peek_disk_scheme = [&]() -> uint16_t {
+        if (!qint4_peek_tried) {
+          qint4_peek_tried = true;
+          qint4_peek_stream.open((v.size() == 2) ? v[1] : v[0],
+                                 std::ios::in | std::ios::binary);
+        }
+        uint16_t disk_scheme = 0xFFFF;
+        if (qint4_peek_stream.is_open()) {
+          qint4_peek_stream.clear();
+          qint4_peek_stream.seekg(static_cast<std::streamoff>(start_from),
+                                  std::ios::beg);
+          qint4_peek_stream.read(reinterpret_cast<char *>(&disk_scheme),
+                                 sizeof(uint16_t));
+          if (!qint4_peek_stream.good())
+            disk_scheme = 0xFFFF;
+        }
+        return disk_scheme;
+      };
+      if (tensor_data_type == TensorDim::DataType::QINT4) {
+        if (peek_disk_scheme() ==
+            static_cast<uint16_t>(QScheme::PER_CHANNEL_AFFINE)) {
+          const TensorDim &d = weight->getDim();
+          size = sizeof(uint16_t) +
+                 Int4Utils::plainRecordPayloadBytes(d.width(), d.height());
+        }
+      }
+      if (legacy_int4_model && tensor_data_type == TensorDim::DataType::QS4CX) {
+        // Legacy QINT4 record loaded as a QS4CX tensor: the
+        // on-disk record is the legacy form, not the QS4CX in-memory size. Flag
+        // the tensor so read() transcodes, and size by the peeked container.
+        weight->getVariableRef().setOnDiskLegacyQint4(true);
+        const uint16_t disk_scheme = peek_disk_scheme();
+        const TensorDim &d = weight->getDim();
+        if (disk_scheme == static_cast<uint16_t>(QScheme::PER_CHANNEL_AFFINE))
+          size = sizeof(uint16_t) +
+                 Int4Utils::plainRecordPayloadBytes(d.width(), d.height());
+        else
+          size = sizeof(uint16_t) +
+                 Int4Utils::kaiNibblePayloadBytes(d.width(), d.height()) +
+                 static_cast<size_t>(d.width()) * sizeof(uint16_t);
       }
       file_offset.emplace_back(std::make_pair(start_from, size));
       start_from += size;

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -35,6 +35,25 @@
 
 namespace nntrainer {
 
+// nntr_gemm_qai8dxp_qsi4cxp_* per-channel int4 KAI template decls. Upstream's
+// kleidiai refactor (the qai8dxp/qsi4cxp rhs-packed GEMM path) dropped these
+// from this header; our facade keeps the nntr_*<T> API, and
+// arm_compute_backend_fp16.cpp defines nntrainer::-scoped specializations, so
+// re-declare them here.
+template <typename T = float>
+uint32_t nntr_gemm_qai8dxp_qsi4cxp_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales, T *dst_mtx, bool transB = true,
+  T lower_bound = std::numeric_limits<T>::lowest(),
+  T upper_bound = std::numeric_limits<T>::max());
+
+template <typename T = float>
+void nntr_gemm_qai8dxp_qsi4cxp_packed(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
+  void *rhs_packed_mtx_qs4cx, T *dst_act_mtx_f32, uint32_t idx_variant,
+  bool transB = true, T lower_bound = std::numeric_limits<T>::lowest(),
+  T upper_bound = std::numeric_limits<T>::max());
+
 #ifdef ENABLE_FP16
 /**
  * @brief F32 * F16 = F32 GEMM

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -439,6 +439,44 @@ void nntr_quant_qs4c32_f32(size_t n, size_t k, size_t bl,
                             (uint8_t *)rhs_native_mtx_qs4c32);
 }
 
+// i8mm-gated, matching the loader-side contract this dispatch seam assumes
+// (see half_tensor.cpp): the KAI rhs-packed weight is packed once, ahead of
+// time, for the qai8dxp4x8/qsi4cxp4x8 pack family (nr=4 kr=16 sr=2). Locking
+// to that family (rather than also falling back to the dotprod-only
+// nr=4/kr=8/sr=2 family on non-i8mm ARM) avoids a silent pack-layout
+// mismatch — the loader-side packer does not exist in-tree yet (deferred to
+// the QS4CX-FP16 host-FC infra track), so there is nothing to confirm it
+// would target the other family too.
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+template <>
+void nntr_gemm_qai8dxp_qsi4cxp_packed(size_t m, size_t n, size_t k,
+                                      void *lhs_native_mtx_f16,
+                                      void *rhs_packed_mtx_qs4cx,
+                                      _FP16 *dst_act_mtx_f16,
+                                      uint32_t idx_variant, bool transB,
+                                      _FP16 lower_bound, _FP16 upper_bound) {
+  // Routes to the upstream qai8dxp/qsi4cxp f16 ukernel family
+  // (kleidiai_interface_f16_qai8dxp_qsi4cxp.cpp's ukernel_variants[]) — GEMV
+  // (idx 1: qai8dxp1x8_qsi4cxp4x8_1x4_neon_dotprod, mr=1) for a single-row
+  // decode step, GEMM (idx 3: qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm, mr=4)
+  // otherwise. idx_variant is informational here, not a caller-selectable
+  // choice: both indices share nr=4 kr=16 sr=2, so rhs_packed_mtx_qs4cx —
+  // packed once at load for that {nr,kr,sr} family — is valid for either
+  // without repacking; only mr (the LHS pack block / compute microkernel)
+  // differs between them. transB is not part of
+  // __kai_gemm_f16_qai8dxp_qsi4cxp's contract: the packed rhs is always
+  // nxk-packed-as-transposed by construction.
+  (void)idx_variant;
+  (void)transB;
+  static constexpr uint32_t kGemvVariant = 1;
+  static constexpr uint32_t kGemmVariant = 3;
+  const uint32_t variant = (m == 1) ? kGemvVariant : kGemmVariant;
+  __kai_gemm_f16_qai8dxp_qsi4cxp(
+    m, n, k, lhs_native_mtx_f16, rhs_packed_mtx_qs4cx, dst_act_mtx_f16, variant,
+    static_cast<float>(lower_bound), static_cast<float>(upper_bound));
+}
+#endif // defined(__ARM_FEATURE_MATMUL_INT8)
+
 size_t nntr_get_rhs_packed_size_qsi8d32p_qsi4c32p(size_t n, size_t k,
                                                   uint32_t idx_variant,
                                                   bool transB) {

--- a/nntrainer/tensor/half_tensor.cpp
+++ b/nntrainer/tensor/half_tensor.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <compute_ops.h>
+#include <cpu_backend.h>
 #include <half_tensor.h>
 #include <tensor.h>
 #include <util_func.h>
@@ -719,6 +720,42 @@ Tensor &HalfTensor::dot(Tensor const &input, Tensor &output, bool trans,
   case Tdatatype::Q6_K:
     dotQnK(input, output, trans, trans_in, beta, input.getDataType());
     break;
+#if (defined(__aarch64__) || defined(__ARM_ARCH_7A__) ||                       \
+     defined(__ANDROID__) || defined(__arm__) || defined(_M_ARM) ||            \
+     defined(_M_ARM64)) &&                                                     \
+  defined(__ARM_FEATURE_MATMUL_INT8)
+  case Tdatatype::QS4CX: {
+    // [KAI fp16 dispatch seam] Host fp16 GEMM for an upstream QS4CX weight —
+    // e.g. an lm_head (N = vocab) that exceeds the GPU image cap and falls
+    // back to host. The rhs is the qai8dxp4x8/qsi4cxp4x8-packed buffer built
+    // at load (QS4CXTensor::getPackedData); it is routed through the
+    // upstream KleidiAI f16 qai8dxp/qsi4cxp ukernel family (added by
+    // `308bdd4f3b` [kleidiai] Add `matmul_clamp_f16_qai8dxp_qsi4cxp`) via the
+    // packed<_FP16> facade, so no fp16<->fp32 cast pass over the LHS / DST.
+    // i8mm-gated because the facade is locked to the qai8dxp4x8/qsi4cxp4x8
+    // (nr=4 kr=16 sr=2) pack family — see arm_compute_backend_fp16.cpp.
+    //
+    // NOTE: the "is this weight already KAI-packed?" gate
+    // (isPackedF16Activation), the lazy plain-QS4CX -> KAI rhs assembly
+    // (Int4Utils::packPlainToSectionA / assembleKaiRhsPacked) and the x86
+    // reference-GEMM fallback are deferred to the QS4CX-FP16 host-FC infra
+    // track — they depend on the packF16Activation / Int4Utils body that is
+    // out of scope for this dispatch seam. This case assumes the weight was
+    // pre-packed at load by that track.
+    const unsigned int M = getDim().height();
+    const unsigned int K = getDim().width();
+    const unsigned int N = output.getDim().width();
+    const uint8_t *kai_rhs = input.getPackedData<uint8_t>();
+    _FP16 *data = (_FP16 *)getData();
+    _FP16 *rdata = output.getData<_FP16>();
+    const _FP16 lb = static_cast<_FP16>(-65504.0f);
+    const _FP16 ub = static_cast<_FP16>(65504.0f);
+    // transB=true: the KAI rhs-packed buffer is always row-major-as-transposed.
+    nntr_gemm_qai8dxp_qsi4cxp_packed<_FP16>(
+      M, N, K, (void *)data, (void *)kai_rhs, rdata, 3u, true, lb, ub);
+    break;
+  }
+#endif
   default:
     throw std::invalid_argument("Error: unsupported datatype");
   }

--- a/nntrainer/tensor/int4_utils.cpp
+++ b/nntrainer/tensor/int4_utils.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 #include "cpu_backend.h"
 #include "fp16.h"
@@ -180,6 +181,175 @@ int Int4Utils::convertInt4ToInt(const uint8_t int4_value) {
                          -8, -7, -6, -5, -4, -3, -2, -1};
 
   return lookup[int4_value];
+}
+
+void Int4Utils::quantizePlain(const float *weights, const size_t rows_count,
+                              const size_t columns_count,
+                              std::vector<uint8_t> &out_plain_nibbles,
+                              std::vector<uint16_t> &out_scales) {
+  std::vector<float> scales_fp32(rows_count);
+  out_scales.resize(rows_count);
+  for (size_t n = 0; n < rows_count; ++n) {
+    scales_fp32[n] =
+      computeScaleForGroup(weights + n * columns_count, columns_count);
+    out_scales[n] = compute_fp32_to_fp16(scales_fp32[n]);
+  }
+
+  // Build raw nibble matrix in N x roundup(K,2)/2 bytes. Each nibble holds
+  // uint4 = int4 + 8 (the rhs_zero_point=8 input form expected by
+  // kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0).
+  const size_t rhs_row_bytes = (columns_count + 1) / 2;
+  out_plain_nibbles.assign(rows_count * rhs_row_bytes, 0u);
+  for (size_t n = 0; n < rows_count; ++n) {
+    for (size_t k = 0; k < columns_count; k += 2) {
+      const uint8_t u0 =
+        quantizeToInt4(weights[n * columns_count + k], scales_fp32[n]);
+      uint8_t byte = (uint8_t)((u0 + 8) & 0x0F);
+      if (k + 1 < columns_count) {
+        const uint8_t u1 =
+          quantizeToInt4(weights[n * columns_count + k + 1], scales_fp32[n]);
+        byte |= (uint8_t)(((u1 + 8) & 0x0F) << 4);
+      } else {
+        byte |= (uint8_t)(8u << 4); // pad nibble = uint4(0)
+      }
+      out_plain_nibbles[n * rhs_row_bytes + (k / 2)] = byte;
+    }
+  }
+}
+
+void Int4Utils::packPlainToSectionA(const uint8_t *plain_nibbles,
+                                    size_t rows_count, size_t columns_count,
+                                    uint8_t *out_section_a) {
+  const uint8_t *raw_nibbles = plain_nibbles;
+  const size_t rhs_row_bytes = (columns_count + 1) / 2;
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  const size_t nibble_bytes_per_super_row = KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = KAI_KR / KAI_SR; // = 8
+  const uint8_t pad_byte = (uint8_t)(8u | (8u << 4));   // uint4(0)|uint4(0)
+
+  for (size_t dst_row_idx = 0; dst_row_idx < super_row_count; ++dst_row_idx) {
+    uint8_t *dst_row = out_section_a + dst_row_idx * nibble_bytes_per_super_row;
+
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t block_byte_idx = dst_byte_idx % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / KAI_NR;
+      const size_t nr_idx = block_idx % KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         KAI_K_INTERLEAVE) *
+        KAI_K_INTERLEAVE;
+      const size_t k0_idx =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1_idx = k0_idx + KAI_K_INTERLEAVE;
+      const size_t n0_idx = dst_row_idx * KAI_NR + nr_idx;
+      const size_t n0_valid_idx =
+        (n0_idx < rows_count) ? n0_idx : (rows_count - 1);
+
+      uint8_t byte0 = pad_byte;
+      uint8_t byte1 = pad_byte;
+      if (k0_idx < columns_count) {
+        byte0 = raw_nibbles[n0_valid_idx * rhs_row_bytes + (k0_idx / 2)];
+      }
+      if (k1_idx < columns_count) {
+        byte1 = raw_nibbles[n0_valid_idx * rhs_row_bytes + (k1_idx / 2)];
+      }
+      const size_t shift_right_x0 = (k0_idx % 2) * 4;
+      const size_t shift_right_x1 = (k1_idx % 2) * 4;
+      const uint8_t src_x0_lo = (uint8_t)((byte0 >> shift_right_x0) & 0x0F);
+      const uint8_t src_x0_hi = (uint8_t)((byte1 >> shift_right_x1) & 0x0F);
+      const uint8_t dst_qs0 = (uint8_t)(src_x0_lo | (src_x0_hi << 4));
+      *dst_row = (uint8_t)(dst_qs0 ^ 0x88);
+      ++dst_row;
+    }
+  }
+}
+
+void Int4Utils::quantizeAndPackKai(const float *weights,
+                                   const size_t rows_count,
+                                   const size_t columns_count,
+                                   std::vector<uint8_t> &out_weights,
+                                   std::vector<uint16_t> &out_scales) {
+  std::vector<uint8_t> plain_nibbles;
+  quantizePlain(weights, rows_count, columns_count, plain_nibbles, out_scales);
+  out_weights.assign(kaiNibblePayloadBytes(rows_count, columns_count), 0u);
+  packPlainToSectionA(plain_nibbles.data(), rows_count, columns_count,
+                      out_weights.data());
+}
+
+size_t Int4Utils::kaiNibblePayloadBytes(size_t rows_count,
+                                        size_t columns_count) {
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  return super_row_count * KAI_NR * (k_internal / 2);
+}
+
+void Int4Utils::assembleKaiRhsPacked(const uint8_t *section_a,
+                                     const uint16_t *fp16_scales,
+                                     size_t rows_count, size_t columns_count,
+                                     std::vector<uint8_t> &out_kai_packed) {
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  const size_t nibble_bytes_per_super_row = KAI_NR * (k_internal / 2);
+  const size_t trailer_bytes_per_super_row = KAI_NR * (4 + 4 + 4);
+  const size_t super_row_stride =
+    nibble_bytes_per_super_row + trailer_bytes_per_super_row;
+
+  out_kai_packed.assign(super_row_count * super_row_stride, 0u);
+
+  const size_t block_length_in_bytes = KAI_KR / KAI_SR; // = 8
+
+  for (size_t sr_idx = 0; sr_idx < super_row_count; ++sr_idx) {
+    uint8_t *dst_row = out_kai_packed.data() + sr_idx * super_row_stride;
+    const uint8_t *src_row = section_a + sr_idx * nibble_bytes_per_super_row;
+
+    // Nibbles are byte-identical to Section A on disk — just copy them.
+    std::memcpy(dst_row, src_row, nibble_bytes_per_super_row);
+
+    // Per-channel sums = sum_k int4[n][k] * 16. Decode each Section A byte
+    // back to two int4 lanes via XOR 0x88 -> uint4 -> int4 = uint4 - 8.
+    int32_t sums[KAI_NR] = {0, 0, 0, 0};
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t nr_idx = block_idx % KAI_NR;
+
+      const uint8_t stored = src_row[dst_byte_idx] ^ 0x88;
+      const int u_lo = stored & 0x0F;
+      const int u_hi = (stored >> 4) & 0x0F;
+      // Both nibbles belong to the same n0 (= sr_idx * KAI_NR + nr_idx) —
+      // the K interleave shuffles k0/k1 within the same channel.
+      sums[nr_idx] += (u_lo - 8) + (u_hi - 8);
+    }
+
+    int32_t *sums_dst = (int32_t *)(dst_row + nibble_bytes_per_super_row);
+    for (size_t i = 0; i < KAI_NR; ++i) {
+      sums_dst[i] = sums[i] * 16;
+    }
+
+    // Scales: per-channel fp16 -> fp32 -> baked × 0.0625 (matches KAI
+    // packer line 212).
+    float *scales_dst = (float *)(dst_row + nibble_bytes_per_super_row +
+                                  KAI_NR * sizeof(int32_t));
+    for (size_t i = 0; i < KAI_NR; ++i) {
+      const size_t n_idx = std::min(sr_idx * KAI_NR + i, rows_count - 1);
+      const float s = compute_fp16_to_fp32(fp16_scales[n_idx]);
+      scales_dst[i] = s * 0.0625F;
+    }
+
+    // Bias: always zero for FC int4 weights — the bias tensor (if any) is
+    // a separate FP16 weight that the layer adds outside this matmul.
+    // 4 floats already memset to 0 by assign(.., 0u).
+  }
 }
 
 void Int4Utils::dequantizePacked(const std::vector<uint8_t> &weights,

--- a/nntrainer/tensor/int4_utils.cpp
+++ b/nntrainer/tensor/int4_utils.cpp
@@ -17,6 +17,7 @@
 #include "cpu_backend.h"
 #include "fp16.h"
 #include "nntrainer_error.h"
+#include "quantizer.h"
 #include "util_func.h"
 
 namespace nntrainer {
@@ -289,6 +290,146 @@ size_t Int4Utils::kaiNibblePayloadBytes(size_t rows_count,
     KAI_K_PAD_MULTIPLE;
   const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
   return super_row_count * KAI_NR * (k_internal / 2);
+}
+
+size_t Int4Utils::plainNibbleBytes(size_t rows_count, size_t columns_count) {
+  return rows_count * ((columns_count + 1) / 2);
+}
+
+size_t Int4Utils::plainScalesOffsetBytes(size_t rows_count,
+                                         size_t columns_count) {
+  // Mirrors the PR#3978 writer/reader expression `N * (K + 1) / 2` exactly
+  // (left-to-right integer math) -- for even K this lands N/2 bytes past the
+  // nibble end, leaving a zero gap that is part of the on-disk format.
+  return rows_count * (columns_count + 1) / 2;
+}
+
+size_t Int4Utils::plainRecordPayloadBytes(size_t rows_count,
+                                          size_t columns_count) {
+  // kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 for the PR
+  // writer's idx_variant=8 kernel: nr=8, k rounded up to 32, and a 12-byte
+  // per-channel trailer slot (fp32 sum + fp32 scale + fp32 bias).
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t n_rounded =
+    ((rows_count + PLAIN_KAI_NR - 1) / PLAIN_KAI_NR) * PLAIN_KAI_NR;
+  return n_rounded * (k_internal / 2 + 12);
+}
+
+void Int4Utils::sectionAToPlain(const uint8_t *section_a, size_t rows_count,
+                                size_t columns_count,
+                                uint8_t *out_plain_nibbles) {
+  // Exact inverse of packPlainToSectionA: walk the same Section A super-row /
+  // block iteration, un-XOR 0x88, and scatter each recovered nibble back to
+  // its plain [n][k] position. Padding entries (n >= rows_count,
+  // k >= columns_count) come from clamped / pad reads in the forward and carry
+  // no unique data, so they are skipped. A valid plain nibble may be produced
+  // by more than one Section A byte (the forward reads it as both a k0 and a
+  // k1); every such copy holds the same value, so writing with |= over a
+  // zeroed buffer is idempotent and reproduces the plain layout byte-for-byte.
+  const size_t rhs_row_bytes = (columns_count + 1) / 2;
+  std::memset(out_plain_nibbles, 0, rows_count * rhs_row_bytes);
+
+  const size_t k_internal =
+    ((columns_count + KAI_K_PAD_MULTIPLE - 1) / KAI_K_PAD_MULTIPLE) *
+    KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count = (rows_count + KAI_NR - 1) / KAI_NR;
+  const size_t nibble_bytes_per_super_row = KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = KAI_KR / KAI_SR; // = 8
+
+  for (size_t dst_row_idx = 0; dst_row_idx < super_row_count; ++dst_row_idx) {
+    const uint8_t *src_row =
+      section_a + dst_row_idx * nibble_bytes_per_super_row;
+
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t block_byte_idx = dst_byte_idx % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / KAI_NR;
+      const size_t nr_idx = block_idx % KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         KAI_K_INTERLEAVE) *
+        KAI_K_INTERLEAVE;
+      const size_t k0_idx =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1_idx = k0_idx + KAI_K_INTERLEAVE;
+      const size_t n0_idx = dst_row_idx * KAI_NR + nr_idx;
+
+      if (n0_idx >= rows_count)
+        continue; // padding super-row (clamped in the forward)
+
+      const uint8_t qs0 = (uint8_t)(src_row[dst_byte_idx] ^ 0x88);
+      // nibble at (n0,k0)
+      const uint8_t src_x0_lo = (uint8_t)(qs0 & 0x0F);
+      // nibble at (n0,k1)
+      const uint8_t src_x0_hi = (uint8_t)((qs0 >> 4) & 0x0F);
+
+      if (k0_idx < columns_count) {
+        const size_t bi = n0_idx * rhs_row_bytes + (k0_idx / 2);
+        out_plain_nibbles[bi] |= (uint8_t)(src_x0_lo << ((k0_idx % 2) * 4));
+      }
+      if (k1_idx < columns_count) {
+        const size_t bi = n0_idx * rhs_row_bytes + (k1_idx / 2);
+        out_plain_nibbles[bi] |= (uint8_t)(src_x0_hi << ((k1_idx % 2) * 4));
+      }
+    }
+  }
+}
+
+void Int4Utils::readLegacyQint4RecordToQs4cx(
+  const uint8_t *record, size_t record_bytes, size_t rows_count,
+  size_t columns_count, uint8_t *out_plain_nibbles, float *out_fp32_scales) {
+  const size_t N = rows_count;
+  const size_t K = columns_count;
+  const size_t hdr = sizeof(uint16_t);
+
+  NNTR_THROW_IF(record_bytes < hdr, std::runtime_error)
+    << "[readLegacyQint4RecordToQs4cx] record too small for qscheme header";
+
+  uint16_t scheme = 0;
+  std::memcpy(&scheme, record, hdr);
+  const uint8_t *body = record + hdr;
+
+  if (scheme == static_cast<uint16_t>(QScheme::KAI_QSI4CXP_4x4x32)) {
+    // 0x06: Section A nibbles + per-channel fp16 scales.
+    const size_t nib = kaiNibblePayloadBytes(N, K);
+    NNTR_THROW_IF(record_bytes < hdr + nib + N * sizeof(uint16_t),
+                  std::runtime_error)
+      << "[readLegacyQint4RecordToQs4cx] Section A record truncated: have "
+      << record_bytes << " need " << (hdr + nib + N * sizeof(uint16_t));
+    // Lossless re-layout of the int4 values.
+    sectionAToPlain(body, N, K, out_plain_nibbles);
+    // Exact fp16 -> fp32 widening of the per-channel scales.
+    const uint8_t *scale_src = body + nib;
+    for (size_t n = 0; n < N; ++n) {
+      uint16_t h;
+      std::memcpy(&h, scale_src + n * sizeof(uint16_t), sizeof(uint16_t));
+      out_fp32_scales[n] = compute_fp16_to_fp32(h);
+    }
+  } else if (scheme == static_cast<uint16_t>(QScheme::PER_CHANNEL_AFFINE)) {
+    // 0x01: PR#3978 plain container (padded plain nibbles + fp32 scales).
+    const size_t pay = plainRecordPayloadBytes(N, K);
+    NNTR_THROW_IF(record_bytes < hdr + pay, std::runtime_error)
+      << "[readLegacyQint4RecordToQs4cx] plain-container record truncated: "
+         "have "
+      << record_bytes << " need " << (hdr + pay);
+    // Normalize the padded plain nibbles to the canonical (unpadded) plain
+    // layout by round-tripping through Section A (drops the KAI nr=8 / K->32
+    // padding); both directions are lossless int4 re-layouts.
+    std::vector<uint8_t> sec_a(kaiNibblePayloadBytes(N, K));
+    packPlainToSectionA(body, N, K, sec_a.data());
+    sectionAToPlain(sec_a.data(), N, K, out_plain_nibbles);
+    // The plain container already stores fp32 scales -- copy verbatim.
+    std::memcpy(out_fp32_scales, body + plainScalesOffsetBytes(N, K),
+                N * sizeof(float));
+  } else {
+    NNTR_THROW_IF(true, std::runtime_error)
+      << "[readLegacyQint4RecordToQs4cx] unsupported on-disk qscheme 0x"
+      << std::hex << scheme << std::dec << " (N=" << N << " K=" << K << ")";
+  }
 }
 
 void Int4Utils::assembleKaiRhsPacked(const uint8_t *section_a,

--- a/nntrainer/tensor/int4_utils.h
+++ b/nntrainer/tensor/int4_utils.h
@@ -152,6 +152,74 @@ public:
   static size_t kaiNibblePayloadBytes(size_t rows_count, size_t columns_count);
 
   /**
+   * @brief Shared plain int4 container (engine-neutral, byte-compatible with
+   *        the upstream PR#3978 writer/reader):
+   *        record = [u16 qscheme = PER_CHANNEL_AFFINE (0x01)]
+   *                 [N x ceil(K/2) plain nibbles, row-major; even k in the
+   *                  low nibble; each stored uint4 = int4 + 8]
+   *                 [N fp32 per-channel scales at byte offset (N*(K+1))/2
+   *                  -- the PR writer/reader expression, which for even K
+   *                  leaves an N/2-byte zero gap after the nibbles]
+   *                 [zero pad to plainRecordPayloadBytes]
+   *        The pad mirrors the PR writer's KAI packed size for its
+   *        idx_variant=8 micro-kernel (nr=8) -- NOT the 4x4x32 (nr=4) family
+   *        above -- because the disk record must stay byte-identical to
+   *        PR#3978.
+   */
+  static constexpr const size_t PLAIN_KAI_NR = 8;
+
+  /// @brief Bytes of the plain nibble matrix: N * ceil(K/2).
+  static size_t plainNibbleBytes(size_t rows_count, size_t columns_count);
+
+  /// @brief Byte offset of the fp32 scales inside the plain payload.
+  static size_t plainScalesOffsetBytes(size_t rows_count, size_t columns_count);
+
+  /// @brief Full plain payload size (excluding the u16 qscheme header):
+  ///        ceil(N/8)*8 * (roundup(K,32)/2 + 12).
+  static size_t plainRecordPayloadBytes(size_t rows_count,
+                                        size_t columns_count);
+
+  /**
+   * @brief LOSSLESS inverse of packPlainToSectionA: de-permute a KAI Section A
+   *        nibble payload back into plain row-major
+   *        [rows_count(N)][ceil(K/2)] nibbles (uint4 = int4+8, no XOR),
+   *        byte-identical to the plain form that produced it. It does NOT
+   *        touch scales or dequantize -- it only re-lays-out the int4
+   *        nibbles, so a Section A weight becomes the canonical plain nibble
+   *        layout with its exact original values preserved.
+   * @param out_plain_nibbles caller-provided buffer of
+   *        plainNibbleBytes(rows_count, columns_count) bytes
+   */
+  static void sectionAToPlain(const uint8_t *section_a, size_t rows_count,
+                              size_t columns_count, uint8_t *out_plain_nibbles);
+
+  /**
+   * @brief Standalone reader for a legacy on-disk int4 weight record (the
+   *        deprecated QINT4 dtype) that materialises it in the canonical
+   *        QS4CX in-memory layout: plain nibbles + per-channel fp32 scales.
+   *
+   * Both recognised containers are handled, keyed off the record's u16
+   * qscheme header:
+   *  - 0x06 (KAI_QSI4CXP_4x4x32): Section A nibbles + per-channel fp16
+   *    scales. Nibbles are re-laid-out by sectionAToPlain and the scales are
+   *    widened fp16 -> fp32 (exact).
+   *  - 0x01 (PER_CHANNEL_AFFINE): the PR#3978 plain container. Its padded
+   *    nibbles are normalised to the canonical unpadded plain layout and its
+   *    fp32 scales are copied verbatim.
+   * Both paths are lossless in the int4 values and in the scale magnitudes.
+   *
+   * @param record            whole record, starting at the u16 qscheme header
+   * @param record_bytes      readable bytes at @a record (bounds-checked)
+   * @param rows_count        N (output channels)
+   * @param columns_count     K (input channels)
+   * @param out_plain_nibbles buffer of plainNibbleBytes(N, K) bytes
+   * @param out_fp32_scales   buffer of N floats
+   */
+  static void readLegacyQint4RecordToQs4cx(
+    const uint8_t *record, size_t record_bytes, size_t rows_count,
+    size_t columns_count, uint8_t *out_plain_nibbles, float *out_fp32_scales);
+
+  /**
    * @brief Reassemble Section A nibbles (quantizeAndPackKai's output) +
    *        per-channel fp16 scales into a full KAI rhs_packed buffer, ready
    *        for the qai8dxp_qsi4cxp matmul micro-kernels. Per super-row of

--- a/nntrainer/tensor/int4_utils.h
+++ b/nntrainer/tensor/int4_utils.h
@@ -30,6 +30,16 @@ public:
   /// @brief Numbers of element in one byte of date in the osv32_isv2 layout
   static constexpr const size_t COLUMN_BLOCK_SIZE = 2;
 
+  /// @brief KAI qsi4cxp packing constants for the {nr=4, kr=16, sr=2}
+  ///        qai8dxp/qsi4cxp pack family (matmul_clamp_f32_qai8dxp4x8_
+  ///        qsi4cxp4x8_4x4x32_neon_i8mm and the fp16 16x4 variant share this
+  ///        family, so one rhs_packed buffer serves both).
+  static constexpr const size_t KAI_NR = 4;
+  static constexpr const size_t KAI_KR = 16;
+  static constexpr const size_t KAI_SR = 2;
+  static constexpr const size_t KAI_K_INTERLEAVE = 16;
+  static constexpr const size_t KAI_K_PAD_MULTIPLE = 32;
+
   /**
    * @brief     Compute scale for input weights
    * @param[in] group_weights float * inout vector of weights
@@ -88,6 +98,80 @@ public:
                                 const size_t group_size,
                                 std::vector<uint8_t> &out_weights,
                                 std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Quantize float* matrix into the plain per-channel int4 nibble
+   *        form: N x ceil(K/2) bytes, row-major, even k in the low nibble,
+   *        each stored uint4 = int4 + 8. Scale is per-channel absmax/7
+   *        (the same formula quantizeToInt4 expects). This is stage 1 of
+   *        quantizeAndPackKai.
+   * @param out_plain_nibbles N x ceil(K/2) bytes, row-major
+   * @param out_scales per-channel fp16 scales, size = rows_count
+   */
+  static void quantizePlain(const float *weights, const size_t rows_count,
+                            const size_t columns_count,
+                            std::vector<uint8_t> &out_plain_nibbles,
+                            std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Permute plain per-channel int4 nibbles (quantizePlain's output)
+   *        into the KAI qsi4cxp Section A super-row payload: mirrors the
+   *        rhs_zero_point=8 path of kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0
+   *        (nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/) with
+   *        the trailer (sums, scales, bias) elided — assembleKaiRhsPacked
+   *        reconstructs that separately. This is stage 2 of
+   *        quantizeAndPackKai.
+   * @param out_section_a caller-provided buffer of
+   *        kaiNibblePayloadBytes(rows_count, columns_count) bytes
+   */
+  static void packPlainToSectionA(const uint8_t *plain_nibbles,
+                                  size_t rows_count, size_t columns_count,
+                                  uint8_t *out_section_a);
+
+  /**
+   * @brief Quantize float* matrix into KAI qsi4cxp Section A nibble payload
+   *        (quantizePlain + packPlainToSectionA combined). No sums/scales/
+   *        bias trailer is written — assembleKaiRhsPacked reassembles that
+   *        at load time from the nibbles + per-channel scales this emits.
+   * @param weights float * input matrix (rows_count x columns_count)
+   * @param rows_count N (output channels)
+   * @param columns_count K (input channels)
+   * @param out_weights output nibble payload, size
+   *        = ceil(N/KAI_NR) * KAI_NR * (roundup(K, KAI_K_PAD_MULTIPLE) / 2)
+   * @param out_scales output per-channel fp16 scales, size = rows_count
+   */
+  static void quantizeAndPackKai(const float *weights, const size_t rows_count,
+                                 const size_t columns_count,
+                                 std::vector<uint8_t> &out_weights,
+                                 std::vector<uint16_t> &out_scales);
+
+  /**
+   * @brief Convenience: byte size of the KAI Section A nibble payload for
+   *        the given (N, K) shape.
+   */
+  static size_t kaiNibblePayloadBytes(size_t rows_count, size_t columns_count);
+
+  /**
+   * @brief Reassemble Section A nibbles (quantizeAndPackKai's output) +
+   *        per-channel fp16 scales into a full KAI rhs_packed buffer, ready
+   *        for the qai8dxp_qsi4cxp matmul micro-kernels. Per super-row of
+   *        nr=4 output channels the layout is
+   *          [nibbles : 4*(k_internal/2) bytes (copied as-is)]
+   *          [sums    : 4 * int32, each = sum_k int4[n][k] * 16]
+   *          [scales  : 4 * fp32,  each = (fp16->fp32 scale) * 0.0625]
+   *          [bias    : 4 * fp32 = 0]
+   *
+   * @param section_a       nibble payload; size must be
+   *                        kaiNibblePayloadBytes(rows_count, columns_count).
+   * @param fp16_scales     per-output-channel fp16 scales, size N.
+   * @param rows_count      N (output channels). Must be a multiple of 4.
+   * @param columns_count   K (input channels). Must be a multiple of 32.
+   * @param out_kai_packed  output buffer, sized by this function.
+   */
+  static void assembleKaiRhsPacked(const uint8_t *section_a,
+                                   const uint16_t *fp16_scales,
+                                   size_t rows_count, size_t columns_count,
+                                   std::vector<uint8_t> &out_kai_packed);
 
   /**
    * @brief     Quantize one float value to 4-bits integer

--- a/nntrainer/tensor/qs4cx_tensor.cpp
+++ b/nntrainer/tensor/qs4cx_tensor.cpp
@@ -9,10 +9,60 @@
  */
 
 #include <cpu_backend.h>
+#include <cstdlib>
 #include <qs4cx_tensor.h>
 #include <tensor.h>
 
 namespace nntrainer {
+
+namespace {
+/**
+ * @brief VALUE-checked env truthiness: set, non-empty, and not starting with
+ *   '0', so that NNTR_QS4CX_ALLOC_ZERO=0 really is "off" rather than "present,
+ *   therefore on". Kept file-local on purpose: this translation unit must
+ *   compile against a tree that ships no shared env helper, and a header that
+ *   only this file would consume does not belong in the public include set.
+ */
+bool envOn(const char *name) {
+  const char *e = std::getenv(name);
+  return e != nullptr && e[0] != '\0' && e[0] != '0';
+}
+
+/**
+ * @brief [init-latency L1] Is this process's QS4CX payload allocation
+ *   load-destined, i.e. may allocate() hand back UNINITIALIZED memory?
+ *
+ * NNTR_QS4CX_HEAP_BYPASS is exactly the "self-owned weight payload about to be
+ * filled from the model file" signal: Manager::requestWeights only takes the
+ * bypass branch (weight_pool.request(UNMANAGED) + var->allocate()) under it,
+ * and every QS4CX tensor reached that way is a weight (the only other producer
+ * is the offline quantize tool, which never sets this env). Both zero passes
+ * that allocate() used to do -- `new uint8_t[size()]{}` and
+ * initialize()->setZero() -- are dead stores there: the payload is
+ * subsequently overwritten IN FULL, either by TensorBase::read (bytes() ==
+ * size() for QS4CX, since its data-type size is 1 and size() is overridden to
+ * the packed nibble+scale byte count) or by copy_qs4cx (scopy over size()).
+ *
+ * TRIPWIRE FOR FUTURE READERS. "Uninitialized is safe" holds only while EVERY
+ * reader of this payload writes all size() bytes. It is true of every reader in
+ * this tree today (TensorBase::read and copy_qs4cx, both above). It is NOT
+ * automatically true of a partial writer, and one such reader exists in the
+ * sibling trees: the legacy on-disk QINT4 -> QS4CX transcode. There, for even
+ * K, the QS4CX scale offset is `N*(K+1)/2` evaluated left-to-right
+ * (= N*K/2 + N/2) while the nibble region is only N*(K/2) bytes, so an
+ * N/2-byte gap sits between them that the transcode never touches; it used to
+ * be zero purely by virtue of the allocation. If that read path (or any other
+ * partial writer) is ever added here, it MUST call setZero() before
+ * transcoding, or the gap becomes uninitialized heap.
+ *
+ * Escape hatch: NNTR_QS4CX_ALLOC_ZERO=1 restores the old double zero-fill.
+ */
+bool qs4cxAllocUninitialized() {
+  static const bool v =
+    envOn("NNTR_QS4CX_HEAP_BYPASS") && !envOn("NNTR_QS4CX_ALLOC_ZERO");
+  return v;
+}
+} // namespace
 
 QS4CX_Tensor::QS4CX_Tensor(std::string name_, Tformat fm) :
   TensorBase(name_, fm) {
@@ -47,14 +97,23 @@ void QS4CX_Tensor::allocate() {
   } else {
     MemoryData *mem_data;
 
-    mem_data = new MemoryData((void *)(new uint8_t[size()]{}));
+    // [init-latency L1] Load-destined payload: allocate UNINITIALIZED and skip
+    // initialize(). See qs4cxAllocUninitialized() for why both zero passes are
+    // dead stores. The page faults are NOT saved -- they move to the read()
+    // that fills the buffer -- but the two full-arena writes are.
+    const bool uninit = qs4cxAllocUninitialized();
+    mem_data = new MemoryData(uninit ? (void *)(new uint8_t[size()])
+                                     : (void *)(new uint8_t[size()]{}));
     data = std::shared_ptr<MemoryData>(mem_data, [](auto *mem_data) {
       delete[] mem_data->template getAddr<uint8_t>();
       delete mem_data;
     });
 
     offset = 0;
-    initialize();
+    if (uninit)
+      putData();
+    else
+      initialize();
   }
 }
 

--- a/nntrainer/tensor/qs4cx_tensor.cpp
+++ b/nntrainer/tensor/qs4cx_tensor.cpp
@@ -13,6 +13,14 @@
 #include <qs4cx_tensor.h>
 #include <tensor.h>
 
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <vector>
+
+#include <int4_utils.h>
+#include <util_func.h>
+
 namespace nntrainer {
 
 namespace {
@@ -26,6 +34,50 @@ namespace {
 bool envOn(const char *name) {
   const char *e = std::getenv(name);
   return e != nullptr && e[0] != '\0' && e[0] != '0';
+}
+
+/**
+ * @brief Read a legacy on-disk int4 record (u16 qscheme header + KAI Section A
+ *   or plain container) via @a do_read and transcode it losslessly to the
+ *   canonical QS4CX in-memory layout (plain nibbles + fp32 scales). Shared by
+ *   the std::ifstream and ReadSource read() overloads.
+ */
+void readLegacyQint4ToQs4cx(
+  size_t N, size_t K, size_t start_offset,
+  const std::function<void(char *, std::streamsize, size_t)> &do_read,
+  uint8_t *out_nibbles, float *out_scales) {
+  uint16_t scheme = 0;
+  do_read(reinterpret_cast<char *>(&scheme), sizeof(uint16_t), start_offset);
+
+  size_t body_bytes;
+  if (scheme == static_cast<uint16_t>(QScheme::KAI_QSI4CXP_4x4x32))
+    body_bytes = Int4Utils::kaiNibblePayloadBytes(N, K) + N * sizeof(uint16_t);
+  else if (scheme == static_cast<uint16_t>(QScheme::PER_CHANNEL_AFFINE))
+    body_bytes = Int4Utils::plainRecordPayloadBytes(N, K);
+  else
+    throw std::runtime_error(
+      "[QS4CX_Tensor::read] unsupported legacy on-disk qscheme");
+
+  std::vector<uint8_t> record(sizeof(uint16_t) + body_bytes);
+  std::memcpy(record.data(), &scheme, sizeof(uint16_t));
+  do_read(reinterpret_cast<char *>(record.data()) + sizeof(uint16_t),
+          static_cast<std::streamsize>(body_bytes),
+          start_offset + sizeof(uint16_t));
+
+  // The transcode is a PARTIAL writer of the payload: it fills
+  // plainNibbleBytes() = N*ceil(K/2) nibble bytes and the N fp32 scales at
+  // plainScalesOffsetBytes() = N*(K+1)/2, so for even K an N/2-byte gap
+  // between them is never written. That gap is part of the on-disk plain form
+  // and must read as zero, which the allocation no longer guarantees (see the
+  // "TRIPWIRE FOR FUTURE READERS" note above qs4cxAllocUninitialized()). Zero
+  // it explicitly instead of relying on the allocator.
+  const size_t nib = Int4Utils::plainNibbleBytes(N, K);
+  const size_t scales_off = Int4Utils::plainScalesOffsetBytes(N, K);
+  if (scales_off > nib)
+    std::memset(out_nibbles + nib, 0, scales_off - nib);
+
+  Int4Utils::readLegacyQint4RecordToQs4cx(record.data(), record.size(), N, K,
+                                          out_nibbles, out_scales);
 }
 
 /**
@@ -44,16 +96,14 @@ bool envOn(const char *name) {
  * the packed nibble+scale byte count) or by copy_qs4cx (scopy over size()).
  *
  * TRIPWIRE FOR FUTURE READERS. "Uninitialized is safe" holds only while EVERY
- * reader of this payload writes all size() bytes. It is true of every reader in
- * this tree today (TensorBase::read and copy_qs4cx, both above). It is NOT
- * automatically true of a partial writer, and one such reader exists in the
- * sibling trees: the legacy on-disk QINT4 -> QS4CX transcode. There, for even
- * K, the QS4CX scale offset is `N*(K+1)/2` evaluated left-to-right
- * (= N*K/2 + N/2) while the nibble region is only N*(K/2) bytes, so an
- * N/2-byte gap sits between them that the transcode never touches; it used to
- * be zero purely by virtue of the allocation. If that read path (or any other
- * partial writer) is ever added here, it MUST call setZero() before
- * transcoding, or the gap becomes uninitialized heap.
+ * reader of this payload writes all size() bytes. TensorBase::read and
+ * copy_qs4cx (both above) do. The legacy on-disk QINT4 -> QS4CX transcode
+ * (readLegacyQint4ToQs4cx, above) does NOT: for even K the QS4CX scale offset
+ * is `N*(K+1)/2` evaluated left-to-right (= N*K/2 + N/2) while the nibble
+ * region is only N*(K/2) bytes, so an N/2-byte gap sits between them that the
+ * transcode never touches. That reader therefore zeroes the gap itself instead
+ * of relying on the allocation. Any further partial writer added here must do
+ * the same, or the gap becomes uninitialized heap.
  *
  * Escape hatch: NNTR_QS4CX_ALLOC_ZERO=1 restores the old double zero-fill.
  */
@@ -205,5 +255,43 @@ void QS4CX_Tensor::print(std::ostream &out) const {
 }
 
 QScheme QS4CX_Tensor::q_scheme() const { return QScheme::QS4CX; }
+
+void QS4CX_Tensor::read(std::ifstream &file, size_t start_offset,
+                        bool read_from_offset) {
+  if (start_offset == std::numeric_limits<size_t>::max())
+    start_offset = file_offset;
+  if (!isOnDiskLegacyQint4()) {
+    TensorBase::read(file, start_offset, read_from_offset);
+    return;
+  }
+  readLegacyQint4ToQs4cx(
+    width(), height(), start_offset,
+    [&](char *dst, std::streamsize n, size_t off) {
+      checkedRead(file, dst, n, "[QS4CX_Tensor::read] legacy QINT4 read failed",
+                  off, read_from_offset);
+    },
+    reinterpret_cast<uint8_t *>(getData()),
+    reinterpret_cast<float *>(getScale()));
+  putData();
+}
+
+void QS4CX_Tensor::read(ReadSource src, size_t start_offset,
+                        bool read_from_offset) {
+  if (start_offset == std::numeric_limits<size_t>::max())
+    start_offset = file_offset;
+  if (!isOnDiskLegacyQint4()) {
+    TensorBase::read(src, start_offset, read_from_offset);
+    return;
+  }
+  readLegacyQint4ToQs4cx(
+    width(), height(), start_offset,
+    [&](char *dst, std::streamsize n, size_t off) {
+      checkedRead(src, dst, n, "[QS4CX_Tensor::read] legacy QINT4 read failed",
+                  off, read_from_offset);
+    },
+    reinterpret_cast<uint8_t *>(getData()),
+    reinterpret_cast<float *>(getScale()));
+  putData();
+}
 
 } // namespace nntrainer

--- a/nntrainer/tensor/qs4cx_tensor.h
+++ b/nntrainer/tensor/qs4cx_tensor.h
@@ -214,6 +214,23 @@ public:
    */
   void pack() override;
 
+  /**
+   * @copydoc Tensor::read(std::ifstream &file, size_t, bool)
+   * @note When this tensor is flagged on-disk-legacy-QINT4
+   *   (setOnDiskLegacyQint4), the record is a legacy QINT4 (u16 header + KAI
+   *   Section A / plain container) and is transcoded losslessly to the QS4CX
+   *   in-memory layout via Int4Utils::readLegacyQint4RecordToQs4cx; otherwise a
+   *   plain TensorBase::read.
+   */
+  void read(std::ifstream &file, size_t start_offset = 0,
+            bool read_from_offset = false) override;
+
+  /**
+   * @copydoc Tensor::read(ReadSource, size_t, bool)
+   */
+  void read(ReadSource src, size_t start_offset = 0,
+            bool read_from_offset = false) override;
+
 private:
   /**
    * @brief copy a buffer to @a this, the caller has to ensure that @a this is

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -37,6 +37,14 @@ enum class QScheme : uint16_t {
   Q4_Kx8 = 0x03,
   Q6_K = 0x4,
   Q4_0 = 0x5,
+  /**
+   * @brief KAI qsi4cxp nibble Section A layout (nr=4, kr=16, sr=2), per-
+   * output-channel fp16 scale, no group. Written by the legacy QINT4 saver and
+   * consumed by Int4Utils::readLegacyQint4RecordToQs4cx. Same KleidiAI qsi4cxp
+   * scheme as QS4CX (both 0x6 = aliases); both names are kept because on-disk
+   * records carry this one.
+   */
+  KAI_QSI4CXP_4x4x32 = 0x06,
   QS4CX = 0x6,
   /** this is for custom use */
   CUSTOM_QUANTIZER_01 = 0x10,

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -1598,6 +1598,8 @@ void Tensor::setFileOffset(const size_t file_offset) {
 
 size_t Tensor::getFileOffset() const { return itensor_->getFileOffset(); }
 
+void Tensor::setOnDiskLegacyQint4(bool v) { itensor_->setOnDiskLegacyQint4(v); }
+
 void Tensor::setName(const std::string &name_) { itensor_->setName(name_); }
 
 const std::string &Tensor::getName() const { return itensor_->getName(); }

--- a/nntrainer/tensor/tensor.h
+++ b/nntrainer/tensor/tensor.h
@@ -1863,6 +1863,11 @@ public:
   void setFileOffset(size_t file_offset);
 
   /**
+   * @copydoc TensorBase::setOnDiskLegacyQint4(bool)
+   */
+  void setOnDiskLegacyQint4(bool v);
+
+  /**
    * @brief     get FileOffset of Tensor
    * @return    size_t fileOffset
    */

--- a/nntrainer/tensor/tensor_base.h
+++ b/nntrainer/tensor/tensor_base.h
@@ -685,6 +685,20 @@ public:
   void setFileOffset(size_t off);
 
   /**
+   * @brief Mark that this tensor's on-disk bytes are a legacy QINT4 record
+   *        (u16 qscheme header + KAI Section A / plain container) that must be
+   *        transcoded losslessly to the canonical QS4CX in-memory layout on
+   *        read. Set by NeuralNetwork::load for QS4CX weights of a legacy
+   *        ("QINT4-*" model_tensor_type) model.
+   */
+  void setOnDiskLegacyQint4(bool v) { on_disk_legacy_qint4_ = v; }
+
+  /**
+   * @brief Whether this tensor's on-disk bytes are a legacy QINT4 record.
+   */
+  bool isOnDiskLegacyQint4() const { return on_disk_legacy_qint4_; }
+
+  /**
    * @brief     set Tensor Dim
    * @param[in] d TensorDim
    * @note      Throws std::invalid_argument if size mismatch
@@ -912,6 +926,8 @@ protected:
   std::shared_ptr<ContextData> ct_data_; /**< per-Context dispatch table */
   size_t offset;
   size_t file_offset; /**< offset of the tensor in the file */
+  bool on_disk_legacy_qint4_ =
+    false; /**< on-disk bytes are a legacy QINT4 record to transcode to QS4CX */
 
   /**<
    * When using shared_data with tensor, this stores the ptr of the source

--- a/test/meson.build
+++ b/test/meson.build
@@ -46,6 +46,49 @@ nntrainer_test_main_deps = [
   nntrainer_testutil_dep
 ]
 
+# KAI qai8dxp/qsi4cxp int4 packing sanity checks (standalone: no gtest, own
+# main()). ARM-only: they link the KleidiAI reference packer/matmul sources
+# under nntrainer/tensor/cpu_backend/arm/, which meson only compiles into
+# nntrainer_dep for aarch64/arm/android builds (see
+# nntrainer/tensor/cpu_backend/meson.build), and they exercise
+# __ARM_FEATURE_MATMUL_INT8 (i8mm) code paths that this project always
+# enables for native aarch64 (see the top-level meson.build extra_defines
+# block). Gate mirrors the existing aarch64-only
+# `unittest_nntrainer_kleidiai` target below.
+if host_machine.cpu_family() == 'aarch64'
+  q4_kai_standalone_targets = [
+    'q4_roundtrip_kai',
+    'q4_kai_bytecompat',
+  ]
+  foreach t : q4_kai_standalone_targets
+    q4_kai_exe = executable(
+      t,
+      t + '.cpp',
+      dependencies: nntrainer_test_deps,
+      install: get_option('enable-test'),
+      install_dir: application_install_dir
+    )
+    test(t, q4_kai_exe, timeout: test_timeout, suite: 'unittests')
+  endforeach
+
+  # The fp16 matmul path additionally needs the enable-fp16-gated
+  # matmul_clamp_f16_qai8dxp_qsi4cxp kernels + qai8dxp_f16 LHS packer
+  # (nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build only
+  # enters that subdir when enable-fp16 is set), so this one test gates on
+  # both.
+  if get_option('enable-fp16')
+    q4_kai_matmul_device_exe = executable(
+      'q4_kai_matmul_device',
+      'q4_kai_matmul_device.cpp',
+      dependencies: nntrainer_test_deps,
+      install: get_option('enable-test'),
+      install_dir: application_install_dir
+    )
+    test('q4_kai_matmul_device', q4_kai_matmul_device_exe,
+      timeout: test_timeout, suite: 'unittests')
+  endif
+endif
+
 if enable_capi
   subdir('tizen_capi')
 endif

--- a/test/q4_kai_bytecompat.cpp
+++ b/test/q4_kai_bytecompat.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_kai_bytecompat.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  Byte-equality check between Int4Utils::quantizeAndPackKai and
+ * KAI's own qsi4cxp reference packer
+ */
+// Byte-equality check between Int4Utils::quantizeAndPackKai (host C++
+// emit) and KAI's own kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0 (the
+// reference packer from nntrainer/tensor/cpu_backend/arm/kai/pack/).
+//
+// The KAI source is pure C with a __ARM_NEON guard, so it builds on x86
+// for verification. We feed both packers from the same FP32 weights and
+// scales, then strip KAI's per-super-row trailer (sums + scales + bias =
+// 48 B for nr=4) and compare the remaining nibble payload byte-for-byte
+// to our packer's output.
+//
+// Standalone (no gtest).
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <fp16.h>
+#include <int4_utils.h>
+
+extern "C" {
+#include "kai/pack/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h"
+}
+
+using namespace nntrainer;
+
+static void quantize_raw_nibbles(const std::vector<float> &W, unsigned N,
+                                 unsigned K, std::vector<uint8_t> &raw_nibbles,
+                                 std::vector<float> &scales_fp32) {
+  scales_fp32.assign(N, 1.0f);
+  const size_t row_bytes = (K + 1) / 2;
+  raw_nibbles.assign((size_t)N * row_bytes, 0u);
+  for (unsigned n = 0; n < N; ++n) {
+    float max_abs = 0.0f;
+    for (unsigned k = 0; k < K; ++k) {
+      float a = std::fabs(W[(size_t)n * K + k]);
+      if (a > max_abs)
+        max_abs = a;
+    }
+    scales_fp32[n] = (max_abs == 0.0f) ? 1.0f : (max_abs / 7.0f);
+    const float s = scales_fp32[n];
+    for (unsigned k = 0; k < K; k += 2) {
+      const uint8_t u0 = Int4Utils::quantizeToInt4(W[(size_t)n * K + k], s);
+      uint8_t byte = (uint8_t)((u0 + 8) & 0x0F);
+      if (k + 1 < K) {
+        const uint8_t u1 =
+          Int4Utils::quantizeToInt4(W[(size_t)n * K + k + 1], s);
+        byte |= (uint8_t)(((u1 + 8) & 0x0F) << 4);
+      } else {
+        byte |= (uint8_t)(8u << 4);
+      }
+      raw_nibbles[(size_t)n * row_bytes + (k / 2)] = byte;
+    }
+  }
+}
+
+static int run(unsigned K, unsigned N, const char *tag) {
+  std::mt19937 rng(1234);
+  std::normal_distribution<float> nd(0.0f, 0.05f);
+  std::vector<float> W((size_t)N * K);
+  for (auto &v : W)
+    v = nd(rng);
+
+  // 1) Our packer (FP32 in, Section A out).
+  std::vector<uint8_t> qw_ours;
+  std::vector<uint16_t> qs_ours;
+  Int4Utils::quantizeAndPackKai(W.data(), N, K, qw_ours, qs_ours);
+
+  // 2) KAI reference packer: feed pre-quantized nibbles + fp32 scales.
+  //    Round-trip the scales through fp16 so the trailer bytes match
+  //    Int4Utils::assembleKaiRhsPacked (which reads fp16 from disk).
+  std::vector<uint8_t> raw_nibbles;
+  std::vector<float> scales_fp32;
+  quantize_raw_nibbles(W, N, K, raw_nibbles, scales_fp32);
+  for (auto &s : scales_fp32) {
+    s = compute_fp16_to_fp32(compute_fp32_to_fp16(s));
+  }
+
+  const size_t nr = Int4Utils::KAI_NR;
+  const size_t kr = Int4Utils::KAI_KR;
+  const size_t sr = Int4Utils::KAI_SR;
+  const size_t kai_packed_size =
+    kai_get_rhs_packed_size_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(N, K, nr, kr, sr);
+  std::vector<uint8_t> kai_packed(kai_packed_size, 0u);
+
+  kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_params params;
+  params.lhs_zero_point = 1;
+  params.rhs_zero_point = 8;
+  const float *no_bias = nullptr; // no bias for this test
+  const size_t no_extra_bytes = 0;
+  kai_run_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(
+    1, N, K, nr, kr, sr, raw_nibbles.data(), no_bias, scales_fp32.data(),
+    kai_packed.data(), no_extra_bytes, &params);
+
+  // 3) Strip KAI trailer per super-row, compare Section A.
+  const size_t k_internal = ((size_t)K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) /
+                            Int4Utils::KAI_K_PAD_MULTIPLE *
+                            Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t nibble_bytes_per_super_row = nr * (k_internal / 2);
+  const size_t kai_stride =
+    kai_get_rhs_packed_stride_rhs_pack_nxk_qsi4cxp_qs4cxs1s0(K, nr, kr, sr);
+  const size_t super_row_count = (N + nr - 1) / nr;
+
+  if (qw_ours.size() != super_row_count * nibble_bytes_per_super_row) {
+    printf("[%s/bytecompat] FAIL: ours size %zu != expected %zu\n", tag,
+           qw_ours.size(), super_row_count * nibble_bytes_per_super_row);
+    return 1;
+  }
+
+  size_t mismatches = 0;
+  size_t first_mismatch = (size_t)-1;
+  uint8_t first_a = 0, first_b = 0;
+  for (size_t sr_i = 0; sr_i < super_row_count; ++sr_i) {
+    const uint8_t *kai_row = kai_packed.data() + sr_i * kai_stride;
+    const uint8_t *ours_row =
+      qw_ours.data() + sr_i * nibble_bytes_per_super_row;
+    for (size_t b = 0; b < nibble_bytes_per_super_row; ++b) {
+      if (kai_row[b] != ours_row[b]) {
+        ++mismatches;
+        if (first_mismatch == (size_t)-1) {
+          first_mismatch = sr_i * nibble_bytes_per_super_row + b;
+          first_a = ours_row[b];
+          first_b = kai_row[b];
+        }
+      }
+    }
+  }
+
+  if (mismatches != 0) {
+    printf("[%s/bytecompat] FAIL nibble: %zu mismatched bytes, first at "
+           "offset %zu (ours=0x%02x vs kai=0x%02x)\n",
+           tag, mismatches, first_mismatch, first_a, first_b);
+    return 1;
+  }
+
+  // Now exercise Int4Utils::assembleKaiRhsPacked: reassemble Section A +
+  // fp16 scales into a full KAI rhs_packed buffer (with trailer) and
+  // compare byte-for-byte to the KAI packer's output. This locks the
+  // load-time trailer reassembly (sums, scales*0.0625, bias) to the
+  // matmul kernel's expectations.
+  std::vector<uint8_t> ours_full;
+  Int4Utils::assembleKaiRhsPacked(qw_ours.data(), qs_ours.data(), N, K,
+                                  ours_full);
+  if (ours_full.size() != kai_packed.size()) {
+    printf("[%s/bytecompat] FAIL trailer: assembled size %zu vs KAI %zu\n", tag,
+           ours_full.size(), kai_packed.size());
+    return 1;
+  }
+  size_t t_mismatches = 0;
+  size_t t_first = (size_t)-1;
+  uint8_t t_a = 0, t_b = 0;
+  for (size_t i = 0; i < ours_full.size(); ++i) {
+    if (ours_full[i] != kai_packed[i]) {
+      ++t_mismatches;
+      if (t_first == (size_t)-1) {
+        t_first = i;
+        t_a = ours_full[i];
+        t_b = kai_packed[i];
+      }
+    }
+  }
+  if (t_mismatches != 0) {
+    printf("[%s/bytecompat] FAIL trailer: %zu mismatched bytes, first at "
+           "offset %zu (ours=0x%02x vs kai=0x%02x)\n",
+           tag, t_mismatches, t_first, t_a, t_b);
+    return 1;
+  }
+
+  printf("[%s/bytecompat] OK: %zu super-rows, nibble %zu B + trailer 48 B = "
+         "%zu B byte-identical with KAI rhs_pack\n",
+         tag, super_row_count, nibble_bytes_per_super_row, kai_packed.size());
+  return 0;
+}
+
+int main() {
+  int rc = 0;
+  rc |= run(32, 4, "tiny");
+  rc |= run(256, 32, "small");
+  rc |= run(1536, 1536, "square");
+  rc |= run(1536, 6144, "ffn_up");
+  rc |= run(6144, 1536, "ffn_down");
+  return rc;
+}

--- a/test/q4_kai_matmul_device.cpp
+++ b/test/q4_kai_matmul_device.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_kai_matmul_device.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  ARM device sanity test for the KAI qsi4cxp matmul path
+ * end-to-end
+ */
+// ARM device sanity test for the KAI qsi4cxp matmul path end-to-end.
+//
+// For both the upstream fp32 matmul (4x4x32 i8mm variant) and the fp16
+// matmul (16x4 i8mm variant, from upstream `308bdd4f3b`
+// [kleidiai] Add `matmul_clamp_f16_qai8dxp_qsi4cxp`), this:
+//   1. Generates a random fp32 weight tensor [N x K].
+//   2. Packs it via Int4Utils::quantizeAndPackKai (Section A nibbles +
+//      per-channel fp16 scales).
+//   3. Reassembles the full KAI rhs_packed buffer via
+//      assembleKaiRhsPacked (sums / scales*0.0625 / bias=0 trailer).
+//   4. Runs the KAI matmul over a random LHS activation.
+//   5. Compares against a reference matmul performed in fp32 with
+//      dequantized int4 weights — same quantization noise on both
+//      sides, so the residual measures only the matmul path itself.
+//
+// Standalone (no gtest, no libnntrainer). Cross-compiles directly with
+// the NDK clang; pushes to the device and prints diagnostic numbers.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "fp16.h"
+#include "int4_utils.h"
+
+extern "C" {
+#include "kai/matmul_clamp_f16_qai8dxp_qsi4cxp/kai_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm.h"
+#include "kai/matmul_clamp_f32_qai8dxp_qsi4cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_4x4x32_neon_i8mm.h"
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f16_neon.h"
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
+}
+
+using namespace nntrainer;
+
+// Mirror of nntr_kai_gemm_qai8dxp_qsi4cxp_olp_single_thread for variant 2,
+// inlined here so this test does not pull in libnntrainer.
+static void run_kai_fp32(size_t m, size_t n, size_t k, const float *lhs_f32,
+                         const uint8_t *rhs_packed, float *dst_f32) {
+  constexpr size_t mr = 4, kr = 16, sr = 2;
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr);
+  std::vector<uint8_t> lhs_packed(lhs_packed_size);
+  kai_run_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr, 0, lhs_f32,
+                                     k * sizeof(float), lhs_packed.data());
+
+  const size_t dst_stride = n * sizeof(float);
+  kai_run_matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_4x4x32_neon_i8mm(
+    m, n, k, lhs_packed.data(), rhs_packed, dst_f32, dst_stride, sizeof(float),
+    -1e30f, 1e30f);
+}
+
+static void run_kai_fp16(size_t m, size_t n, size_t k, const __fp16 *lhs_f16,
+                         const uint8_t *rhs_packed, __fp16 *dst_f16) {
+  // nr=4 kr=16 sr=2 — the qai8dxp4x8_qsi4cxp4x8 pack family shared by the
+  // 16x4 i8mm GEMM variant used here and the 1x4 dotprod GEMV variant
+  // (idx 1) selected by the arm_compute_backend_fp16.cpp facade for M==1;
+  // see the comment there for why the same rhs_packed buffer is valid for
+  // both.
+  constexpr size_t mr = 4, kr = 16, sr = 2;
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f16_neon(m, k, mr, kr, sr);
+  std::vector<uint8_t> lhs_packed(lhs_packed_size);
+  kai_run_lhs_quant_pack_qai8dxp_f16_neon(
+    m, k, mr, kr, sr, 0, lhs_f16, k * sizeof(__fp16), lhs_packed.data());
+
+  const size_t dst_stride = n * sizeof(__fp16);
+  kai_run_matmul_clamp_f16_qai8dxp4x8_qsi4cxp4x8_16x4_neon_i8mm(
+    m, n, k, lhs_packed.data(), rhs_packed, dst_f16, dst_stride, sizeof(__fp16),
+    -65504.0f, 65504.0f);
+}
+
+// Dequantize Section A bytes back to fp32 weight matrix [N x K] using the
+// same reverse-permutation as test/q4_roundtrip_kai.cpp's helper.
+static void dequant_for_reference(const std::vector<uint8_t> &section_a,
+                                  const std::vector<uint16_t> &fp16_scales,
+                                  size_t N, size_t K,
+                                  std::vector<float> &W_dq) {
+  const size_t k_internal =
+    ((K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) / Int4Utils::KAI_K_PAD_MULTIPLE) *
+    Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count =
+    (N + Int4Utils::KAI_NR - 1) / Int4Utils::KAI_NR;
+  const size_t nibble_bytes_per_super_row =
+    Int4Utils::KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = Int4Utils::KAI_KR / Int4Utils::KAI_SR;
+
+  W_dq.assign(N * K, 0.0f);
+
+  // fp16 -> fp32 once
+  std::vector<float> sc(N);
+  for (size_t n = 0; n < N; ++n) {
+    sc[n] = compute_fp16_to_fp32(fp16_scales[n]);
+  }
+
+  for (size_t sr_i = 0; sr_i < super_row_count; ++sr_i) {
+    const uint8_t *src_row =
+      section_a.data() + sr_i * nibble_bytes_per_super_row;
+    for (size_t b = 0; b < nibble_bytes_per_super_row; ++b) {
+      const size_t block_idx = b / block_length_in_bytes;
+      const size_t block_byte_idx = b % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / Int4Utils::KAI_NR;
+      const size_t nr_idx = block_idx % Int4Utils::KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         Int4Utils::KAI_K_INTERLEAVE) *
+        Int4Utils::KAI_K_INTERLEAVE;
+      const size_t k0 =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1 = k0 + Int4Utils::KAI_K_INTERLEAVE;
+      const size_t n0 = sr_i * Int4Utils::KAI_NR + nr_idx;
+      if (n0 >= N)
+        continue;
+
+      const uint8_t stored = src_row[b] ^ 0x88;
+      const int q0 = (stored & 0x0F) - 8;
+      const int q1 = ((stored >> 4) & 0x0F) - 8;
+      if (k0 < K)
+        W_dq[n0 * K + k0] = (float)q0 * sc[n0];
+      if (k1 < K)
+        W_dq[n0 * K + k1] = (float)q1 * sc[n0];
+    }
+  }
+}
+
+static void run_shape(unsigned M, unsigned N, unsigned K, const char *tag) {
+  std::mt19937 rng(987);
+  std::normal_distribution<float> w_nd(0.0f, 0.05f);
+  std::normal_distribution<float> a_nd(0.0f, 1.0f);
+
+  // RHS weight [N x K] in row-major (this is what quantizeAndPackKai expects).
+  std::vector<float> W((size_t)N * K);
+  for (auto &v : W)
+    v = w_nd(rng);
+
+  // LHS activation [M x K].
+  std::vector<float> A((size_t)M * K);
+  for (auto &v : A)
+    v = a_nd(rng);
+
+  // Pack + assemble.
+  std::vector<uint8_t> qw;
+  std::vector<uint16_t> qs;
+  Int4Utils::quantizeAndPackKai(W.data(), N, K, qw, qs);
+  std::vector<uint8_t> rhs_packed;
+  Int4Utils::assembleKaiRhsPacked(qw.data(), qs.data(), N, K, rhs_packed);
+
+  // Reference: dequant int4 -> fp32 weights, then plain matmul. This shares
+  // the same quantization noise as the KAI path, so the comparison measures
+  // matmul fidelity only.
+  std::vector<float> W_dq;
+  dequant_for_reference(qw, qs, N, K, W_dq);
+  std::vector<float> ref((size_t)M * N, 0.0f);
+  for (unsigned i = 0; i < M; ++i) {
+    for (unsigned j = 0; j < N; ++j) {
+      float acc = 0.0f;
+      for (unsigned k = 0; k < K; ++k) {
+        acc += A[(size_t)i * K + k] * W_dq[(size_t)j * K + k];
+      }
+      ref[(size_t)i * N + j] = acc;
+    }
+  }
+
+  auto report = [&](const char *path, const std::vector<float> &got) {
+    double se = 0.0, sigpow = 0.0, maxabs = 0.0;
+    for (size_t i = 0; i < (size_t)M * N; ++i) {
+      double e = (double)got[i] - (double)ref[i];
+      se += e * e;
+      sigpow += (double)ref[i] * (double)ref[i];
+      if (std::fabs(e) > maxabs)
+        maxabs = std::fabs(e);
+    }
+    double mse = se / ((double)M * N);
+    double rel = std::sqrt(se / (sigpow + 1e-12));
+    printf("  [%s/%s] M=%u N=%u K=%u  MSE=%.3e relL2=%.3e maxAbs=%.3e\n", tag,
+           path, M, N, K, mse, rel, maxabs);
+  };
+
+  // fp32 KAI matmul path.
+  std::vector<float> out_f32((size_t)M * N);
+  run_kai_fp32(M, N, K, A.data(), rhs_packed.data(), out_f32.data());
+  report("fp32", out_f32);
+
+  // fp16 KAI matmul path: cast input + cast output to compare on the same
+  // scale as ref.
+  std::vector<__fp16> A_f16((size_t)M * K);
+  for (size_t i = 0; i < (size_t)M * K; ++i)
+    A_f16[i] = (__fp16)A[i];
+  std::vector<__fp16> out_f16_raw((size_t)M * N);
+  run_kai_fp16(M, N, K, A_f16.data(), rhs_packed.data(), out_f16_raw.data());
+  std::vector<float> out_f16((size_t)M * N);
+  for (size_t i = 0; i < (size_t)M * N; ++i)
+    out_f16[i] = (float)out_f16_raw[i];
+  report("fp16", out_f16);
+}
+
+int main() {
+  printf("[KAI matmul device sanity]\n");
+  run_shape(1, 1536, 1536, "square_M=1");
+  run_shape(4, 1536, 1536, "square_M=4");
+  run_shape(16, 1536, 1536, "square_M=16");
+  run_shape(64, 1536, 1536, "square_M=64");
+  run_shape(1, 6144, 1536, "ffn_up_M=1");
+  run_shape(4, 6144, 1536, "ffn_up_M=4");
+  printf("[done]\n");
+  return 0;
+}

--- a/test/q4_roundtrip_kai.cpp
+++ b/test/q4_roundtrip_kai.cpp
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Jijoong Moon <jijoong.moon@samsung.com>
+ *
+ * @file   q4_roundtrip_kai.cpp
+ * @date   21 July 2026
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  QINT4 channel-wise (KAI qsi4cxp Section A) round-trip check
+ */
+// QINT4 channel-wise (KAI qsi4cxp Section A) round-trip check:
+//   pack:    Int4Utils::quantizeAndPackKai   (matches kai_run_rhs_pack_nxk_
+//                                             qsi4cxp_qs4cxs1s0 nibble bytes,
+//                                             trailer stripped)
+//   dequant: reverse-permute Section A → uint4 → int4 → * scale
+//
+// Standalone (no gtest). Mirrors the structure of test/q4_roundtrip.cpp so
+// the two paths can be compared side-by-side from CLI output.
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+#include <fp16.h>
+#include <int4_utils.h>
+
+using namespace nntrainer;
+
+// Reverse-permute KAI Section A back into [N][K] dequantized floats. This
+// mirrors Int4Utils::quantizeAndPackKai byte-for-byte, then undoes the
+// XOR-0x88 and the uint4 = int4 + 8 encoding to recover the original signed
+// 4-bit value, finally scales by the per-channel fp16 scale (expanded to
+// fp32 at use time).
+static void dequant_kai_section_a(const std::vector<uint8_t> &packed,
+                                  const std::vector<uint16_t> &scales,
+                                  unsigned N, unsigned K,
+                                  std::vector<float> &out) {
+  const size_t k_internal = ((size_t)K + Int4Utils::KAI_K_PAD_MULTIPLE - 1) /
+                            Int4Utils::KAI_K_PAD_MULTIPLE *
+                            Int4Utils::KAI_K_PAD_MULTIPLE;
+  const size_t super_row_count =
+    ((size_t)N + Int4Utils::KAI_NR - 1) / Int4Utils::KAI_NR;
+  const size_t nibble_bytes_per_super_row =
+    Int4Utils::KAI_NR * (k_internal / 2);
+  const size_t block_length_in_bytes = Int4Utils::KAI_KR / Int4Utils::KAI_SR;
+  const size_t kK = (size_t)K;
+
+  out.assign((size_t)N * K, 0.0f);
+
+  // Expand fp16 scales to fp32 once, since K iterations re-use them.
+  std::vector<float> sc(N);
+  for (unsigned n = 0; n < N; ++n) {
+    sc[n] = compute_fp16_to_fp32(scales[n]);
+  }
+
+  for (size_t dst_row_idx = 0; dst_row_idx < super_row_count; ++dst_row_idx) {
+    const uint8_t *dst_row =
+      packed.data() + dst_row_idx * nibble_bytes_per_super_row;
+
+    for (size_t dst_byte_idx = 0; dst_byte_idx < nibble_bytes_per_super_row;
+         ++dst_byte_idx) {
+      const size_t block_idx = dst_byte_idx / block_length_in_bytes;
+      const size_t block_byte_idx = dst_byte_idx % block_length_in_bytes;
+      const size_t super_block_idx = block_idx / Int4Utils::KAI_NR;
+      const size_t nr_idx = block_idx % Int4Utils::KAI_NR;
+
+      const size_t k_adjustment =
+        ((block_byte_idx + super_block_idx * block_length_in_bytes) /
+         Int4Utils::KAI_K_INTERLEAVE) *
+        Int4Utils::KAI_K_INTERLEAVE;
+      const size_t k0_idx =
+        block_byte_idx + super_block_idx * block_length_in_bytes + k_adjustment;
+      const size_t k1_idx = k0_idx + Int4Utils::KAI_K_INTERLEAVE;
+      const size_t n0_idx = dst_row_idx * Int4Utils::KAI_NR + nr_idx;
+      if (n0_idx >= N)
+        continue;
+
+      const uint8_t stored = dst_row[dst_byte_idx] ^ 0x88;
+      const int u_lo = stored & 0x0F;
+      const int u_hi = (stored >> 4) & 0x0F;
+      const int q0 = u_lo - 8; // signed int4 in [-8, 7]
+      const int q1 = u_hi - 8;
+      const float s = sc[n0_idx];
+
+      if (k0_idx < kK)
+        out[n0_idx * kK + k0_idx] = (float)q0 * s;
+      if (k1_idx < kK)
+        out[n0_idx * kK + k1_idx] = (float)q1 * s;
+    }
+  }
+}
+
+static void run(unsigned K, unsigned N, const char *tag) {
+  std::mt19937 rng(1234);
+  std::normal_distribution<float> nd(0.0f, 0.05f);
+
+  // Original FC weight as nntrainer stores it: [K, N] row-major.
+  std::vector<float> W((size_t)K * N);
+  for (auto &v : W)
+    v = nd(rng);
+
+  // ---- save path: transpose [K,N] -> [N,K], pack KAI Section A ----
+  std::vector<float> Wt((size_t)N * K);
+  for (unsigned k = 0; k < K; ++k)
+    for (unsigned n = 0; n < N; ++n)
+      Wt[(size_t)n * K + k] = W[(size_t)k * N + n];
+
+  std::vector<uint8_t> qw;
+  std::vector<uint16_t> qs;
+  Int4Utils::quantizeAndPackKai(Wt.data(), N, K, qw, qs);
+
+  // ---- dequant path: reverse-permute Section A -> [N, K] ----
+  std::vector<float> deq;
+  dequant_kai_section_a(qw, qs, N, K, deq);
+
+  // rebuild [K, N]
+  std::vector<float> R((size_t)K * N);
+  for (unsigned n = 0; n < N; ++n)
+    for (unsigned k = 0; k < K; ++k)
+      R[(size_t)k * N + n] = deq[(size_t)n * K + k];
+
+  // Expected packed size for sanity:
+  const size_t expected = Int4Utils::kaiNibblePayloadBytes(N, K);
+
+  double se = 0.0, maxabs = 0.0, sigpow = 0.0;
+  for (size_t i = 0; i < (size_t)K * N; ++i) {
+    double e = (double)R[i] - (double)W[i];
+    se += e * e;
+    sigpow += (double)W[i] * (double)W[i];
+    if (std::fabs(e) > maxabs)
+      maxabs = std::fabs(e);
+  }
+  double mse = se / ((double)K * N);
+  double rel = se / (sigpow + 1e-12);
+  printf("[%s/KAI] K=%u N=%u  qw=%zuB (exp %zuB) qs=%zu  MSE=%.3e relErr=%.3e "
+         "maxAbs=%.3e\n  W[0..4]  =",
+         tag, K, N, qw.size(), expected, qs.size(), mse, rel, maxabs);
+  for (int i = 0; i < 5; ++i)
+    printf(" % .5f", W[i]);
+  printf("\n  R[0..4]  =");
+  for (int i = 0; i < 5; ++i)
+    printf(" % .5f", R[i]);
+  printf("\n");
+}
+
+int main() {
+  run(1536, 1536, "square");
+  run(1536, 6144, "ffn_up");
+  run(6144, 1536, "ffn_down");
+  run(256, 1536, "ple_proj");
+  return 0;
+}


### PR DESCRIPTION
**Depends-on: #4128** (base — the KAI `qsi4cxp` Section-A packing helpers this extends arrive there).
**Land #4212 first** if both are in flight: this branch re-includes the QS4CX single-zero-fill rung, which then arrives as a no-op.
**Rebase and merge only, never squash.**

Every model package whose `model_tensor_type` is `QINT4-*` fails to load on this tree. The loader
over-counts each int4 weight, the running file offset drifts, and the EOF tripwire fires. Reproduced
on three packages (a 35-layer model with an untied QINT4 lm_head, and two smaller ones):

```
FATAL ERROR: Model layout mismatch: graph expects 3,539,836,016 bytes of weights
             but file '...' has only 3,399,793,776 bytes
```

## Root cause

The on-disk int4 record and the in-memory int4 tensor are two different formats, and only one of them
is implemented.

**On disk**, an int4 record carries **one scale per output channel** — either
`[u16 0x06][KAI qsi4cxp Section-A nibbles][N fp16 scales]` or the plain container
`[u16 0x01][padded nibbles][N fp32 scales]`.

**In memory**, `Int4QTensor::scale_size()` returns the upstream group-of-32 count `H*W/32`, so
`getMemoryBytes()` — which is what advances `start_from` — claims `H*W/16` scale bytes instead of
`2*N`. For the package above that is **142,467,072 expected vs 2,424,832 on disk**: exactly the
140,042,240-byte delta in the error.

Nothing in this tree can *write* a group-32 int4 record, so there is no such package to preserve.

## The fix

A QINT4 weight materialises as QS4CX, and the legacy record is transcoded at read time — both
containers. The nibbles are re-laid out and the fp16→fp32 scale widening is exact, so the transcode
is **lossless**: a legacy package and its regenerated QS4CX twin emit byte-identical continuations.

## Verification

- The three previously-unloadable packages load and generate; the 35-layer one is **token-identical
  to a reference binary** on the same package.
- Canonical (non-legacy) packages are untouched — the flag is off, so `TensorBase::read` is unchanged.
- Verified on both the CPU engine and the OpenCL lane.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
