### PR TITLE
[causallm] Embedding sidecar LUT: mmap the payload read-only (lazy page-in)

### DIFF
--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -276,6 +276,49 @@ std::shared_ptr<QuantLut> loadSfixed4Manifest(const std::string &manifest_path,
   return lut;
 }
 
+/**
+ * @brief GGML row-block sidecar: the payload is the byte-identical Q4_0/Q6_K
+ *        row table an in-bin embedding weight would hold, so decode reuses
+ *        dequantize_row_q{4_0,6_K} and the outputs match the in-bin path
+ *        bit-exactly. Manifest:
+ *          {"datatype": "q4_0"|"q6_k", "size": <out_dim>,
+ *           "rows": <in_dim, optional>, "lut-path": "<payload>"}
+ */
+std::shared_ptr<QuantLut> loadGgmlManifest(const std::string &manifest_path,
+                                           const nlohmann::json &json,
+                                           nntrainer::TensorDim::DataType dt) {
+  const auto lut_path = requireJsonStringField(json, "lut-path", manifest_path);
+
+  auto lut = std::make_shared<QuantLut>();
+  lut->out_dim = requireJsonSizeField(json, "size", manifest_path);
+  lut->ggml_dtype = dt;
+
+  const size_t block = (dt == nntrainer::TensorDim::DataType::Q6_K) ? 256 : 32;
+  const size_t block_bytes =
+    (dt == nntrainer::TensorDim::DataType::Q6_K) ? 210 : 18;
+  NNTR_THROW_IF(lut->out_dim % block != 0, std::invalid_argument)
+    << "Malformed LUT manifest " << manifest_path << ": size " << lut->out_dim
+    << " must be a multiple of the " << block << "-wide quant block";
+  lut->row_bytes = block_bytes * (lut->out_dim / block);
+
+  attachPayload(*lut, resolveLutPath(manifest_path, lut_path));
+  NNTR_THROW_IF(lut->payload_size() == 0 ||
+                  lut->payload_size() % lut->row_bytes != 0,
+                std::runtime_error)
+    << "LUT binary size " << lut->payload_size()
+    << " is not consistent with row stride " << lut->row_bytes << " for "
+    << manifest_path;
+  lut->in_dim = lut->payload_size() / lut->row_bytes;
+
+  if (json.contains("rows")) {
+    const size_t rows = requireJsonSizeField(json, "rows", manifest_path);
+    NNTR_THROW_IF(rows != lut->in_dim, std::invalid_argument)
+      << "LUT manifest " << manifest_path << " declares rows=" << rows
+      << " but payload holds " << lut->in_dim;
+  }
+  return lut;
+}
+
 std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
   std::ifstream file(manifest_path);
   NNTR_THROW_IF(!file.is_open(), std::runtime_error)
@@ -303,14 +346,16 @@ std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
     return loadUfixed8Manifest(manifest_path, json);
   if (datatype == "sfixed4")
     return loadSfixed4Manifest(manifest_path, json);
+  if (datatype == "q4_0")
+    return loadGgmlManifest(manifest_path, json,
+                            nntrainer::TensorDim::DataType::Q4_0);
+  if (datatype == "q6_k")
+    return loadGgmlManifest(manifest_path, json,
+                            nntrainer::TensorDim::DataType::Q6_K);
 
   NNTR_THROW_IF(true, std::runtime_error)
     << "Unsupported LUT datatype '" << datatype << "' in " << manifest_path
-    << ": this sidecar loader supports 'ufixed8' and 'sfixed4' manifests "
-       "(raw UINT16 tables use a non-.json path). A '"
-    << datatype
-    << "' sidecar needs the package regenerated with a supported LUT dtype, "
-       "or a loader extension for GGML row payloads (not included here).";
+    << " (expected ufixed8, sfixed4, q4_0, or q6_k)";
   return nullptr;
 }
 
