### PR TITLE
[htp] HVX kernel device bring-up on CDSP

### DIFF
--- a/test/htp/.gitignore
+++ b/test/htp/.gitignore
@@ -1,0 +1,2 @@
+generated/
+build/

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates the FastRPC stub/skel from nntr_hvx.idl and builds the DSP skel.
+#
+# Prerequisite: source $HEXAGON_SDK_ROOT/setup_sdk_env.source
+# Override the target with: HEX_ARCH=v75 ./build.sh
+
+set -eu
+
+: "${HEXAGON_SDK_ROOT:?source setup_sdk_env.source first}"
+: "${DEFAULT_HEXAGON_TOOLS_ROOT:?source setup_sdk_env.source first}"
+
+HEX_ARCH="${HEX_ARCH:-v79}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+mkdir -p generated build
+
+"$HEXAGON_SDK_ROOT/ipc/fastrpc/qaic/Ubuntu/qaic" \
+    -I "$HEXAGON_SDK_ROOT/incs" \
+    -I "$HEXAGON_SDK_ROOT/incs/stddef" \
+    -mdll -o generated nntr_hvx.idl
+
+"$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
+    -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \
+    -Wall -Werror \
+    -I generated \
+    -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/qurt" \
+    -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/posix" \
+    -isystem "$HEXAGON_SDK_ROOT/incs" \
+    -isystem "$HEXAGON_SDK_ROOT/incs/stddef" \
+    -isystem "$HEXAGON_SDK_ROOT/ipc/fastrpc/incs" \
+    hvx_add_f32.c generated/nntr_hvx_skel.c \
+    -o build/libnntr_hvx_skel.so
+
+echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH)"

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * @file   hvx_add_f32.c
- * @brief  DSP-side implementation of the nntr_hvx FastRPC interface.
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
  *
- * Built into libnntr_hvx_skel.so and loaded into the CDSP unsigned PD.
+ * @file   hvx_add_f32.c
+ * @date   03 Aug 2026
+ * @brief  DSP-side implementation of the nntr_hvx FastRPC interface
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <stdlib.h>
@@ -51,8 +55,8 @@ int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
     return AEE_EUNSUPPORTED;
   }
 
-  /* FastRPC buffers carry no vector alignment guarantee, so the unaligned
-     vector type is what keeps this from faulting on a misaligned input. */
+  // FastRPC buffers carry no vector alignment guarantee, so the unaligned
+  // vector type is what keeps this from faulting on a misaligned input.
   const HVX_UVector *va = (const HVX_UVector *)a;
   const HVX_UVector *vb = (const HVX_UVector *)b;
   HVX_UVector *vc = (HVX_UVector *)c;
@@ -62,8 +66,8 @@ int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
     vc[i] = Q6_Vsf_vadd_VsfVsf(va[i], vb[i]);
   }
 
-  /* ponytail: scalar tail; a masked vector store would fold it in, add
-     that only if the tail shows up in a profile. */
+  // ponytail: scalar tail; a masked vector store would fold it in, add
+  // that only if the tail shows up in a profile.
   for (int i = n_vec * LANES; i < aLen; ++i) {
     c[i] = a[i] + b[i];
   }

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   hvx_add_f32.c
+ * @brief  DSP-side implementation of the nntr_hvx FastRPC interface.
+ *
+ * Built into libnntr_hvx_skel.so and loaded into the CDSP unsigned PD.
+ */
+
+#include <stdlib.h>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
+  (void)uri;
+  /* No per-session state; a unique non-NULL handle is all FastRPC needs. */
+  void *ctx = malloc(1);
+  if (!ctx) {
+    return AEE_ENOMEMORY;
+  }
+  *handle = (remote_handle64)ctx;
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_close(remote_handle64 handle) {
+  free((void *)handle);
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
+                     const float *b, int bLen, float *c, int cLen) {
+  (void)handle;
+  (void)a;
+  (void)b;
+  (void)c;
+
+  if (aLen != bLen || aLen != cLen) {
+    return AEE_EBADPARM;
+  }
+
+  /* Not implemented yet -- Task 3 replaces this with the HVX kernel.
+     Reaching this return proves the FastRPC path is up. */
+  return AEE_EUNSUPPORTED;
+}

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -11,7 +11,16 @@
 #include <AEEStdErr.h>
 #include <remote.h>
 
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+#include <qurt.h>
+
 #include "nntr_hvx.h"