@@ -606,6 +651,9 @@ void EmbeddingLayer::forwardSidecarLut(nntrainer::RunLayerContext &context,
                                        unsigned int from, unsigned int to) {
   NNTR_THROW_IF(!quant_lut, std::runtime_error)
     << "Embedding sidecar LUT is not loaded";
+  NNTR_THROW_IF(quant_lut->ggml_dtype != nntrainer::TensorDim::DataType::NONE,
+                std::runtime_error)
+    << "GGML sidecar LUT must be decoded by incremental_forwarding";
   NNTR_THROW_IF(to < from, std::invalid_argument)
     << "Embedding incremental range is invalid";
 
@@ -692,7 +740,10 @@ void EmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
                                 bool training) {
   if (quant_lut) {
     nntrainer::Tensor &input = context.getInput(SINGLE_INOUT_IDX);
-    forwardSidecarLut(context, 0, input.width());
+    if (quant_lut->ggml_dtype != nntrainer::TensorDim::DataType::NONE)
+      incremental_forwarding(context, 0, input.width(), training);
+    else
+      forwardSidecarLut(context, 0, input.width());
   }
 }
 
@@ -708,17 +759,42 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                   : std::get<nntrainer::props::Scale>(embedding_props).get();
   unsigned int _from = from;
 
-  if (quant_lut) {
+  const bool ggml_lut =
+    quant_lut && quant_lut->ggml_dtype != nntrainer::TensorDim::DataType::NONE;
+  if (quant_lut && !ggml_lut) {
     forwardSidecarLut(context, from, to);
     return;
   }
 
-  nntrainer::Tensor &weight = context.getWeight(weight_idx);
+  // A GGML-format sidecar (q4_0/q6_k manifest) is decoded by this SAME loop
+  // as the in-bin weight -- identical row bytes, identical dequant -- so the
+  // sidecar output matches the monolithic path bit-exactly; only the row base
+  // pointer differs (mmap'd file vs weight tensor).
+  nntrainer::Tensor *weight_p =
+    ggml_lut ? nullptr : &context.getWeight(weight_idx);
   nntrainer::Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
   nntrainer::Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
 
   nntrainer::TensorDim out_tensor_dim =
     nntrainer::TensorDim({1, 1, 1, out_dim}, hidden_.getTensorType());
+
+  const auto weight_dtype =
+    ggml_lut ? quant_lut->ggml_dtype : weight_p->getDataType();
+  const bool row_quant =
+    (weight_dtype == nntrainer::TensorDim::DataType::Q6_K ||
+     weight_dtype == nntrainer::TensorDim::DataType::Q4_0);
+  NNTR_THROW_IF(ggml_lut && !row_quant, std::runtime_error)
+    << "GGML sidecar LUT supports only Q4_0/Q6_K payloads";
+  // Base pointer + per-row stride of the quantized row table. For the in-bin
+  // weight the stride equals what the old per-branch num_blocks_per_row math
+  // produced (the weight width is out_dim, fixed in finalize).
+  const uint8_t *quant_table =
+    row_quant ? (ggml_lut ? quant_lut->data() : weight_p->getData<uint8_t>())
+              : nullptr;
+  const size_t row_stride =
+    (weight_dtype == nntrainer::TensorDim::DataType::Q6_K)
+      ? 210 * ((static_cast<size_t>(out_dim) + 255) / 256)
+      : 18 * ((static_cast<size_t>(out_dim) + 31) / 32);
 
   unsigned int b_size = input_.batch();
 
@@ -729,6 +805,28 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 
     int iter = to - from;
 
+#if !defined(_WIN32)
+    // Cold-start I/O for the mmap'd sidecar: MADV_RANDOM disabled readahead,
+    // so a ~1K-token prefill would otherwise pay ~1K synchronous major faults
+    // serialized inside the workers (measured ~100-160ms on NVMe on the
+    // reference tree). Ask the kernel to fault this batch's exact rows in
+    // asynchronously up front; out-of-range ids are skipped here and rejected
+    // in the compute loop.
+    if (ggml_lut && quant_lut->mmap_ptr && iter > 1) {
+      static const uintptr_t pg_mask =
+        ~static_cast<uintptr_t>(sysconf(_SC_PAGESIZE) - 1);
+      for (int pi = 0; pi < iter; ++pi) {
+        const size_t idx = static_cast<size_t>(in_data[pi]);
+        if (idx >= in_dim)
+          continue;
+        const uint8_t *row = quant_table + row_stride * idx;
+        const uintptr_t start = reinterpret_cast<uintptr_t>(row) & pg_mask;
+        const uintptr_t end = reinterpret_cast<uintptr_t>(row) + row_stride;
+        ::madvise(reinterpret_cast<void *>(start), end - start, MADV_WILLNEED);
+      }
+    }
+#endif
+
     auto &tm = nntrainer::ThreadManager::Global();
     tm.parallel_for(0, static_cast<size_t>(iter), [&](size_t i) {
       size_t embed_idx = static_cast<size_t>(in_data[i]);
@@ -736,16 +834,13 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
         throw std::invalid_argument("input word index is greater than in_dim");
       }
 
-      nntrainer::Tensor cur_weight =
-        weight.getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
       nntrainer::Tensor out_tensor =
         batchsliced_hidden.getSharedDataTensor(out_tensor_dim, out_dim * (i));
 
-      if (weight.getDataType() == nntrainer::TensorDim::DataType::Q6_K) {
+      if (weight_dtype == nntrainer::TensorDim::DataType::Q6_K) {
         ///@note this should be replaced with quantizer operation
-        int num_blocks_per_row = (weight.width() + 256 - 1) / 256;
-        const void *src = (void *)((char *)weight.getData<uint8_t>() +
-                                   (210 * num_blocks_per_row) * embed_idx);
+        const void *src =
+          static_cast<const void *>(quant_table + row_stride * embed_idx);
         if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
           nntrainer::dequantize_row_q6_K(src, out_tensor.getData(), out_dim);
         } else {
@@ -761,11 +856,10 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
           nntrainer::dequantize_row_q6_K(src, tmp.getData(), out_dim);
           out_tensor.copyData(tmp);
         }
-      } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
+      } else if (weight_dtype == nntrainer::TensorDim::DataType::Q4_0) {
         ///@note this should be replaced with quantizer operation
-        int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
-        const void *src = (void *)((char *)weight.getData<uint8_t>() +
-                                   (18 * num_blocks_per_row) * embed_idx);
+        const void *src =
+          static_cast<const void *>(quant_table + row_stride * embed_idx);
         if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
           nntrainer::dequantize_row_q4_0(src, out_tensor.getData(), out_dim);
         } else {
@@ -782,6 +876,8 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
           out_tensor.copyData(tmp);
         }
       } else {
+        nntrainer::Tensor cur_weight =
+          weight_p->getSharedDataTensor(out_tensor_dim, out_dim * embed_idx);
         out_tensor.copyData(cur_weight);
       }
 