+
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128
+/** @brief float lanes per HVX vector. */
+#define LANES ((int)(VLEN / sizeof(float)))
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
   (void)uri;
@@ -32,15 +41,32 @@ int nntr_hvx_close(remote_handle64 handle) {
 int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
                      const float *b, int bLen, float *c, int cLen) {
   (void)handle;
-  (void)a;
-  (void)b;
-  (void)c;
 
   if (aLen != bLen || aLen != cLen) {
     return AEE_EBADPARM;
   }
 
-  /* Not implemented yet -- Task 3 replaces this with the HVX kernel.
-     Reaching this return proves the FastRPC path is up. */
-  return AEE_EUNSUPPORTED;
+  /* Bits 15:8 hold the number of 128-byte HVX contexts. */
+  if (((qurt_hvx_get_units() >> 8) & 0xFF) == 0) {
+    return AEE_EUNSUPPORTED;
+  }
+
+  /* FastRPC buffers carry no vector alignment guarantee, so the unaligned
+     vector type is what keeps this from faulting on a misaligned input. */
+  const HVX_UVector *va = (const HVX_UVector *)a;
+  const HVX_UVector *vb = (const HVX_UVector *)b;
+  HVX_UVector *vc = (HVX_UVector *)c;
+
+  const int n_vec = aLen / LANES;
+  for (int i = 0; i < n_vec; ++i) {
+    vc[i] = Q6_Vsf_vadd_VsfVsf(va[i], vb[i]);
+  }
+
+  /* ponytail: scalar tail; a masked vector store would fold it in, add
+     that only if the tail shows up in a profile. */
+  for (int i = n_vec * LANES; i < aLen; ++i) {
+    c[i] = a[i] + b[i];
+  }
+
+  return AEE_SUCCESS;
 }

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -1,0 +1,13 @@
+//============================================================================
+// SPDX-License-Identifier: Apache-2.0
+//
+// FastRPC interface for HVX kernel device bring-up.
+//============================================================================
+
+#include "AEEStdDef.idl"
+#include "remote.idl"
+
+interface nntr_hvx : remote_handle64 {
+   AEEResult add_f32(in sequence<float> a, in sequence<float> b,
+                     rout sequence<float> c);
+};

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -897,3 +897,31 @@ LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
+
+# HVX device bring-up test. Needs the Hexagon SDK for the FastRPC headers
+# and the generated stub, so it is skipped entirely when the SDK is absent.
+# Build the skel first: test/htp/build.sh
+ifdef HEXAGON_SDK_ROOT
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_hvx_add
+LOCAL_CFLAGS := -Igoogletest/include -pthread -fexceptions -O3 -DNDK_BUILD=1
+LOCAL_CXXFLAGS += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_hvx_kernels.cpp \
+	 ../htp/generated/nntr_hvx_stub.c
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../htp/generated \
+	 $(HEXAGON_SDK_ROOT)/incs \
+	 $(HEXAGON_SDK_ROOT)/incs/stddef \
+	 $(HEXAGON_SDK_ROOT)/ipc/fastrpc/incs
+
+LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
+	 -lcdsprpc
+
+LOCAL_STATIC_LIBRARIES := googletest_main
+
+include $(BUILD_EXECUTABLE)
+endif

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
  * @file   unittest_hvx_kernels.cpp
- * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does.
+ * @date   03 Aug 2026
+ * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
  *
  * Runs on an Android device only. Requires libnntr_hvx_skel.so on
  * ADSP_LIBRARY_PATH. See test/htp/build.sh.
@@ -43,8 +49,7 @@ protected:
     remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
     int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
                                      &unsigned_pd, sizeof(unsigned_pd));
-    ASSERT_EQ(err, AEE_SUCCESS)
-      << "enabling unsigned PD failed: " << hex(err);
+    ASSERT_EQ(err, AEE_SUCCESS) << "enabling unsigned PD failed: " << hex(err);
 
     const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
     err = nntr_hvx_open(uri.c_str(), &handle_);
@@ -75,6 +80,18 @@ TEST_F(HvxAdd, MatchesCpuForFullVectorsPlusRemainder) {
   int err = nntr_hvx_add_f32(handle_, a.data(), n, b.data(), n, c.data(), n);
   ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
   EXPECT_EQ(c, expected);
+}
+
+TEST_F(HvxAdd, MatchesCpuBelowOneVector) {
+  // Fewer floats than a single vector holds: n_vec is 0 and only the
+  // scalar tail runs.
+  const std::vector<float> a = {1.5f};
+  const std::vector<float> b = {2.25f};
+  std::vector<float> c = {0.0f};
+
+  int err = nntr_hvx_add_f32(handle_, a.data(), 1, b.data(), 1, c.data(), 1);
+  ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
+  EXPECT_EQ(c[0], 3.75f);
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   unittest_hvx_kernels.cpp
+ * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does.
+ *
+ * Runs on an Android device only. Requires libnntr_hvx_skel.so on
+ * ADSP_LIBRARY_PATH. See test/htp/build.sh.
+ */
+
+#include <gtest/gtest.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+namespace {
+
+/** @brief Render a FastRPC error as hex so the code is searchable. */
+std::string hex(int err) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(8) << std::setfill('0')
+     << static_cast<unsigned>(err);
+  return os.str();
+}
+
+/**
+ * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ *
+ * A failure here is a hard FAIL rather than a skip: proving the DSP comes
+ * up on the device is the point of this test, so a quiet skip would
+ * report success for the thing being measured.
+ */
+class HvxAdd : public ::testing::Test {
+protected:
+  void SetUp() override {
+    remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
+    int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
+                                     &unsigned_pd, sizeof(unsigned_pd));
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "enabling unsigned PD failed: " << hex(err);
+
+    const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
+    err = nntr_hvx_open(uri.c_str(), &handle_);
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "nntr_hvx_open failed: " << hex(err)
+      << " -- is libnntr_hvx_skel.so on ADSP_LIBRARY_PATH?";
+  }
+
+  void TearDown() override {
+    if (handle_) {
+      nntr_hvx_close(handle_);
+    }
+  }
+
+  remote_handle64 handle_ = 0;
+};
+
+TEST_F(HvxAdd, MatchesCpuForFullVectorsPlusRemainder) {
+  // 100 floats = 3 full 128-byte vectors (32 floats each) + 4 left over.
+  const int n = 100;
+  std::vector<float> a(n), b(n), c(n, 0.0f), expected(n);
+  for (int i = 0; i < n; ++i) {
+    a[i] = static_cast<float>(i) * 0.5f;
+    b[i] = static_cast<float>(n - i) * 0.25f;
+    expected[i] = a[i] + b[i];
+  }
+
+  int err = nntr_hvx_add_f32(handle_, a.data(), n, b.data(), n, c.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
+  EXPECT_EQ(c, expected);
+}
+
+} // namespace
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -37,7 +37,7 @@ std::string hex(int err) {
 }
 
 /**
- * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ * @brief Opens an unsigned-PD CDSP session for the each test.
  *
  * A failure here is a hard FAIL rather than a skip: proving the DSP comes
  * up on the device is the point of this test, so a quiet skip would


### PR DESCRIPTION
## Dependency of the PR

None. This is a standalone device-side test that links neither libnntrainer nor test_util; it only uses FastRPC and gtest.

## Commits to be reviewed in this PR


<details><summary>8755f959 [htp] Add the FastRPC interface and DSP skel build for HVX bring-up</summary><br />

[htp] Add the FastRPC interface and DSP skel build for HVX bring-up

Defines a one-method IDL and the build script that turns it into a
loadable CDSP skel. qaic generates the stub and skel, hexagon-clang
builds them against v79 with HVX enabled; nothing here is hand-written
plumbing.

add_f32 returns AEE_EUNSUPPORTED for now, on purpose. The next commit's
test starts red against that return, which separates "the session
opened and the call reached the DSP" from "the kernel computes the
right values" -- two failures that are otherwise easy to confuse.

The build stays a manual step rather than a meson or ndk-build hook.
One kernel does not justify wiring a cross-compiler into the main build,
and a hook would have to be guarded for every environment without the
Hexagon SDK installed.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

</details>



<details><summary>960075e3 [htp] Verify an HVX kernel end to end on device</summary><br />

[htp] Verify an HVX kernel end to end on device

An nntrainer gtest opens an unsigned-PD CDSP session, calls an HVX
elementwise add across FastRPC, and compares the result bit for bit
against the CPU. 100 floats crosses three full 128-byte vectors and a
four-element tail, so one case covers both paths.

A failed session open is a FAIL, not a SKIP. Whether the DSP comes up on
the device is exactly what this test measures, and a skip would report
success for the measurement being absent.

Nothing locks HVX. The SDK's own profiling example uses HVX intrinsics
inside a skel with no lock -- the RPC thread already holds it -- so the
kernel only checks that a 128-byte context exists at all. Loads go
through HVX_UVector because FastRPC makes no alignment promise about
the buffers it hands the skel.

The module builds only under ifdef HEXAGON_SDK_ROOT and links neither
libnntrainer nor test_util; it needs FastRPC and gtest and nothing else.
Environments without the Hexagon SDK build exactly as before.

Deviation from plan (two changes, both required to build):

1. The test source is named unittest_hvx_kernels.cpp, not the plan's
   unittest_hvx_add.cpp. The LOCAL_MODULE (binary name) stays
   unittest_hvx_add so the existing adb push / run commands are
   unchanged.

2. The test defines its own int main(int argc, char**). The plan
   expected googletest_main to supply main(), but this repo's
   googletest_main module (Android.mk:82) compiles only gtest-all.cc;
   gtest_main.cc is absent. Every other unittest in this tree defines
   main at the bottom of its .cpp (e.g. unittest_common_properties.cpp:268). The
   new test follows that pattern rather than re-architecting the shared
   gtest module, which would touch every other test's build.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

</details>



<details><summary>8652ecf4 [htp] Cover the below-one-vector input for HVX add</summary><br />

[htp] Cover the below-one-vector input for HVX add

n=100 never exercises n_vec == 0, so the scalar tail runs unguarded for
any input shorter than a single 128-byte vector. This case pins that
boundary.

It likely passes without touching the kernel, which is the point: it is
a regression guard against a future rewrite that assumes at least one
full vector.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

</details>

### Summary

- Define a one-method FastRPC IDL (`nntr_hvx`) and a manual `build.sh` that runs `qaic` + `hexagon-clang` (v79, `-mhvx`) to produce `libnntr_hvx_skel.so` for the CDSP unsigned PD.
- Add a device-only gtest that opens an unsigned-PD CDSP session, calls an HVX elementwise add (`Q6_Vsf_vadd_VsfVsf`) across FastRPC, and compares the result bit-for-bit against the CPU. The TDD flow is preserved in history: commit 2 ships the stub returning `AEE_EUNSUPPORTED` first (RED proves the FastRPC path is up, separated from kernel correctness), commit 3 implements the HVX kernel (GREEN), commit 4 adds a below-one-vector regression guard.
- The test module builds only under `ifdef HEXAGON_SDK_ROOT` and links neither `libnntrainer` nor `test_util`; environments without the Hexagon SDK build exactly as before.
- Verified on Galaxy S25 Ultra (adb `R3CY205ZMND`, CDSP, v79): `[  PASSED  ] 2 tests.`

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