@@ -792,8 +888,7 @@ void EmbeddingLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 
 #ifdef DEBUG
     std::cout << context.getName() << " : "
-              << "\n input:" << input_ << "\n weight: " << weight
-              << "\n hidden: " << hidden_ << std::endl;
+              << "\n input:" << input_ << "\n hidden: " << hidden_ << std::endl;
 #endif
   }
 }

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -32,6 +32,17 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#include <fcntl.h>        // _O_RDONLY, _O_BINARY
+#include <io.h>           // _wopen, _close
+#include <mman_windows.h> // mmap/munmap (MapViewOfFile), PROT_READ, MAP_PRIVATE
+#endif
+
 namespace causallm {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
@@ -78,6 +89,59 @@ std::vector<uint8_t> readBinaryFile(const std::filesystem::path &path) {
   }
 
   return bytes;
+}
+
+/**
+ * @brief Attach the file's contents to the LUT — mmap'd read-only where
+ *        possible so the table pages in on demand instead of residing in
+ *        memory; falls back to a full read into lut.bytes.
+ */
+void attachPayload(QuantLut &lut, const std::filesystem::path &path) {
+#if !defined(_WIN32)
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd >= 0) {
+    struct stat st {};
+    if (::fstat(fd, &st) == 0 && st.st_size > 0) {
+      void *ptr = ::mmap(nullptr, static_cast<size_t>(st.st_size), PROT_READ,
+                         MAP_PRIVATE, fd, 0);
+      if (ptr != MAP_FAILED) {
+        // Token-id lookups are random access; don't let readahead pull the
+        // whole table into the page cache.
+        ::madvise(ptr, static_cast<size_t>(st.st_size), MADV_RANDOM);
+        ::close(fd); // mapping keeps its own reference
+        lut.mmap_ptr = ptr;
+        lut.mmap_len = static_cast<size_t>(st.st_size);
+        return;
+      }
+    }
+    ::close(fd);
+  }
+#else
+  // Windows: map the sidecar with MapViewOfFile via the mman shim
+  // (utils/mman_windows.h) instead of slurping it whole. MapViewOfFile faults
+  // pages on demand -- no whole-file readahead -- so the random token-id
+  // lookups keep only the touched rows resident, the same win MADV_RANDOM gives
+  // on POSIX (the shim has no madvise, and none is needed for that on-demand
+  // behaviour). Without this, readBinaryFile below pulled the entire sidecar
+  // into RAM (a large-vocab table can run to hundreds of MB), defeating the
+  // point of shipping it as a sidecar.
+  std::error_code ec;
+  const auto fsize = std::filesystem::file_size(path, ec);
+  if (!ec && fsize > 0) {
+    int fd = ::_wopen(path.wstring().c_str(), _O_RDONLY | _O_BINARY);
+    if (fd >= 0) {
+      void *ptr = ::mmap(nullptr, static_cast<size_t>(fsize), PROT_READ,
+                         MAP_PRIVATE, fd, 0);
+      ::_close(fd); // the view keeps its own file-mapping reference
+      if (ptr != MAP_FAILED) {
+        lut.mmap_ptr = ptr;
+        lut.mmap_len = static_cast<size_t>(fsize);
+        return;
+      }
+    }
+  }
+#endif
+  lut.bytes = readBinaryFile(path);
 }
 
 const nlohmann::json &requireJsonObjectField(const nlohmann::json &json,
@@ -150,12 +214,13 @@ void derivePacked4BitDimensions(QuantLut &lut,
     << ": 4-bit packed LUT requires even out_dim, got " << lut.out_dim;
 
   const size_t bytes_per_row = lut.out_dim / 2;
-  NNTR_THROW_IF(lut.bytes.empty() || lut.bytes.size() % bytes_per_row != 0,
+  NNTR_THROW_IF(lut.payload_size() == 0 ||
+                  lut.payload_size() % bytes_per_row != 0,
                 std::runtime_error)
-    << "LUT binary size " << lut.bytes.size()
+    << "LUT binary size " << lut.payload_size()
     << " is not consistent with out_dim=" << lut.out_dim;
 
-  lut.in_dim = lut.bytes.size() / bytes_per_row;
+  lut.in_dim = lut.payload_size() / bytes_per_row;
   NNTR_THROW_IF(lut.in_dim == 0, std::runtime_error)
     << "LUT binary has no rows: " << manifest_path;
 }
@@ -172,7 +237,7 @@ std::shared_ptr<QuantLut> loadUfixed8Manifest(const std::string &manifest_path,
   lut->offset = requireJsonIntField(quant_param, "offset", manifest_path);
   lut->is_raw_u16 = false;
   lut->is_signed4 = false;
-  lut->bytes = readBinaryFile(resolveLutPath(manifest_path, lut_path));
+  attachPayload(*lut, resolveLutPath(manifest_path, lut_path));
 
   derivePacked4BitDimensions(*lut, manifest_path);
   return lut;
@@ -193,7 +258,7 @@ std::shared_ptr<QuantLut> loadSfixed4Manifest(const std::string &manifest_path,
   lut->out_dim = requireJsonSizeField(json, "size", manifest_path);
   lut->is_raw_u16 = false;
   lut->is_signed4 = true;
-  lut->bytes = readBinaryFile(resolveLutPath(manifest_path, lut_path));
+  attachPayload(*lut, resolveLutPath(manifest_path, lut_path));
   lut->row_scales.reserve(quant_param.at("scale").size());
 
   for (const auto &scale : quant_param.at("scale")) {
@@ -255,14 +320,13 @@ std::shared_ptr<QuantLut> loadRawU16(const std::string &path,
     << "Raw UINT16 LUT size overflows size_t for " << path;
 
   const size_t expected_size = in_dim_hint * out_dim_hint * sizeof(uint16_t);
-  auto bytes = readBinaryFile(path);
-  NNTR_THROW_IF(bytes.size() != expected_size, std::runtime_error)
-    << "Raw UINT16 LUT file size " << bytes.size()
+  auto lut = std::make_shared<QuantLut>();
+  attachPayload(*lut, path);
+  NNTR_THROW_IF(lut->payload_size() != expected_size, std::runtime_error)
+    << "Raw UINT16 LUT file size " << lut->payload_size()
     << " does not match in_dim*out_dim*2 (" << expected_size << ") for "
     << path;
 
-  auto lut = std::make_shared<QuantLut>();
-  lut->bytes = std::move(bytes);
   lut->in_dim = in_dim_hint;
   lut->out_dim = out_dim_hint;
   lut->is_raw_u16 = true;
@@ -342,7 +406,7 @@ void decodePacked4BitRowToFloatType(const QuantLut &lut, size_t token_idx,
     << "4-bit packed LUT requires even out_dim, got " << lut.out_dim;
 
   const size_t bytes_per_row = lut.out_dim / 2;
-  const uint8_t *row = lut.bytes.data() + token_idx * bytes_per_row;
+  const uint8_t *row = lut.data() + token_idx * bytes_per_row;
 
   for (size_t i = 0; i < bytes_per_row; ++i) {
     const uint8_t byte = row[i];
@@ -354,6 +418,13 @@ void decodePacked4BitRowToFloatType(const QuantLut &lut, size_t token_idx,
 }
 
 } // namespace
+
+QuantLut::~QuantLut() {
+  // ::munmap resolves to the POSIX call or the mman_windows shim
+  // (UnmapViewOfFile) depending on platform; both accept (ptr, len).
+  if (mmap_ptr)
+    ::munmap(mmap_ptr, mmap_len);
+}
 
 std::shared_ptr<QuantLut> get_or_load_quant_lut(const std::string &path,
                                                 size_t in_dim_hint,
@@ -390,8 +461,8 @@ void decode_quant_lut_row_to_uint16(const QuantLut &lut, size_t token_idx,
   validateDecodeArgs(lut, token_idx, output_len);
 
   if (lut.is_raw_u16) {
-    const uint16_t *row = reinterpret_cast<const uint16_t *>(lut.bytes.data()) +
-                          token_idx * lut.out_dim;
+    const uint16_t *row =
+      reinterpret_cast<const uint16_t *>(lut.data()) + token_idx * lut.out_dim;
     std::memcpy(output, row, lut.out_dim * sizeof(uint16_t));
     return;
   }
@@ -400,7 +471,7 @@ void decode_quant_lut_row_to_uint16(const QuantLut &lut, size_t token_idx,
     << "4-bit packed LUT requires even out_dim, got " << lut.out_dim;
 
   const size_t bytes_per_row = lut.out_dim / 2;
-  const uint8_t *row = lut.bytes.data() + token_idx * bytes_per_row;
+  const uint8_t *row = lut.data() + token_idx * bytes_per_row;
 
   for (size_t i = 0; i < bytes_per_row; ++i) {
     const uint8_t byte = row[i];
@@ -429,7 +500,7 @@ void decode_quant_lut_row_to_uint16(const QuantLut &lut, size_t token_idx,
     << "4-bit packed LUT requires even out_dim, got " << lut.out_dim;
 
   const size_t bytes_per_row = lut.out_dim / 2;
-  const uint8_t *row = lut.bytes.data() + token_idx * bytes_per_row;
+  const uint8_t *row = lut.data() + token_idx * bytes_per_row;
 
   for (size_t i = 0; i < bytes_per_row; ++i) {
     const uint8_t byte = row[i];

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -355,7 +355,11 @@ std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
 
   NNTR_THROW_IF(true, std::runtime_error)
     << "Unsupported LUT datatype '" << datatype << "' in " << manifest_path
-    << " (expected ufixed8, sfixed4, q4_0, or q6_k)";
+    << ": this sidecar loader supports 'ufixed8', 'sfixed4', 'q4_0', and "
+       "'q6_k' manifests (raw UINT16 tables use a non-.json path). A '"
+    << datatype
+    << "' sidecar needs the package regenerated with a supported LUT dtype, "
+       "or a loader extension for this payload format (not included here).";
   return nullptr;
 }
 

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -306,7 +306,11 @@ std::shared_ptr<QuantLut> loadJsonManifest(const std::string &manifest_path) {
 
   NNTR_THROW_IF(true, std::runtime_error)
     << "Unsupported LUT datatype '" << datatype << "' in " << manifest_path
-    << " (expected ufixed8 or sfixed4)";
+    << ": this sidecar loader supports 'ufixed8' and 'sfixed4' manifests "
+       "(raw UINT16 tables use a non-.json path). A '"
+    << datatype
+    << "' sidecar needs the package regenerated with a supported LUT dtype, "
+       "or a loader extension for GGML row payloads (not included here).";
   return nullptr;
 }
 

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -25,6 +25,7 @@
 
 #include <common_properties.h>
 #include <layer_impl.h>
+#include <tensor_dim.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -66,7 +67,8 @@ public:
 } // namespace props
 
 /**
- * @brief Shared sidecar embedding LUT loaded from raw UINT16 or JSON manifest.
+ * @brief Shared sidecar embedding LUT loaded from raw UINT16, JSON manifest,
+ *        or GGML (q4_0/q6_k) row payload.
  *
  * The payload is mmap'd read-only when possible so a multi-hundred-MB table
  * stays out of resident memory and rows are paged in on demand; `bytes` is
@@ -84,6 +86,11 @@ struct QuantLut {
 
   bool is_raw_u16 = false;
   bool is_signed4 = false;
+
+  /// GGML row-block payload (Q4_0/Q6_K); NONE for the packed-4bit/raw formats.
+  nntrainer::TensorDim::DataType ggml_dtype =
+    nntrainer::TensorDim::DataType::NONE;
+  size_t row_bytes = 0; ///< payload stride per row (ggml mode)
 
   void *mmap_ptr = nullptr;
   size_t mmap_len = 0;

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -67,6 +67,11 @@ public:
 
 /**
  * @brief Shared sidecar embedding LUT loaded from raw UINT16 or JSON manifest.
+ *
+ * The payload is mmap'd read-only when possible so a multi-hundred-MB table
+ * stays out of resident memory and rows are paged in on demand; `bytes` is
+ * the fallback container (mmap failure). Always access the payload through
+ * data()/payload_size().
  */
 struct QuantLut {
   std::vector<uint8_t> bytes;
@@ -79,6 +84,19 @@ struct QuantLut {
 
   bool is_raw_u16 = false;
   bool is_signed4 = false;
+
+  void *mmap_ptr = nullptr;
+  size_t mmap_len = 0;
+
+  const uint8_t *data() const {
+    return mmap_ptr ? static_cast<const uint8_t *>(mmap_ptr) : bytes.data();
+  }
+  size_t payload_size() const { return mmap_ptr ? mmap_len : bytes.size(); }
+
+  QuantLut() = default;
+  QuantLut(const QuantLut &) = delete;
+  QuantLut &operator=(const QuantLut &) = delete;
+  ~QuantLut();
 };
 
 /**

--- a/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
+++ b/Applications/CausalLM/layers/unittest_embedding_sidecar_lut.cpp
@@ -113,7 +113,7 @@ TEST(CausalLmEmbeddingSidecarLut, rawUint16RequiresExactHintedSize) {
   EXPECT_TRUE(lut->is_raw_u16);
   EXPECT_EQ(lut->in_dim, 2u);
   EXPECT_EQ(lut->out_dim, 3u);
-  EXPECT_EQ(lut->bytes.size(), 6u * sizeof(uint16_t));
+  EXPECT_EQ(lut->payload_size(), 6u * sizeof(uint16_t));
 
   const auto bad_path = dir.path() / "bad_embedding.u16";
   writeU16(bad_path, {1, 2, 3, 4, 5, 6});
@@ -142,7 +142,7 @@ TEST(CausalLmEmbeddingSidecarLut, ufixed8ManifestUsesRelativePathAndDims) {
   EXPECT_EQ(lut->out_dim, 4u);
   EXPECT_FLOAT_EQ(lut->scale, 0.5f);
   EXPECT_EQ(lut->offset, -1);
-  EXPECT_EQ(lut->bytes.size(), 6u);
+  EXPECT_EQ(lut->payload_size(), 6u);
 }
 
 TEST(CausalLmEmbeddingSidecarLut, sfixed4ManifestParsesAndValidatesRowScale) {


### PR DESCRIPTION
The embedding sidecar lookup table declared by `quantized_lut_path` was read whole into a heap
`std::vector<uint8_t>` at `finalize()`, so a multi-hundred-MB table became fully resident before the
first token was produced. This series maps the payload read-only instead, so rows page in on demand.

Base: this branch applies on top of `main` (base commit `308bdd4f3`, "[kleidiai] Add
`matmul_clamp_f16_qai8dxp_qsi4cxp`"). It has no dependency on any other pull request. `main` has moved
four commits ahead of that base since; none of those four touch
`Applications/CausalLM/layers/embedding_layer.{cpp,h}` or the sidecar unit test, so it still merges
cleanly. Rebasing onto current `main` is fine if preferred.

## Commits

1. `[causallm] Embedding sidecar LUT: mmap the payload read-only (lazy page-in)`
2. `[causallm] Sidecar LUT: make the unsupported-datatype error actionable`
3. `[causallm][OPTIONAL] Sidecar LUT: accept GGML q4_0/q6_k row payloads`
4. `[causallm][test] Sidecar LUT unit test: check payload_size(), not bytes.size()`
5. `[causallm] Sidecar LUT: restore the two-ways-forward text after GGML support landed`

Commit 3 is separable. Dropping it keeps GGML sidecar support deferred and leaves the actionable error
from commit 2 in place; commits 4 and 5 still apply. It is included because it is routing over the
dequant loop this file already runs (`dequantize_row_q4_0` / `dequantize_row_q6_K` were already consumed
here, so it adds no dependency), and because it is what makes the lazy page-in reachable for the
q4_0/q6_k sidecar packages that exist in practice.

## What changes

`QuantLut` gains `mmap_ptr`/`mmap_len` and `data()`/`payload_size()` accessors. `attachPayload()` opens
the file and calls `::mmap(PROT_READ, MAP_PRIVATE)` plus `madvise(MADV_RANDOM)` — token-id lookups are
random access, so readahead would defeat the point. If the map fails for any reason, it falls back to the
previous full read into `QuantLut::bytes`; every consumer now reads through the accessors, so decode
behaves identically on either backing store. `QuantLut` becomes non-copyable and owns the mapping,
unmapping in its destructor. On Windows the same `::mmap` call resolves to `MapViewOfFile` through the
existing `utils/mman_windows.h` shim, which also faults pages on demand. The process-wide `weak_ptr`
dedup in `get_or_load_quant_lut()` is unchanged and now dedups the mapping itself.

Commit 3 adds a `"q4_0"`/`"q6_k"` manifest datatype whose payload is the same row table an in-bin
embedding weight would hold. Decode reuses the existing `incremental_forwarding` dequant loop unchanged;
only the row base pointer is selected between the weight tensor and the mapping, and the row stride is
hoisted to the value the previous per-branch block math already produced. Sidecar output is therefore
bit-identical to the monolithic package by construction, not by coincidence.

## Effect, and what is actually measured

The honest claim is narrow, so let me separate what follows from the code from what rests on numbers.

**Provable by construction:** on the mmap path the heap vector is never allocated, so the payload is no
longer counted as anonymous resident memory at load. That is a property of the diff, not of a benchmark.

**Not established by this PR:** the magnitude. The commit messages carry figures from an earlier tree —
RSS reduction of roughly 1.27 GB, model init about 41% faster, load residual about 44% lower. Those were
single-run observations on a different tree and have **not** been reproduced on this branch. I am citing
them as the reason the change was made, not as a result this PR demonstrates. Treat them as an
expectation to be re-measured, and note that memory numbers on the devices in question have shown
run-to-run spreads wide enough to swallow differences of this order, so a single run per arm is not
sufficient evidence. I would rather understate this than repeat an earlier overclaim.

**A tradeoff worth naming explicitly:** commit 3 adds an `MADV_WILLNEED` prefetch to cover cold-start
prefill, because `MADV_RANDOM` disables readahead and a long prefill would otherwise serialize one major
fault per token (about 100–160 ms on NVMe on the earlier tree — again single-run, not re-measured).
`MADV_WILLNEED` pulls pages in, which pushes RSS **up**, so this is latency bought with memory, not a
free win. Two things bound the cost: it is gated on `iter > 1`, so it never fires during single-token
decode, and it advises only the specific rows of the incoming batch — token count times row stride, not
the table. The residency cost of that bounded set has not been measured. Reviewers who care more about
peak memory than prefill latency can drop commit 3 and keep the page-in behaviour.

## Compatibility

Packages without a `quantized_lut_path` are byte-identical by construction: no `QuantLut` is created,
`ggml_lut` is false, the loop reads the same weight rows through the same branches, and the only work
removed is the construction of a `Tensor` view that was never used on the quant branches.

## Verification status

Not run for this PR: no build, no model execution, no re-measurement. The claim that sidecar output is
bit-exact against the monolithic package follows from the shared decode path rather than from a run on
this branch. Please treat CI as the first compile signal. Two areas deserve reviewer attention in
particular: the Windows `_wopen` / `mman_windows.h` path, which no build here exercised, and the unit
test, which only compiles when tests are enabled — commit 4 fixes two assertions that read
`QuantLut::bytes` directly and would fail once the mmap path starts succeeding on a real filesystem.

Rebase and merge only, never squash.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>