### PR TITLE
[kleidiai] Add matmul_clamp_f32_qai8dxp_qsi8cxp

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.c
@@ -1,0 +1,244 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.c
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD)
+#error "Dotprod extension required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+// Compute args
+static const size_t kai_m_step = 1;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 1;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 4;
+static const size_t kai_sr = 1;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_qvalue_rhs = 1;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 4;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+inline static size_t kai_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t rhs_packed_stride = kai_nr * (k_internal * kai_num_bytes_qvalue_rhs);
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  float *restrict dst,             // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(float));
+
+  if (m == 0) {
+    return;
+  }
+
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t num_blocks = k_internal / kai_k_multiple_of;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  __asm__ __volatile__(
+    "mov x26, #0x20\n"
+    "mov x20, #0x8\n"
+    "mov x25, %x[m]\n"
+    "madd x26, %x[num_blocks], x26, x20\n"
+    "1:" // Row loop
+    "mov x24, %x[rhs_packed]\n"
+    "mov x23, %x[n]\n"
+    "add x22, %x[dst], %x[dst_stride_row]\n"
+    "2:" // Column loop
+    "mov x21, %x[lhs_packed]\n"
+    "movi v25.4s, #0x0\n"
+    "mov x20, %x[num_blocks]\n"
+    "3:" // Sub block loop
+    "ldr q16, [x24, #0x0]\n"
+    "ldr q24, [x21, #0x0]\n"
+    "subs x20, x20, #0x1\n"
+    "ldr q23, [x24, #0x10]\n"
+    "ldr q22, [x24, #0x20]\n"
+    "ldr q21, [x24, #0x30]\n"
+    "ldr q20, [x24, #0x40]\n"
+    "ldr q19, [x21, #0x10]\n"
+    "ldr q18, [x24, #0x50]\n"
+    ".inst 0x4f98e219  // sdot v25.4s, v16.16b, v24.4b[0]\n"
+    "add x21, x21, #0x20\n"
+    "ldr q17, [x24, #0x60]\n"
+    "ldr q16, [x24, #0x70]\n"
+    "add x24, x24, #0x80\n"
+    ".inst 0x4fb8e2f9  // sdot v25.4s, v23.16b, v24.4b[1]\n"
+    ".inst 0x4f98ead9  // sdot v25.4s, v22.16b, v24.4b[2]\n"
+    ".inst 0x4fb8eab9  // sdot v25.4s, v21.16b, v24.4b[3]\n"
+    ".inst 0x4f93e299  // sdot v25.4s, v20.16b, v19.4b[0]\n"
+    ".inst 0x4fb3e259  // sdot v25.4s, v18.16b, v19.4b[1]\n"
+    ".inst 0x4f93ea39  // sdot v25.4s, v17.16b, v19.4b[2]\n"
+    ".inst 0x4fb3ea19  // sdot v25.4s, v16.16b, v19.4b[3]\n"
+    "bgt 3b\n"
+    "ldr q22, [x24, #0x0]\n"
+    "ld1r { v21.4s }, [x21]\n"
+    "add x21, x21, #0x4\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "ld1r { v20.4s }, [x21]\n"
+    "ldr q16, [x24, #0x10]\n"
+    "cmp x23, #0x4\n"
+    "ldr q19, [x24, #0x20]\n"
+    "ld1r { v18.4s }, [%x[clamp_vals]]\n"
+    "add x24, x24, #0x30\n"
+    "ld1r { v17.4s }, [x20]\n"
+    "mla v25.4s, v22.4s, v21.s[0]\n"
+    "fmul v16.4s, v16.4s, v20.4s\n"
+    "scvtf v25.4s, v25.4s\n"
+    "fmul v16.4s, v25.4s, v16.4s\n"
+    "fadd v16.4s, v16.4s, v19.4s\n"
+    "fmax v16.4s, v16.4s, v18.4s\n"
+    "fmin v16.4s, v16.4s, v17.4s\n"
+    "blt 4f\n"
+    "str q16, [%x[dst], #0x0]\n"
+    "b 7f\n"
+    "4:" // Partial output
+    "mov x20, %x[dst]\n"
+    "tbz x23, #1, 5f\n"
+    "st1 { v16.d }[0], [x20], #0x8\n"
+    "tbz x23, #0, 6f\n"
+    "st1 { v16.s }[2], [x20]\n"
+    "b 6f\n"
+    "5:" // Output block 0: partial_1_0
+    "st1 { v16.s }[0], [x20]\n"
+    "6:" // Output block 0: Done
+    "7:" // Stores done
+    "subs x23, x23, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 2b\n"
+    "subs x25, x25, #0x1\n"
+    "add %x[lhs_packed], %x[lhs_packed], x26\n"
+    "mov %x[dst], x22\n"
+    "bgt 1b\n"
+    : [dst] "+&r"(dst), [lhs_packed] "+&r"(lhs_packed)
+    : [clamp_vals] "r"(clamp_vals), [dst_stride_row] "r"(dst_stride_row),
+      [m] "r"(m), [n] "r"(n), [num_blocks] "r"(num_blocks),
+      [rhs_packed] "r"(rhs_packed)
+    : "cc", "memory", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+      "v24", "v25", "x20", "x21", "x22", "x23", "x24", "x25", "x26");
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h
@@ -1,0 +1,163 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f32 to dynamically quantize and pack the
+/// LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be 1.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 8-bit with per-channel
+/// quantization (qsi8cx) values.
+///
+/// @param[in] n_idx Row index in the RHS matrix (not packed). It must be a
+/// multiple of 4.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be 1.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple
+/// of 4.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed RHS matrix: Quantized Symmetric Signed 8-bit with
+/// per-channel quantization (qsi8cx) and packed. Output tile: (rows x cols) = 1
+/// x 4
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written. It must be 1.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(float) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  float *dst,             //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.c
@@ -1,0 +1,248 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.c
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD)
+#error "Dotprod extension required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+// Compute args
+static const size_t kai_m_step = 1;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 1;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 8;
+static const size_t kai_sr = 1;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_qvalue_rhs = 1;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 4;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+inline static size_t kai_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t rhs_packed_stride = kai_nr * (k_internal * kai_num_bytes_qvalue_rhs);
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  float *restrict dst,             // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(float));
+
+  if (m == 0) {
+    return;
+  }
+
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t num_blocks = k_internal / kai_k_multiple_of;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  __asm__ __volatile__(
+    "mov x26, #0x20\n"
+    "mov x20, #0x8\n"
+    "mov x25, %x[m]\n"
+    "madd x26, %x[num_blocks], x26, x20\n"
+    "1:" // Row loop
+    "mov x24, %x[rhs_packed]\n"
+    "mov x23, %x[n]\n"
+    "add x22, %x[dst], %x[dst_stride_row]\n"
+    "2:" // Column loop
+    "mov x21, %x[lhs_packed]\n"
+    "movi v27.4s, #0x0\n"
+    "movi v26.4s, #0x0\n"
+    "mov x20, %x[num_blocks]\n"
+    "3:" // Sub block loop
+    "ldr q25, [x24, #0x0]\n"
+    "ldr q17, [x24, #0x10]\n"
+    "subs x20, x20, #0x1\n"
+    "ld1r { v16.2d }, [x21], #0x8\n"
+    "ldr q24, [x24, #0x20]\n"
+    "ldr q23, [x24, #0x30]\n"
+    "ldr q22, [x24, #0x40]\n"
+    "ld1r { v21.2d }, [x21], #0x8\n"
+    "ldr q20, [x24, #0x50]\n"
+    "ld1r { v19.2d }, [x21], #0x8\n"
+    "ldr q18, [x24, #0x60]\n"
+    ".inst 0x4e90973b  // sdot v27.4s, v25.16b, v16.16b\n"
+    ".inst 0x4e90963a  // sdot v26.4s, v17.16b, v16.16b\n"
+    "ldr q17, [x24, #0x70]\n"
+    "add x24, x24, #0x80\n"
+    "ld1r { v16.2d }, [x21], #0x8\n"
+    ".inst 0x4e95971b  // sdot v27.4s, v24.16b, v21.16b\n"
+    ".inst 0x4e9596fa  // sdot v26.4s, v23.16b, v21.16b\n"
+    ".inst 0x4e9396db  // sdot v27.4s, v22.16b, v19.16b\n"
+    ".inst 0x4e93969a  // sdot v26.4s, v20.16b, v19.16b\n"
+    ".inst 0x4e90965b  // sdot v27.4s, v18.16b, v16.16b\n"
+    ".inst 0x4e90963a  // sdot v26.4s, v17.16b, v16.16b\n"
+    "bgt 3b\n"
+    "ldr q22, [x24, #0x0]\n"
+    "ld1r { v21.4s }, [x21]\n"
+    "addp v27.4s, v27.4s, v26.4s\n"
+    "add x21, x21, #0x4\n"
+    "ld1r { v20.4s }, [x21]\n"
+    "ldr q16, [x24, #0x10]\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "cmp x23, #0x4\n"
+    "ldr q19, [x24, #0x20]\n"
+    "ld1r { v18.4s }, [%x[clamp_vals]]\n"
+    "add x24, x24, #0x30\n"
+    "ld1r { v17.4s }, [x20]\n"
+    "mla v27.4s, v22.4s, v21.s[0]\n"
+    "fmul v16.4s, v16.4s, v20.4s\n"
+    "scvtf v27.4s, v27.4s\n"
+    "fmul v16.4s, v27.4s, v16.4s\n"
+    "fadd v16.4s, v16.4s, v19.4s\n"
+    "fmax v16.4s, v16.4s, v18.4s\n"
+    "fmin v16.4s, v16.4s, v17.4s\n"
+    "blt 4f\n"
+    "str q16, [%x[dst], #0x0]\n"
+    "b 7f\n"
+    "4:" // Partial output
+    "mov x20, %x[dst]\n"
+    "tbz x23, #1, 5f\n"
+    "st1 { v16.d }[0], [x20], #0x8\n"
+    "tbz x23, #0, 6f\n"
+    "st1 { v16.s }[2], [x20]\n"
+    "b 6f\n"
+    "5:" // Output block 0: partial_1_0
+    "st1 { v16.s }[0], [x20]\n"
+    "6:" // Output block 0: Done
+    "7:" // Stores done
+    "subs x23, x23, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 2b\n"
+    "subs x25, x25, #0x1\n"
+    "add %x[lhs_packed], %x[lhs_packed], x26\n"
+    "mov %x[dst], x22\n"
+    "bgt 1b\n"
+    : [dst] "+&r"(dst), [lhs_packed] "+&r"(lhs_packed)
+    : [clamp_vals] "r"(clamp_vals), [dst_stride_row] "r"(dst_stride_row),
+      [m] "r"(m), [n] "r"(n), [num_blocks] "r"(num_blocks),
+      [rhs_packed] "r"(rhs_packed)
+    : "cc", "memory", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+      "v24", "v25", "v26", "v27", "x20", "x21", "x22", "x23", "x24", "x25",
+      "x26");
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h
@@ -1,0 +1,163 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f32 to dynamically quantize and pack the
+/// LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be 1.
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 8-bit with per-channel
+/// quantization (qsi8cx) values.
+///
+/// @param[in] n_idx Row index in the RHS matrix (not packed). It must be a
+/// multiple of 4.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be 1.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple
+/// of 4.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed RHS matrix: Quantized Symmetric Signed 8-bit with
+/// per-channel quantization (qsi8cx) and packed. Output tile: (rows x cols) = 1
+/// x 4
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written. It must be 1.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(float) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  float *dst,             //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.c
@@ -1,0 +1,797 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.c
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Do not flag up inline assembly blocks
+#pragma GCC diagnostic ignored "-Woverlength-strings"
+
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_DOTPROD)
+#error "Dotprod extension required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+// Compute args
+static const size_t kai_m_step = 16;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 4;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 4;
+static const size_t kai_sr = 1;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_qvalue_rhs = 1;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 4;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+inline static size_t kai_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t rhs_packed_stride = kai_nr * (k_internal * kai_num_bytes_qvalue_rhs);
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_n_step;
+}
+
+size_t
+kai_get_mr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_mr;
+}
+
+size_t
+kai_get_nr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_nr;
+}
+
+size_t
+kai_get_kr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_kr;
+}
+
+size_t
+kai_get_sr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_rhs_packed_stride(k);
+}
+
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t
+kai_get_dst_size_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  float *restrict dst,             // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(float));
+
+  if (m == 0) {
+    return;
+  }
+
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t num_blocks = k_internal / kai_k_multiple_of;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  __asm__ __volatile__(
+    "mov x13, %x[m]\n"
+    "mov x12, #0x80\n"
+    "mov x20, #0x20\n"
+    "cmp x13, #0x10\n"
+    "madd x12, %x[num_blocks], x12, x20\n"
+    "blt 14f\n"
+    "1:" // Row loop
+    "mov x11, %x[rhs_packed]\n"
+    "mov x10, %x[n]\n"
+    "add x9, %x[dst], %x[dst_stride_row], LSL #4\n"
+    "2:" // Column loop
+    "mov x27, %x[lhs_packed]\n"
+    "movi v31.4s, #0x0\n"
+    "movi v30.4s, #0x0\n"
+    "mov x23, %x[num_blocks]\n"
+    "movi v29.4s, #0x0\n"
+    "movi v28.4s, #0x0\n"
+    "movi v27.4s, #0x0\n"
+    "movi v26.4s, #0x0\n"
+    "add x22, x27, x12\n"
+    "add x21, x22, x12\n"
+    "add x20, x21, x12\n"
+    "movi v25.4s, #0x0\n"
+    "movi v24.4s, #0x0\n"
+    "movi v23.4s, #0x0\n"
+    "movi v22.4s, #0x0\n"
+    "movi v21.4s, #0x0\n"
+    "movi v20.4s, #0x0\n"
+    "movi v19.4s, #0x0\n"
+    "movi v18.4s, #0x0\n"
+    "movi v17.4s, #0x0\n"
+    "movi v16.4s, #0x0\n"
+    "3:" // Sub block loop
+    "ldr q15, [x11, #0x0]\n"
+    "ldr q7, [x27, #0x0]\n"
+    "subs x23, x23, #0x1\n"
+    "ldr q5, [x22, #0x0]\n"
+    "ldr q6, [x21, #0x0]\n"
+    "ldr q4, [x20, #0x0]\n"
+    "ldr q14, [x11, #0x10]\n"
+    "ldr q3, [x27, #0x10]\n"
+    "ldr q2, [x22, #0x10]\n"
+    ".inst 0x4f87e1ff  // sdot v31.4s, v15.16b, v7.4b[0]\n"
+    ".inst 0x4fa7e1fe  // sdot v30.4s, v15.16b, v7.4b[1]\n"
+    "ldr q1, [x21, #0x10]\n"
+    "ldr q0, [x20, #0x10]\n"
+    ".inst 0x4f87e9fd  // sdot v29.4s, v15.16b, v7.4b[2]\n"
+    ".inst 0x4fa7e9fc  // sdot v28.4s, v15.16b, v7.4b[3]\n"
+    "ldr q10, [x11, #0x20]\n"
+    "ldr q13, [x27, #0x20]\n"
+    ".inst 0x4f85e1fb  // sdot v27.4s, v15.16b, v5.4b[0]\n"
+    ".inst 0x4fa5e1fa  // sdot v26.4s, v15.16b, v5.4b[1]\n"
+    "ldr q12, [x22, #0x20]\n"
+    "ldr q11, [x21, #0x20]\n"
+    ".inst 0x4f85e9f9  // sdot v25.4s, v15.16b, v5.4b[2]\n"
+    ".inst 0x4fa5e9f8  // sdot v24.4s, v15.16b, v5.4b[3]\n"
+    "ldr q9, [x20, #0x20]\n"
+    "ldr q5, [x11, #0x30]\n"
+    ".inst 0x4f86e1f7  // sdot v23.4s, v15.16b, v6.4b[0]\n"
+    ".inst 0x4fa6e1f6  // sdot v22.4s, v15.16b, v6.4b[1]\n"
+    "ldr q8, [x27, #0x30]\n"
+    "ldr q7, [x22, #0x30]\n"
+    ".inst 0x4f86e9f5  // sdot v21.4s, v15.16b, v6.4b[2]\n"
+    ".inst 0x4fa6e9f4  // sdot v20.4s, v15.16b, v6.4b[3]\n"
+    "ldr q6, [x21, #0x30]\n"
+    ".inst 0x4f84e1f3  // sdot v19.4s, v15.16b, v4.4b[0]\n"
+    ".inst 0x4fa4e1f2  // sdot v18.4s, v15.16b, v4.4b[1]\n"
+    ".inst 0x4f84e9f1  // sdot v17.4s, v15.16b, v4.4b[2]\n"
+    ".inst 0x4fa4e9f0  // sdot v16.4s, v15.16b, v4.4b[3]\n"
+    "ldr q4, [x20, #0x30]\n"
+    "ldr q15, [x11, #0x40]\n"
+    ".inst 0x4f83e1df  // sdot v31.4s, v14.16b, v3.4b[0]\n"
+    ".inst 0x4fa3e1de  // sdot v30.4s, v14.16b, v3.4b[1]\n"
+    ".inst 0x4f83e9dd  // sdot v29.4s, v14.16b, v3.4b[2]\n"
+    ".inst 0x4fa3e9dc  // sdot v28.4s, v14.16b, v3.4b[3]\n"
+    "ldr q3, [x27, #0x40]\n"
+    ".inst 0x4f82e1db  // sdot v27.4s, v14.16b, v2.4b[0]\n"
+    ".inst 0x4fa2e1da  // sdot v26.4s, v14.16b, v2.4b[1]\n"
+    ".inst 0x4f82e9d9  // sdot v25.4s, v14.16b, v2.4b[2]\n"
+    ".inst 0x4fa2e9d8  // sdot v24.4s, v14.16b, v2.4b[3]\n"
+    "ldr q2, [x22, #0x40]\n"
+    ".inst 0x4f81e1d7  // sdot v23.4s, v14.16b, v1.4b[0]\n"
+    ".inst 0x4fa1e1d6  // sdot v22.4s, v14.16b, v1.4b[1]\n"
+    ".inst 0x4f81e9d5  // sdot v21.4s, v14.16b, v1.4b[2]\n"
+    ".inst 0x4fa1e9d4  // sdot v20.4s, v14.16b, v1.4b[3]\n"
+    "ldr q1, [x21, #0x40]\n"
+    ".inst 0x4f80e1d3  // sdot v19.4s, v14.16b, v0.4b[0]\n"
+    ".inst 0x4fa0e1d2  // sdot v18.4s, v14.16b, v0.4b[1]\n"
+    ".inst 0x4f80e9d1  // sdot v17.4s, v14.16b, v0.4b[2]\n"
+    ".inst 0x4fa0e9d0  // sdot v16.4s, v14.16b, v0.4b[3]\n"
+    "ldr q0, [x20, #0x40]\n"
+    "ldr q14, [x11, #0x50]\n"
+    ".inst 0x4f8de15f  // sdot v31.4s, v10.16b, v13.4b[0]\n"
+    ".inst 0x4fade15e  // sdot v30.4s, v10.16b, v13.4b[1]\n"
+    ".inst 0x4f8de95d  // sdot v29.4s, v10.16b, v13.4b[2]\n"
+    ".inst 0x4fade95c  // sdot v28.4s, v10.16b, v13.4b[3]\n"
+    "ldr q13, [x27, #0x50]\n"
+    ".inst 0x4f8ce15b  // sdot v27.4s, v10.16b, v12.4b[0]\n"
+    ".inst 0x4face15a  // sdot v26.4s, v10.16b, v12.4b[1]\n"
+    ".inst 0x4f8ce959  // sdot v25.4s, v10.16b, v12.4b[2]\n"
+    ".inst 0x4face958  // sdot v24.4s, v10.16b, v12.4b[3]\n"
+    "ldr q12, [x22, #0x50]\n"
+    ".inst 0x4f8be157  // sdot v23.4s, v10.16b, v11.4b[0]\n"
+    ".inst 0x4fabe156  // sdot v22.4s, v10.16b, v11.4b[1]\n"
+    ".inst 0x4f8be955  // sdot v21.4s, v10.16b, v11.4b[2]\n"
+    ".inst 0x4fabe954  // sdot v20.4s, v10.16b, v11.4b[3]\n"
+    "ldr q11, [x21, #0x50]\n"
+    ".inst 0x4f89e153  // sdot v19.4s, v10.16b, v9.4b[0]\n"
+    ".inst 0x4fa9e152  // sdot v18.4s, v10.16b, v9.4b[1]\n"
+    ".inst 0x4f89e951  // sdot v17.4s, v10.16b, v9.4b[2]\n"
+    ".inst 0x4fa9e950  // sdot v16.4s, v10.16b, v9.4b[3]\n"
+    "ldr q10, [x20, #0x50]\n"
+    "ldr q9, [x11, #0x60]\n"
+    ".inst 0x4f88e0bf  // sdot v31.4s, v5.16b, v8.4b[0]\n"
+    ".inst 0x4fa8e0be  // sdot v30.4s, v5.16b, v8.4b[1]\n"
+    ".inst 0x4f88e8bd  // sdot v29.4s, v5.16b, v8.4b[2]\n"
+    ".inst 0x4fa8e8bc  // sdot v28.4s, v5.16b, v8.4b[3]\n"
+    "ldr q8, [x27, #0x60]\n"
+    ".inst 0x4f87e0bb  // sdot v27.4s, v5.16b, v7.4b[0]\n"
+    ".inst 0x4fa7e0ba  // sdot v26.4s, v5.16b, v7.4b[1]\n"
+    ".inst 0x4f87e8b9  // sdot v25.4s, v5.16b, v7.4b[2]\n"
+    ".inst 0x4fa7e8b8  // sdot v24.4s, v5.16b, v7.4b[3]\n"
+    "ldr q7, [x22, #0x60]\n"
+    ".inst 0x4f86e0b7  // sdot v23.4s, v5.16b, v6.4b[0]\n"
+    ".inst 0x4fa6e0b6  // sdot v22.4s, v5.16b, v6.4b[1]\n"
+    ".inst 0x4f86e8b5  // sdot v21.4s, v5.16b, v6.4b[2]\n"
+    ".inst 0x4fa6e8b4  // sdot v20.4s, v5.16b, v6.4b[3]\n"
+    "ldr q6, [x21, #0x60]\n"
+    ".inst 0x4f84e0b3  // sdot v19.4s, v5.16b, v4.4b[0]\n"
+    ".inst 0x4fa4e0b2  // sdot v18.4s, v5.16b, v4.4b[1]\n"
+    ".inst 0x4f84e8b1  // sdot v17.4s, v5.16b, v4.4b[2]\n"
+    ".inst 0x4fa4e8b0  // sdot v16.4s, v5.16b, v4.4b[3]\n"
+    "ldr q5, [x20, #0x60]\n"
+    "ldr q4, [x11, #0x70]\n"
+    ".inst 0x4f83e1ff  // sdot v31.4s, v15.16b, v3.4b[0]\n"
+    ".inst 0x4fa3e1fe  // sdot v30.4s, v15.16b, v3.4b[1]\n"
+    "add x11, x11, #0x80\n"
+    ".inst 0x4f83e9fd  // sdot v29.4s, v15.16b, v3.4b[2]\n"
+    ".inst 0x4fa3e9fc  // sdot v28.4s, v15.16b, v3.4b[3]\n"
+    "ldr q3, [x27, #0x70]\n"
+    "add x27, x27, #0x80\n"
+    ".inst 0x4f82e1fb  // sdot v27.4s, v15.16b, v2.4b[0]\n"
+    ".inst 0x4fa2e1fa  // sdot v26.4s, v15.16b, v2.4b[1]\n"
+    ".inst 0x4f82e9f9  // sdot v25.4s, v15.16b, v2.4b[2]\n"
+    ".inst 0x4fa2e9f8  // sdot v24.4s, v15.16b, v2.4b[3]\n"
+    "ldr q2, [x22, #0x70]\n"
+    "add x22, x22, #0x80\n"
+    ".inst 0x4f81e1f7  // sdot v23.4s, v15.16b, v1.4b[0]\n"
+    ".inst 0x4fa1e1f6  // sdot v22.4s, v15.16b, v1.4b[1]\n"
+    ".inst 0x4f81e9f5  // sdot v21.4s, v15.16b, v1.4b[2]\n"
+    ".inst 0x4fa1e9f4  // sdot v20.4s, v15.16b, v1.4b[3]\n"
+    "ldr q1, [x21, #0x70]\n"
+    "add x21, x21, #0x80\n"
+    ".inst 0x4f80e1f3  // sdot v19.4s, v15.16b, v0.4b[0]\n"
+    ".inst 0x4fa0e1f2  // sdot v18.4s, v15.16b, v0.4b[1]\n"
+    ".inst 0x4f80e9f1  // sdot v17.4s, v15.16b, v0.4b[2]\n"
+    ".inst 0x4fa0e9f0  // sdot v16.4s, v15.16b, v0.4b[3]\n"
+    "ldr q0, [x20, #0x70]\n"
+    "add x20, x20, #0x80\n"
+    ".inst 0x4f8de1df  // sdot v31.4s, v14.16b, v13.4b[0]\n"
+    ".inst 0x4fade1de  // sdot v30.4s, v14.16b, v13.4b[1]\n"
+    ".inst 0x4f8de9dd  // sdot v29.4s, v14.16b, v13.4b[2]\n"
+    ".inst 0x4fade9dc  // sdot v28.4s, v14.16b, v13.4b[3]\n"
+    ".inst 0x4f8ce1db  // sdot v27.4s, v14.16b, v12.4b[0]\n"
+    ".inst 0x4face1da  // sdot v26.4s, v14.16b, v12.4b[1]\n"
+    ".inst 0x4f8ce9d9  // sdot v25.4s, v14.16b, v12.4b[2]\n"
+    ".inst 0x4face9d8  // sdot v24.4s, v14.16b, v12.4b[3]\n"
+    ".inst 0x4f8be1d7  // sdot v23.4s, v14.16b, v11.4b[0]\n"
+    ".inst 0x4fabe1d6  // sdot v22.4s, v14.16b, v11.4b[1]\n"
+    ".inst 0x4f8be9d5  // sdot v21.4s, v14.16b, v11.4b[2]\n"
+    ".inst 0x4fabe9d4  // sdot v20.4s, v14.16b, v11.4b[3]\n"
+    ".inst 0x4f8ae1d3  // sdot v19.4s, v14.16b, v10.4b[0]\n"
+    ".inst 0x4faae1d2  // sdot v18.4s, v14.16b, v10.4b[1]\n"
+    ".inst 0x4f8ae9d1  // sdot v17.4s, v14.16b, v10.4b[2]\n"
+    ".inst 0x4faae9d0  // sdot v16.4s, v14.16b, v10.4b[3]\n"
+    ".inst 0x4f88e13f  // sdot v31.4s, v9.16b, v8.4b[0]\n"
+    ".inst 0x4fa8e13e  // sdot v30.4s, v9.16b, v8.4b[1]\n"
+    ".inst 0x4f88e93d  // sdot v29.4s, v9.16b, v8.4b[2]\n"
+    ".inst 0x4fa8e93c  // sdot v28.4s, v9.16b, v8.4b[3]\n"
+    ".inst 0x4f87e13b  // sdot v27.4s, v9.16b, v7.4b[0]\n"
+    ".inst 0x4fa7e13a  // sdot v26.4s, v9.16b, v7.4b[1]\n"
+    ".inst 0x4f87e939  // sdot v25.4s, v9.16b, v7.4b[2]\n"
+    ".inst 0x4fa7e938  // sdot v24.4s, v9.16b, v7.4b[3]\n"
+    ".inst 0x4f86e137  // sdot v23.4s, v9.16b, v6.4b[0]\n"
+    ".inst 0x4fa6e136  // sdot v22.4s, v9.16b, v6.4b[1]\n"
+    ".inst 0x4f86e935  // sdot v21.4s, v9.16b, v6.4b[2]\n"
+    ".inst 0x4fa6e934  // sdot v20.4s, v9.16b, v6.4b[3]\n"
+    ".inst 0x4f85e133  // sdot v19.4s, v9.16b, v5.4b[0]\n"
+    ".inst 0x4fa5e132  // sdot v18.4s, v9.16b, v5.4b[1]\n"
+    ".inst 0x4f85e931  // sdot v17.4s, v9.16b, v5.4b[2]\n"
+    ".inst 0x4fa5e930  // sdot v16.4s, v9.16b, v5.4b[3]\n"
+    ".inst 0x4f83e09f  // sdot v31.4s, v4.16b, v3.4b[0]\n"
+    ".inst 0x4fa3e09e  // sdot v30.4s, v4.16b, v3.4b[1]\n"
+    ".inst 0x4f83e89d  // sdot v29.4s, v4.16b, v3.4b[2]\n"
+    ".inst 0x4fa3e89c  // sdot v28.4s, v4.16b, v3.4b[3]\n"
+    ".inst 0x4f82e09b  // sdot v27.4s, v4.16b, v2.4b[0]\n"
+    ".inst 0x4fa2e09a  // sdot v26.4s, v4.16b, v2.4b[1]\n"
+    ".inst 0x4f82e899  // sdot v25.4s, v4.16b, v2.4b[2]\n"
+    ".inst 0x4fa2e898  // sdot v24.4s, v4.16b, v2.4b[3]\n"
+    ".inst 0x4f81e097  // sdot v23.4s, v4.16b, v1.4b[0]\n"
+    ".inst 0x4fa1e096  // sdot v22.4s, v4.16b, v1.4b[1]\n"
+    ".inst 0x4f81e895  // sdot v21.4s, v4.16b, v1.4b[2]\n"
+    ".inst 0x4fa1e894  // sdot v20.4s, v4.16b, v1.4b[3]\n"
+    ".inst 0x4f80e093  // sdot v19.4s, v4.16b, v0.4b[0]\n"
+    ".inst 0x4fa0e092  // sdot v18.4s, v4.16b, v0.4b[1]\n"
+    ".inst 0x4f80e891  // sdot v17.4s, v4.16b, v0.4b[2]\n"
+    ".inst 0x4fa0e890  // sdot v16.4s, v4.16b, v0.4b[3]\n"
+    "bgt 3b\n"
+    "ldr q5, [x11, #0x0]\n"
+    "ld1 { v1.4s }, [x27]\n"
+    "add x27, x27, #0x10\n"
+    "ldr q4, [x11, #0x10]\n"
+    "ldr q0, [x27, #0x0]\n"
+    "add x11, x11, #0x20\n"
+    "mla v31.4s, v5.4s, v1.s[0]\n"
+    "mla v30.4s, v5.4s, v1.s[1]\n"
+    "mla v29.4s, v5.4s, v1.s[2]\n"
+    "mla v28.4s, v5.4s, v1.s[3]\n"
+    "fmul v3.4s, v4.4s, v0.s[0]\n"
+    "fmul v2.4s, v4.4s, v0.s[1]\n"
+    "fmul v1.4s, v4.4s, v0.s[2]\n"
+    "scvtf v31.4s, v31.4s\n"
+    "fmul v0.4s, v4.4s, v0.s[3]\n"
+    "scvtf v30.4s, v30.4s\n"
+    "scvtf v29.4s, v29.4s\n"
+    "scvtf v28.4s, v28.4s\n"
+    "fmul v31.4s, v31.4s, v3.4s\n"
+    "fmul v30.4s, v30.4s, v2.4s\n"
+    "fmul v29.4s, v29.4s, v1.4s\n"
+    "fmul v28.4s, v28.4s, v0.4s\n"
+    "ld1 { v1.4s }, [x22]\n"
+    "add x22, x22, #0x10\n"
+    "ldr q0, [x22, #0x0]\n"
+    "mla v27.4s, v5.4s, v1.s[0]\n"
+    "mla v26.4s, v5.4s, v1.s[1]\n"
+    "mla v25.4s, v5.4s, v1.s[2]\n"
+    "mla v24.4s, v5.4s, v1.s[3]\n"
+    "fmul v3.4s, v4.4s, v0.s[0]\n"
+    "fmul v2.4s, v4.4s, v0.s[1]\n"
+    "fmul v1.4s, v4.4s, v0.s[2]\n"
+    "scvtf v27.4s, v27.4s\n"
+    "fmul v0.4s, v4.4s, v0.s[3]\n"
+    "scvtf v26.4s, v26.4s\n"
+    "scvtf v25.4s, v25.4s\n"
+    "scvtf v24.4s, v24.4s\n"
+    "fmul v27.4s, v27.4s, v3.4s\n"
+    "fmul v26.4s, v26.4s, v2.4s\n"
+    "fmul v25.4s, v25.4s, v1.4s\n"
+    "fmul v24.4s, v24.4s, v0.4s\n"
+    "ld1 { v1.4s }, [x21]\n"
+    "add x21, x21, #0x10\n"
+    "ldr q0, [x21, #0x0]\n"
+    "mla v23.4s, v5.4s, v1.s[0]\n"
+    "mla v22.4s, v5.4s, v1.s[1]\n"
+    "mla v21.4s, v5.4s, v1.s[2]\n"
+    "mla v20.4s, v5.4s, v1.s[3]\n"
+    "fmul v3.4s, v4.4s, v0.s[0]\n"
+    "fmul v2.4s, v4.4s, v0.s[1]\n"
+    "fmul v1.4s, v4.4s, v0.s[2]\n"
+    "scvtf v23.4s, v23.4s\n"
+    "fmul v0.4s, v4.4s, v0.s[3]\n"
+    "scvtf v22.4s, v22.4s\n"
+    "scvtf v21.4s, v21.4s\n"
+    "scvtf v20.4s, v20.4s\n"
+    "fmul v23.4s, v23.4s, v3.4s\n"
+    "fmul v22.4s, v22.4s, v2.4s\n"
+    "fmul v21.4s, v21.4s, v1.4s\n"
+    "fmul v20.4s, v20.4s, v0.4s\n"
+    "ld1 { v1.4s }, [x20]\n"
+    "add x20, x20, #0x10\n"
+    "ldr q0, [x20, #0x0]\n"
+    "mla v19.4s, v5.4s, v1.s[0]\n"
+    "mla v18.4s, v5.4s, v1.s[1]\n"
+    "mla v17.4s, v5.4s, v1.s[2]\n"
+    "mla v16.4s, v5.4s, v1.s[3]\n"
+    "fmul v3.4s, v4.4s, v0.s[0]\n"
+    "fmul v2.4s, v4.4s, v0.s[1]\n"
+    "fmul v1.4s, v4.4s, v0.s[2]\n"
+    "scvtf v19.4s, v19.4s\n"
+    "fmul v0.4s, v4.4s, v0.s[3]\n"
+    "scvtf v18.4s, v18.4s\n"
+    "scvtf v17.4s, v17.4s\n"
+    "scvtf v16.4s, v16.4s\n"
+    "fmul v19.4s, v19.4s, v3.4s\n"
+    "fmul v18.4s, v18.4s, v2.4s\n"
+    "fmul v17.4s, v17.4s, v1.4s\n"
+    "fmul v16.4s, v16.4s, v0.4s\n"
+    "ldr q2, [x11, #0x0]\n"
+    "ld1r { v1.4s }, [%x[clamp_vals]]\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "cmp x10, #0x4\n"
+    "ld1r { v0.4s }, [x20]\n"
+    "add x11, x11, #0x10\n"
+    "fadd v31.4s, v31.4s, v2.4s\n"
+    "fadd v30.4s, v30.4s, v2.4s\n"
+    "fadd v29.4s, v29.4s, v2.4s\n"
+    "fadd v28.4s, v28.4s, v2.4s\n"
+    "fadd v27.4s, v27.4s, v2.4s\n"
+    "fadd v26.4s, v26.4s, v2.4s\n"
+    "fadd v25.4s, v25.4s, v2.4s\n"
+    "fadd v24.4s, v24.4s, v2.4s\n"
+    "fadd v23.4s, v23.4s, v2.4s\n"
+    "fadd v22.4s, v22.4s, v2.4s\n"
+    "fadd v21.4s, v21.4s, v2.4s\n"
+    "fadd v20.4s, v20.4s, v2.4s\n"
+    "fadd v19.4s, v19.4s, v2.4s\n"
+    "fadd v18.4s, v18.4s, v2.4s\n"
+    "fadd v17.4s, v17.4s, v2.4s\n"
+    "fadd v16.4s, v16.4s, v2.4s\n"
+    "fmax v31.4s, v31.4s, v1.4s\n"
+    "fmax v30.4s, v30.4s, v1.4s\n"
+    "fmax v29.4s, v29.4s, v1.4s\n"
+    "fmax v28.4s, v28.4s, v1.4s\n"
+    "fmax v27.4s, v27.4s, v1.4s\n"
+    "fmax v26.4s, v26.4s, v1.4s\n"
+    "fmax v25.4s, v25.4s, v1.4s\n"
+    "fmax v24.4s, v24.4s, v1.4s\n"
+    "fmax v23.4s, v23.4s, v1.4s\n"
+    "fmax v22.4s, v22.4s, v1.4s\n"
+    "fmax v21.4s, v21.4s, v1.4s\n"
+    "fmax v20.4s, v20.4s, v1.4s\n"
+    "fmax v19.4s, v19.4s, v1.4s\n"
+    "fmax v18.4s, v18.4s, v1.4s\n"
+    "fmax v17.4s, v17.4s, v1.4s\n"
+    "fmax v16.4s, v16.4s, v1.4s\n"
+    "fmin v31.4s, v31.4s, v0.4s\n"
+    "fmin v30.4s, v30.4s, v0.4s\n"
+    "fmin v29.4s, v29.4s, v0.4s\n"
+    "fmin v28.4s, v28.4s, v0.4s\n"
+    "fmin v27.4s, v27.4s, v0.4s\n"
+    "fmin v26.4s, v26.4s, v0.4s\n"
+    "fmin v25.4s, v25.4s, v0.4s\n"
+    "fmin v24.4s, v24.4s, v0.4s\n"
+    "fmin v23.4s, v23.4s, v0.4s\n"
+    "fmin v22.4s, v22.4s, v0.4s\n"
+    "fmin v21.4s, v21.4s, v0.4s\n"
+    "fmin v20.4s, v20.4s, v0.4s\n"
+    "fmin v19.4s, v19.4s, v0.4s\n"
+    "fmin v18.4s, v18.4s, v0.4s\n"
+    "fmin v17.4s, v17.4s, v0.4s\n"
+    "fmin v16.4s, v16.4s, v0.4s\n"
+    "blt 8f\n"
+    "mov x20, %x[dst]\n"
+    "str q31, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q30, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q29, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q28, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q27, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q26, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q25, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q24, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q23, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q22, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q21, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q20, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q19, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q18, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q17, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q16, [x20, #0x0]\n"
+    "b 13f\n"
+    "8:" // Partial output
+    "mov x28, %x[dst]\n"
+    "add x26, x28, %x[dst_stride_row], LSL #2\n"
+    "add x25, x26, %x[dst_stride_row], LSL #1\n"
+    "add x24, x26, %x[dst_stride_row]\n"
+    "add x23, x25, %x[dst_stride_row]\n"
+    "add x22, x28, %x[dst_stride_row], LSL #1\n"
+    "add x21, x28, %x[dst_stride_row]\n"
+    "add x20, x22, %x[dst_stride_row]\n"
+    "add x27, x23, %x[dst_stride_row]\n"
+    "tbz x10, #1, 9f\n"
+    "st1 { v24.d }[0], [x23], #0x8\n"
+    "st1 { v25.d }[0], [x25], #0x8\n"
+    "st1 { v26.d }[0], [x24], #0x8\n"
+    "st1 { v27.d }[0], [x26], #0x8\n"
+    "st1 { v28.d }[0], [x20], #0x8\n"
+    "st1 { v29.d }[0], [x22], #0x8\n"
+    "st1 { v30.d }[0], [x21], #0x8\n"
+    "st1 { v31.d }[0], [x28], #0x8\n"
+    "tbz x10, #0, 10f\n"
+    "st1 { v24.s }[2], [x23]\n"
+    "st1 { v25.s }[2], [x25]\n"
+    "st1 { v26.s }[2], [x24]\n"
+    "st1 { v27.s }[2], [x26]\n"
+    "st1 { v28.s }[2], [x20]\n"
+    "st1 { v29.s }[2], [x22]\n"
+    "st1 { v30.s }[2], [x21]\n"
+    "st1 { v31.s }[2], [x28]\n"
+    "b 10f\n"
+    "9:" // Output block 0: partial_1_0
+    "st1 { v24.s }[0], [x23]\n"
+    "st1 { v25.s }[0], [x25]\n"
+    "st1 { v26.s }[0], [x24]\n"
+    "st1 { v27.s }[0], [x26]\n"
+    "st1 { v28.s }[0], [x20]\n"
+    "st1 { v29.s }[0], [x22]\n"
+    "st1 { v30.s }[0], [x21]\n"
+    "st1 { v31.s }[0], [x28]\n"
+    "10:" // Output block 0: Done
+    "add x26, x27, %x[dst_stride_row], LSL #2\n"
+    "add x25, x27, %x[dst_stride_row], LSL #1\n"
+    "add x24, x26, %x[dst_stride_row], LSL #1\n"
+    "add x23, x27, %x[dst_stride_row]\n"
+    "add x22, x25, %x[dst_stride_row]\n"
+    "add x21, x26, %x[dst_stride_row]\n"
+    "add x20, x24, %x[dst_stride_row]\n"
+    "tbz x10, #1, 11f\n"
+    "st1 { v16.d }[0], [x20], #0x8\n"
+    "st1 { v17.d }[0], [x24], #0x8\n"
+    "st1 { v18.d }[0], [x21], #0x8\n"
+    "st1 { v19.d }[0], [x26], #0x8\n"
+    "st1 { v20.d }[0], [x22], #0x8\n"
+    "st1 { v21.d }[0], [x25], #0x8\n"
+    "st1 { v22.d }[0], [x23], #0x8\n"
+    "st1 { v23.d }[0], [x27], #0x8\n"
+    "tbz x10, #0, 12f\n"
+    "st1 { v16.s }[2], [x20]\n"
+    "st1 { v17.s }[2], [x24]\n"
+    "st1 { v18.s }[2], [x21]\n"
+    "st1 { v19.s }[2], [x26]\n"
+    "st1 { v20.s }[2], [x22]\n"
+    "st1 { v21.s }[2], [x25]\n"
+    "st1 { v22.s }[2], [x23]\n"
+    "st1 { v23.s }[2], [x27]\n"
+    "b 12f\n"
+    "11:" // Output block 1: partial_1_0
+    "st1 { v16.s }[0], [x20]\n"
+    "st1 { v17.s }[0], [x24]\n"
+    "st1 { v18.s }[0], [x21]\n"
+    "st1 { v19.s }[0], [x26]\n"
+    "st1 { v20.s }[0], [x22]\n"
+    "st1 { v21.s }[0], [x25]\n"
+    "st1 { v22.s }[0], [x23]\n"
+    "st1 { v23.s }[0], [x27]\n"
+    "12:" // Output block 1: Done
+    "13:" // Output stage exit
+    "subs x10, x10, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 2b\n"
+    "mov x20, #0x4\n"
+    "sub x13, x13, #0x10\n"
+    "cmp x13, #0x10\n"
+    "mov %x[dst], x9\n"
+    "madd %x[lhs_packed], x20, x12, %x[lhs_packed]\n"
+    "bge 1b\n"
+    "14:" // Row loop skip
+    "cbz x13, 23f\n"
+    "15:" // Row tail: Row loop
+    "mov x26, %x[rhs_packed]\n"
+    "mov x25, %x[n]\n"
+    "add x24, %x[dst], %x[dst_stride_row], LSL #2\n"
+    "16:" // Row tail: Column loop
+    "mov x27, %x[lhs_packed]\n"
+    "movi v31.4s, #0x0\n"
+    "movi v30.4s, #0x0\n"
+    "mov x20, %x[num_blocks]\n"
+    "movi v29.4s, #0x0\n"
+    "movi v28.4s, #0x0\n"
+    "17:" // Row tail: Sub block loop
+    "ldr q17, [x26, #0x0]\n"
+    "ldr q16, [x27, #0x0]\n"
+    "subs x20, x20, #0x1\n"
+    "ldr q1, [x26, #0x10]\n"
+    "ldr q0, [x27, #0x10]\n"
+    "ldr q27, [x26, #0x20]\n"
+    "ldr q26, [x27, #0x20]\n"
+    "ldr q25, [x26, #0x30]\n"
+    "ldr q24, [x27, #0x30]\n"
+    ".inst 0x4f90e23f  // sdot v31.4s, v17.16b, v16.4b[0]\n"
+    ".inst 0x4fb0e23e  // sdot v30.4s, v17.16b, v16.4b[1]\n"
+    "ldr q23, [x26, #0x40]\n"
+    "ldr q22, [x27, #0x40]\n"
+    ".inst 0x4f90ea3d  // sdot v29.4s, v17.16b, v16.4b[2]\n"
+    ".inst 0x4fb0ea3c  // sdot v28.4s, v17.16b, v16.4b[3]\n"
+    "ldr q21, [x26, #0x50]\n"
+    "ldr q20, [x27, #0x50]\n"
+    "ldr q19, [x26, #0x60]\n"
+    "ldr q18, [x27, #0x60]\n"
+    "ldr q17, [x26, #0x70]\n"
+    "ldr q16, [x27, #0x70]\n"
+    ".inst 0x4f80e03f  // sdot v31.4s, v1.16b, v0.4b[0]\n"
+    ".inst 0x4fa0e03e  // sdot v30.4s, v1.16b, v0.4b[1]\n"
+    ".inst 0x4f80e83d  // sdot v29.4s, v1.16b, v0.4b[2]\n"
+    ".inst 0x4fa0e83c  // sdot v28.4s, v1.16b, v0.4b[3]\n"
+    "add x27, x27, #0x80\n"
+    "add x26, x26, #0x80\n"
+    ".inst 0x4f9ae37f  // sdot v31.4s, v27.16b, v26.4b[0]\n"
+    ".inst 0x4fbae37e  // sdot v30.4s, v27.16b, v26.4b[1]\n"
+    ".inst 0x4f9aeb7d  // sdot v29.4s, v27.16b, v26.4b[2]\n"
+    ".inst 0x4fbaeb7c  // sdot v28.4s, v27.16b, v26.4b[3]\n"
+    ".inst 0x4f98e33f  // sdot v31.4s, v25.16b, v24.4b[0]\n"
+    ".inst 0x4fb8e33e  // sdot v30.4s, v25.16b, v24.4b[1]\n"
+    ".inst 0x4f98eb3d  // sdot v29.4s, v25.16b, v24.4b[2]\n"
+    ".inst 0x4fb8eb3c  // sdot v28.4s, v25.16b, v24.4b[3]\n"
+    ".inst 0x4f96e2ff  // sdot v31.4s, v23.16b, v22.4b[0]\n"
+    ".inst 0x4fb6e2fe  // sdot v30.4s, v23.16b, v22.4b[1]\n"
+    ".inst 0x4f96eafd  // sdot v29.4s, v23.16b, v22.4b[2]\n"
+    ".inst 0x4fb6eafc  // sdot v28.4s, v23.16b, v22.4b[3]\n"
+    ".inst 0x4f94e2bf  // sdot v31.4s, v21.16b, v20.4b[0]\n"
+    ".inst 0x4fb4e2be  // sdot v30.4s, v21.16b, v20.4b[1]\n"
+    ".inst 0x4f94eabd  // sdot v29.4s, v21.16b, v20.4b[2]\n"
+    ".inst 0x4fb4eabc  // sdot v28.4s, v21.16b, v20.4b[3]\n"
+    ".inst 0x4f92e27f  // sdot v31.4s, v19.16b, v18.4b[0]\n"
+    ".inst 0x4fb2e27e  // sdot v30.4s, v19.16b, v18.4b[1]\n"
+    ".inst 0x4f92ea7d  // sdot v29.4s, v19.16b, v18.4b[2]\n"
+    ".inst 0x4fb2ea7c  // sdot v28.4s, v19.16b, v18.4b[3]\n"
+    ".inst 0x4f90e23f  // sdot v31.4s, v17.16b, v16.4b[0]\n"
+    ".inst 0x4fb0e23e  // sdot v30.4s, v17.16b, v16.4b[1]\n"
+    ".inst 0x4f90ea3d  // sdot v29.4s, v17.16b, v16.4b[2]\n"
+    ".inst 0x4fb0ea3c  // sdot v28.4s, v17.16b, v16.4b[3]\n"
+    "bgt 17b\n"
+    "ldr q18, [x26, #0x0]\n"
+    "ld1 { v17.4s }, [x27]\n"
+    "add x27, x27, #0x10\n"
+    "ldr q20, [x26, #0x10]\n"
+    "ldr q16, [x27, #0x0]\n"
+    "add x26, x26, #0x20\n"
+    "mla v31.4s, v18.4s, v17.s[0]\n"
+    "mla v30.4s, v18.4s, v17.s[1]\n"
+    "mla v29.4s, v18.4s, v17.s[2]\n"
+    "mla v28.4s, v18.4s, v17.s[3]\n"
+    "fmul v19.4s, v20.4s, v16.s[0]\n"
+    "fmul v18.4s, v20.4s, v16.s[1]\n"
+    "fmul v17.4s, v20.4s, v16.s[2]\n"
+    "scvtf v31.4s, v31.4s\n"
+    "fmul v16.4s, v20.4s, v16.s[3]\n"
+    "scvtf v30.4s, v30.4s\n"
+    "scvtf v29.4s, v29.4s\n"
+    "scvtf v28.4s, v28.4s\n"
+    "fmul v31.4s, v31.4s, v19.4s\n"
+    "fmul v30.4s, v30.4s, v18.4s\n"
+    "fmul v29.4s, v29.4s, v17.4s\n"
+    "fmul v28.4s, v28.4s, v16.4s\n"
+    "ldr q18, [x26, #0x0]\n"
+    "ld1r { v17.4s }, [%x[clamp_vals]]\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "cmp x25, #0x4\n"
+    "ld1r { v16.4s }, [x20]\n"
+    "add x26, x26, #0x10\n"
+    "fadd v31.4s, v31.4s, v18.4s\n"
+    "fadd v30.4s, v30.4s, v18.4s\n"
+    "fadd v29.4s, v29.4s, v18.4s\n"
+    "fadd v28.4s, v28.4s, v18.4s\n"
+    "fmax v31.4s, v31.4s, v17.4s\n"
+    "fmax v30.4s, v30.4s, v17.4s\n"
+    "fmax v29.4s, v29.4s, v17.4s\n"
+    "fmax v28.4s, v28.4s, v17.4s\n"
+    "fmin v31.4s, v31.4s, v16.4s\n"
+    "fmin v30.4s, v30.4s, v16.4s\n"
+    "fmin v29.4s, v29.4s, v16.4s\n"
+    "fmin v28.4s, v28.4s, v16.4s\n"
+    "blt 19f\n"
+    "mov x20, %x[dst]\n"
+    "cmp x13, #0x1\n"
+    "str q31, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "cmp x13, #0x2\n"
+    "str q30, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "cmp x13, #0x3\n"
+    "str q29, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "str q28, [x20, #0x0]\n"
+    "b 22f\n"
+    "19:" // Row tail: Partial output
+    "mov x23, %x[dst]\n"
+    "cmp x13, #0x1\n"
+    "add x22, x23, %x[dst_stride_row]\n"
+    "csel x22, x22, x23, GT\n"
+    "cmp x13, #0x2\n"
+    "add x21, x23, %x[dst_stride_row], LSL #1\n"
+    "csel x21, x21, x22, GT\n"
+    "cmp x13, #0x3\n"
+    "add x20, x21, %x[dst_stride_row]\n"
+    "csel x20, x20, x21, GT\n"
+    "tbz x25, #1, 20f\n"
+    "st1 { v28.d }[0], [x20], #0x8\n"
+    "st1 { v29.d }[0], [x21], #0x8\n"
+    "st1 { v30.d }[0], [x22], #0x8\n"
+    "st1 { v31.d }[0], [x23], #0x8\n"
+    "tbz x25, #0, 21f\n"
+    "st1 { v28.s }[2], [x20]\n"
+    "st1 { v29.s }[2], [x21]\n"
+    "st1 { v30.s }[2], [x22]\n"
+    "st1 { v31.s }[2], [x23]\n"
+    "b 21f\n"
+    "20:" // Row tail: Output block 0: partial_1_0
+    "st1 { v28.s }[0], [x20]\n"
+    "st1 { v29.s }[0], [x21]\n"
+    "st1 { v30.s }[0], [x22]\n"
+    "st1 { v31.s }[0], [x23]\n"
+    "21:" // Row tail: Output block 0: Done
+    "22:" // Row tail: Output stage exit
+    "subs x25, x25, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 16b\n"
+    "subs x13, x13, #0x4\n"
+    "add %x[lhs_packed], %x[lhs_packed], x12\n"
+    "mov %x[dst], x24\n"
+    "bgt 15b\n"
+    "23:" // Row tail: Row loop skip
+    : [dst] "+&r"(dst), [lhs_packed] "+&r"(lhs_packed)
+    : [clamp_vals] "r"(clamp_vals), [dst_stride_row] "r"(dst_stride_row),
+      [m] "r"(m), [n] "r"(n), [num_blocks] "r"(num_blocks),
+      [rhs_packed] "r"(rhs_packed)
+    : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+      "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18",
+      "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+      "v29", "v30", "v31", "x9", "x10", "x11", "x12", "x13", "x20", "x21",
+      "x22", "x23", "x24", "x25", "x26", "x27", "x28");
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h
@@ -1,0 +1,170 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f32 to dynamically quantize and pack the
+/// LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t
+kai_get_mr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t
+kai_get_nr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t
+kai_get_kr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t
+kai_get_sr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be a
+/// multiple of 16
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 8-bit with per-channel
+/// quantization (qsi8cx) values.
+///
+/// @param[in] n_idx Row index in the RHS matrix (not packed). It must be a
+/// multiple of 4.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be a multiple
+/// of 16.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple
+/// of 4.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t
+kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t
+kai_get_dst_size_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed RHS matrix: Quantized Symmetric Signed 8-bit with
+/// per-channel quantization (qsi8cx) and packed. Output tile: (rows x cols) =
+/// 16 x 4
+///
+/// Features used: dotprod
+///
+/// @param[in]  m              The number of output rows written.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(float) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  float *dst,             //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.c
@@ -1,0 +1,731 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.c
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.c
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024-2026 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Do not flag up inline assembly blocks
+#pragma GCC diagnostic ignored "-Woverlength-strings"
+
+#if !defined(__aarch64__) && !defined(__ARM_FEATURE_MATMUL_INT8)
+#error "I8mm extension required to compile this micro-kernel"
+#else // Architectural features check.
+
+#include "kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+// Compute args
+static const size_t kai_m_step = 16;
+static const size_t kai_n_step = 4;
+// Packing args
+static const size_t kai_mr = 4;
+static const size_t kai_nr = 4;
+static const size_t kai_kr = 8;
+static const size_t kai_sr = 1;
+// LHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric))
+static const size_t kai_num_bytes_qvalue_lhs = 1;
+static const size_t kai_num_bytes_multiplier_lhs = 4;
+static const size_t kai_num_bytes_zp_lhs = 4;
+// RHS format args (num. bytes per value, multiplier, zero_point (if
+// asymmetric), and reduction sum (if LHS is asymmetric))
+static const size_t kai_num_bytes_qvalue_rhs = 1;
+static const size_t kai_num_bytes_multiplier_rhs = 4;
+static const size_t kai_num_bytes_rsum_rhs = 4;
+// DST format args
+static const size_t kai_num_bytes_dst_value = 4;
+// Extra args
+static const size_t kai_num_bytes_bias = 4;
+static const size_t kai_k_multiple_of = 32;
+
+inline static size_t kai_k_roundedup(size_t k) {
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+inline static size_t kai_lhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t lhs_packed_stride = kai_mr * ((k_internal * kai_num_bytes_qvalue_lhs) +
+                                       kai_num_bytes_multiplier_lhs);
+  // Since the LHS matrix is asymmetric with per-row quantization, we must
+  // include the the number of bytes to hold the zero point value
+  lhs_packed_stride += kai_mr * kai_num_bytes_zp_lhs;
+
+  return lhs_packed_stride;
+}
+
+inline static size_t kai_rhs_packed_stride(size_t k) {
+  const size_t k_internal = kai_k_roundedup(k);
+  size_t rhs_packed_stride = kai_nr * (k_internal * kai_num_bytes_qvalue_rhs);
+  rhs_packed_stride += kai_nr * kai_num_bytes_multiplier_rhs;
+  // Since the LHS matrix is quantized asymmetric with per-row quantization, we
+  // also include the number of bytes for the reduction sum
+  rhs_packed_stride += kai_nr * kai_num_bytes_rsum_rhs;
+  // Since the bias is packed with the RHS matrix, the stride is adjusted with
+  // the number of bytes of the bias
+  rhs_packed_stride += kai_nr * kai_num_bytes_bias;
+
+  return rhs_packed_stride;
+}
+
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_m_step;
+}
+
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_n_step;
+}
+
+size_t kai_get_mr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_mr;
+}
+
+size_t kai_get_nr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_nr;
+}
+
+size_t kai_get_kr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_kr;
+}
+
+size_t kai_get_sr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void) {
+  return kai_sr;
+}
+
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, size_t k) {
+  KAI_ASSUME((m_idx % kai_mr) == 0);
+
+  return (m_idx / kai_mr) * kai_lhs_packed_stride(k);
+}
+
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t n_idx, size_t k) {
+  KAI_ASSUME((n_idx % kai_nr) == 0);
+
+  return (n_idx / kai_nr) * kai_rhs_packed_stride(k);
+}
+
+size_t kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, size_t n_idx, size_t dst_stride) {
+  KAI_ASSUME((m_idx % kai_m_step) == 0);
+  KAI_ASSUME((n_idx % kai_n_step) == 0);
+
+  return (n_idx * kai_num_bytes_dst_value) + m_idx * dst_stride;
+}
+
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m, size_t n) {
+  return m * n * kai_num_bytes_dst_value;
+}
+
+void kai_run_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m,                        //
+  size_t n,                        //
+  size_t k,                        //
+  const void *restrict lhs_packed, //
+  const void *restrict rhs_packed, //
+  float *restrict dst,             // NOLINT(readability-non-const-parameter)
+  size_t dst_stride_row,           //
+  size_t dst_stride_col,           //
+  float scalar_min,                //
+  float scalar_max) {
+  KAI_ASSUME(dst_stride_col == sizeof(float));
+
+  if (m == 0) {
+    return;
+  }
+
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t num_blocks = k_internal / kai_k_multiple_of;
+  const float clamp_vals[2] = {scalar_min, scalar_max};
+
+  __asm__ __volatile__(
+    "mov x13, %x[m]\n"
+    "mov x12, #0x80\n"
+    "mov x20, #0x20\n"
+    "cmp x13, #0x10\n"
+    "madd x12, %x[num_blocks], x12, x20\n"
+    "blt 14f\n"
+    "1:" // Row loop
+    "mov x11, %x[rhs_packed]\n"
+    "mov x10, %x[n]\n"
+    "add x9, %x[dst], %x[dst_stride_row], LSL #4\n"
+    "2:" // Column loop
+    "mov x27, %x[lhs_packed]\n"
+    "movi v31.4s, #0x0\n"
+    "movi v30.4s, #0x0\n"
+    "mov x23, %x[num_blocks]\n"
+    "movi v29.4s, #0x0\n"
+    "movi v28.4s, #0x0\n"
+    "movi v27.4s, #0x0\n"
+    "movi v26.4s, #0x0\n"
+    "add x22, x27, x12\n"
+    "add x21, x22, x12\n"
+    "add x20, x21, x12\n"
+    "movi v25.4s, #0x0\n"
+    "movi v24.4s, #0x0\n"
+    "movi v23.4s, #0x0\n"
+    "movi v22.4s, #0x0\n"
+    "movi v21.4s, #0x0\n"
+    "movi v20.4s, #0x0\n"
+    "movi v19.4s, #0x0\n"
+    "movi v18.4s, #0x0\n"
+    "movi v17.4s, #0x0\n"
+    "movi v16.4s, #0x0\n"
+    "3:" // Sub block loop
+    "ldr q2, [x11, #0x0]\n"
+    "ldr q1, [x11, #0x10]\n"
+    "subs x23, x23, #0x1\n"
+    "ldr q5, [x27, #0x0]\n"
+    "ldr q9, [x27, #0x10]\n"
+    "ldr q8, [x22, #0x0]\n"
+    "ldr q7, [x22, #0x10]\n"
+    "ldr q4, [x21, #0x0]\n"
+    "ldr q14, [x21, #0x10]\n"
+    "ldr q3, [x20, #0x0]\n"
+    "ldr q0, [x20, #0x10]\n"
+    ".inst 0x4e82a4bf  // smmla v31.4s, v5.16b, v2.16b\n"
+    ".inst 0x4e81a4be  // smmla v30.4s, v5.16b, v1.16b\n"
+    "ldr q6, [x11, #0x20]\n"
+    "ldr q5, [x11, #0x30]\n"
+    ".inst 0x4e82a53d  // smmla v29.4s, v9.16b, v2.16b\n"
+    ".inst 0x4e81a53c  // smmla v28.4s, v9.16b, v1.16b\n"
+    "ldr q13, [x27, #0x20]\n"
+    "ldr q12, [x27, #0x30]\n"
+    ".inst 0x4e82a51b  // smmla v27.4s, v8.16b, v2.16b\n"
+    ".inst 0x4e81a51a  // smmla v26.4s, v8.16b, v1.16b\n"
+    "ldr q11, [x22, #0x20]\n"
+    "ldr q10, [x22, #0x30]\n"
+    ".inst 0x4e82a4f9  // smmla v25.4s, v7.16b, v2.16b\n"
+    ".inst 0x4e81a4f8  // smmla v24.4s, v7.16b, v1.16b\n"
+    "ldr q9, [x21, #0x20]\n"
+    "ldr q8, [x21, #0x30]\n"
+    ".inst 0x4e82a497  // smmla v23.4s, v4.16b, v2.16b\n"
+    ".inst 0x4e81a496  // smmla v22.4s, v4.16b, v1.16b\n"
+    "ldr q7, [x20, #0x20]\n"
+    "ldr q4, [x20, #0x30]\n"
+    ".inst 0x4e82a5d5  // smmla v21.4s, v14.16b, v2.16b\n"
+    ".inst 0x4e81a5d4  // smmla v20.4s, v14.16b, v1.16b\n"
+    "ldr q15, [x11, #0x40]\n"
+    "ldr q14, [x11, #0x50]\n"
+    ".inst 0x4e82a473  // smmla v19.4s, v3.16b, v2.16b\n"
+    ".inst 0x4e81a472  // smmla v18.4s, v3.16b, v1.16b\n"
+    "ldr q3, [x27, #0x40]\n"
+    ".inst 0x4e82a411  // smmla v17.4s, v0.16b, v2.16b\n"
+    "ldr q2, [x27, #0x50]\n"
+    ".inst 0x4e81a410  // smmla v16.4s, v0.16b, v1.16b\n"
+    "ldr q1, [x22, #0x40]\n"
+    "ldr q0, [x22, #0x50]\n"
+    ".inst 0x4e86a5bf  // smmla v31.4s, v13.16b, v6.16b\n"
+    ".inst 0x4e85a5be  // smmla v30.4s, v13.16b, v5.16b\n"
+    "ldr q13, [x21, #0x40]\n"
+    ".inst 0x4e86a59d  // smmla v29.4s, v12.16b, v6.16b\n"
+    ".inst 0x4e85a59c  // smmla v28.4s, v12.16b, v5.16b\n"
+    "ldr q12, [x21, #0x50]\n"
+    ".inst 0x4e86a57b  // smmla v27.4s, v11.16b, v6.16b\n"
+    ".inst 0x4e85a57a  // smmla v26.4s, v11.16b, v5.16b\n"
+    "ldr q11, [x20, #0x40]\n"
+    ".inst 0x4e86a559  // smmla v25.4s, v10.16b, v6.16b\n"
+    ".inst 0x4e85a558  // smmla v24.4s, v10.16b, v5.16b\n"
+    "ldr q10, [x20, #0x50]\n"
+    ".inst 0x4e86a537  // smmla v23.4s, v9.16b, v6.16b\n"
+    ".inst 0x4e85a536  // smmla v22.4s, v9.16b, v5.16b\n"
+    "ldr q9, [x11, #0x60]\n"
+    ".inst 0x4e86a515  // smmla v21.4s, v8.16b, v6.16b\n"
+    ".inst 0x4e85a514  // smmla v20.4s, v8.16b, v5.16b\n"
+    "ldr q8, [x11, #0x70]\n"
+    "add x11, x11, #0x80\n"
+    ".inst 0x4e86a4f3  // smmla v19.4s, v7.16b, v6.16b\n"
+    ".inst 0x4e85a4f2  // smmla v18.4s, v7.16b, v5.16b\n"
+    "ldr q7, [x27, #0x60]\n"
+    ".inst 0x4e86a491  // smmla v17.4s, v4.16b, v6.16b\n"
+    "ldr q6, [x27, #0x70]\n"
+    ".inst 0x4e85a490  // smmla v16.4s, v4.16b, v5.16b\n"
+    "ldr q5, [x22, #0x60]\n"
+    "ldr q4, [x22, #0x70]\n"
+    ".inst 0x4e8fa47f  // smmla v31.4s, v3.16b, v15.16b\n"
+    ".inst 0x4e8ea47e  // smmla v30.4s, v3.16b, v14.16b\n"
+    "ldr q3, [x21, #0x60]\n"
+    ".inst 0x4e8fa45d  // smmla v29.4s, v2.16b, v15.16b\n"
+    ".inst 0x4e8ea45c  // smmla v28.4s, v2.16b, v14.16b\n"
+    "ldr q2, [x21, #0x70]\n"
+    "add x27, x27, #0x80\n"
+    ".inst 0x4e8fa43b  // smmla v27.4s, v1.16b, v15.16b\n"
+    ".inst 0x4e8ea43a  // smmla v26.4s, v1.16b, v14.16b\n"
+    "ldr q1, [x20, #0x60]\n"
+    "add x22, x22, #0x80\n"
+    ".inst 0x4e8fa419  // smmla v25.4s, v0.16b, v15.16b\n"
+    ".inst 0x4e8ea418  // smmla v24.4s, v0.16b, v14.16b\n"
+    "ldr q0, [x20, #0x70]\n"
+    "add x21, x21, #0x80\n"
+    ".inst 0x4e8fa5b7  // smmla v23.4s, v13.16b, v15.16b\n"
+    ".inst 0x4e8ea5b6  // smmla v22.4s, v13.16b, v14.16b\n"
+    "add x20, x20, #0x80\n"
+    ".inst 0x4e8fa595  // smmla v21.4s, v12.16b, v15.16b\n"
+    ".inst 0x4e8ea594  // smmla v20.4s, v12.16b, v14.16b\n"
+    ".inst 0x4e8fa573  // smmla v19.4s, v11.16b, v15.16b\n"
+    ".inst 0x4e8ea572  // smmla v18.4s, v11.16b, v14.16b\n"
+    ".inst 0x4e8fa551  // smmla v17.4s, v10.16b, v15.16b\n"
+    ".inst 0x4e8ea550  // smmla v16.4s, v10.16b, v14.16b\n"
+    ".inst 0x4e89a4ff  // smmla v31.4s, v7.16b, v9.16b\n"
+    ".inst 0x4e88a4fe  // smmla v30.4s, v7.16b, v8.16b\n"
+    ".inst 0x4e89a4dd  // smmla v29.4s, v6.16b, v9.16b\n"
+    ".inst 0x4e88a4dc  // smmla v28.4s, v6.16b, v8.16b\n"
+    ".inst 0x4e89a4bb  // smmla v27.4s, v5.16b, v9.16b\n"
+    ".inst 0x4e88a4ba  // smmla v26.4s, v5.16b, v8.16b\n"
+    ".inst 0x4e89a499  // smmla v25.4s, v4.16b, v9.16b\n"
+    ".inst 0x4e88a498  // smmla v24.4s, v4.16b, v8.16b\n"
+    ".inst 0x4e89a477  // smmla v23.4s, v3.16b, v9.16b\n"
+    ".inst 0x4e88a476  // smmla v22.4s, v3.16b, v8.16b\n"
+    ".inst 0x4e89a455  // smmla v21.4s, v2.16b, v9.16b\n"
+    ".inst 0x4e88a454  // smmla v20.4s, v2.16b, v8.16b\n"
+    ".inst 0x4e89a433  // smmla v19.4s, v1.16b, v9.16b\n"
+    ".inst 0x4e88a432  // smmla v18.4s, v1.16b, v8.16b\n"
+    ".inst 0x4e89a411  // smmla v17.4s, v0.16b, v9.16b\n"
+    ".inst 0x4e88a410  // smmla v16.4s, v0.16b, v8.16b\n"
+    "bgt 3b\n"
+    "ldr q7, [x11, #0x0]\n"
+    "ld1 { v4.4s }, [x27]\n"
+    "uzp1 v3.2d, v31.2d, v30.2d\n"
+    "uzp2 v2.2d, v31.2d, v30.2d\n"
+    "ldr q6, [x11, #0x10]\n"
+    "uzp1 v1.2d, v29.2d, v28.2d\n"
+    "uzp2 v0.2d, v29.2d, v28.2d\n"
+    "add x27, x27, #0x10\n"
+    "ldr q28, [x27, #0x0]\n"
+    "add x11, x11, #0x20\n"
+    "mla v3.4s, v7.4s, v4.s[0]\n"
+    "mla v2.4s, v7.4s, v4.s[1]\n"
+    "mla v1.4s, v7.4s, v4.s[2]\n"
+    "mla v0.4s, v7.4s, v4.s[3]\n"
+    "fmul v31.4s, v6.4s, v28.s[0]\n"
+    "fmul v30.4s, v6.4s, v28.s[1]\n"
+    "fmul v29.4s, v6.4s, v28.s[2]\n"
+    "fmul v28.4s, v6.4s, v28.s[3]\n"
+    "scvtf v3.4s, v3.4s\n"
+    "scvtf v2.4s, v2.4s\n"
+    "scvtf v1.4s, v1.4s\n"
+    "scvtf v0.4s, v0.4s\n"
+    "fmul v31.4s, v3.4s, v31.4s\n"
+    "fmul v30.4s, v2.4s, v30.4s\n"
+    "fmul v29.4s, v1.4s, v29.4s\n"
+    "fmul v28.4s, v0.4s, v28.4s\n"
+    "ld1 { v5.4s }, [x22]\n"
+    "uzp1 v4.2d, v27.2d, v26.2d\n"
+    "uzp2 v3.2d, v27.2d, v26.2d\n"
+    "add x22, x22, #0x10\n"
+    "ldr q2, [x22, #0x0]\n"
+    "uzp1 v1.2d, v25.2d, v24.2d\n"
+    "uzp2 v0.2d, v25.2d, v24.2d\n"
+    "mla v4.4s, v7.4s, v5.s[0]\n"
+    "mla v3.4s, v7.4s, v5.s[1]\n"
+    "mla v1.4s, v7.4s, v5.s[2]\n"
+    "mla v0.4s, v7.4s, v5.s[3]\n"
+    "fmul v27.4s, v6.4s, v2.s[0]\n"
+    "fmul v26.4s, v6.4s, v2.s[1]\n"
+    "fmul v25.4s, v6.4s, v2.s[2]\n"
+    "scvtf v4.4s, v4.4s\n"
+    "fmul v24.4s, v6.4s, v2.s[3]\n"
+    "scvtf v3.4s, v3.4s\n"
+    "scvtf v1.4s, v1.4s\n"
+    "scvtf v0.4s, v0.4s\n"
+    "fmul v27.4s, v4.4s, v27.4s\n"
+    "fmul v26.4s, v3.4s, v26.4s\n"
+    "fmul v25.4s, v1.4s, v25.4s\n"
+    "fmul v24.4s, v0.4s, v24.4s\n"
+    "ld1 { v5.4s }, [x21]\n"
+    "uzp1 v4.2d, v23.2d, v22.2d\n"
+    "uzp2 v3.2d, v23.2d, v22.2d\n"
+    "add x21, x21, #0x10\n"
+    "ldr q2, [x21, #0x0]\n"
+    "uzp1 v1.2d, v21.2d, v20.2d\n"
+    "uzp2 v0.2d, v21.2d, v20.2d\n"
+    "mla v4.4s, v7.4s, v5.s[0]\n"
+    "mla v3.4s, v7.4s, v5.s[1]\n"
+    "mla v1.4s, v7.4s, v5.s[2]\n"
+    "mla v0.4s, v7.4s, v5.s[3]\n"
+    "fmul v23.4s, v6.4s, v2.s[0]\n"
+    "fmul v22.4s, v6.4s, v2.s[1]\n"
+    "fmul v21.4s, v6.4s, v2.s[2]\n"
+    "scvtf v4.4s, v4.4s\n"
+    "fmul v20.4s, v6.4s, v2.s[3]\n"
+    "scvtf v3.4s, v3.4s\n"
+    "scvtf v1.4s, v1.4s\n"
+    "scvtf v0.4s, v0.4s\n"
+    "fmul v23.4s, v4.4s, v23.4s\n"
+    "fmul v22.4s, v3.4s, v22.4s\n"
+    "fmul v21.4s, v1.4s, v21.4s\n"
+    "fmul v20.4s, v0.4s, v20.4s\n"
+    "ld1 { v5.4s }, [x20]\n"
+    "uzp1 v4.2d, v19.2d, v18.2d\n"
+    "uzp2 v3.2d, v19.2d, v18.2d\n"
+    "add x20, x20, #0x10\n"
+    "ldr q2, [x20, #0x0]\n"
+    "uzp1 v1.2d, v17.2d, v16.2d\n"
+    "uzp2 v0.2d, v17.2d, v16.2d\n"
+    "mla v4.4s, v7.4s, v5.s[0]\n"
+    "mla v3.4s, v7.4s, v5.s[1]\n"
+    "mla v1.4s, v7.4s, v5.s[2]\n"
+    "mla v0.4s, v7.4s, v5.s[3]\n"
+    "fmul v19.4s, v6.4s, v2.s[0]\n"
+    "fmul v18.4s, v6.4s, v2.s[1]\n"
+    "fmul v17.4s, v6.4s, v2.s[2]\n"
+    "scvtf v4.4s, v4.4s\n"
+    "fmul v16.4s, v6.4s, v2.s[3]\n"
+    "scvtf v3.4s, v3.4s\n"
+    "scvtf v1.4s, v1.4s\n"
+    "scvtf v0.4s, v0.4s\n"
+    "fmul v19.4s, v4.4s, v19.4s\n"
+    "fmul v18.4s, v3.4s, v18.4s\n"
+    "fmul v17.4s, v1.4s, v17.4s\n"
+    "fmul v16.4s, v0.4s, v16.4s\n"
+    "ldr q2, [x11, #0x0]\n"
+    "ld1r { v1.4s }, [%x[clamp_vals]]\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "cmp x10, #0x4\n"
+    "ld1r { v0.4s }, [x20]\n"
+    "add x11, x11, #0x10\n"
+    "fadd v31.4s, v31.4s, v2.4s\n"
+    "fadd v30.4s, v30.4s, v2.4s\n"
+    "fadd v29.4s, v29.4s, v2.4s\n"
+    "fadd v28.4s, v28.4s, v2.4s\n"
+    "fadd v27.4s, v27.4s, v2.4s\n"
+    "fadd v26.4s, v26.4s, v2.4s\n"
+    "fadd v25.4s, v25.4s, v2.4s\n"
+    "fadd v24.4s, v24.4s, v2.4s\n"
+    "fadd v23.4s, v23.4s, v2.4s\n"
+    "fadd v22.4s, v22.4s, v2.4s\n"
+    "fadd v21.4s, v21.4s, v2.4s\n"
+    "fadd v20.4s, v20.4s, v2.4s\n"
+    "fadd v19.4s, v19.4s, v2.4s\n"
+    "fadd v18.4s, v18.4s, v2.4s\n"
+    "fadd v17.4s, v17.4s, v2.4s\n"
+    "fadd v16.4s, v16.4s, v2.4s\n"
+    "fmax v31.4s, v31.4s, v1.4s\n"
+    "fmax v30.4s, v30.4s, v1.4s\n"
+    "fmax v29.4s, v29.4s, v1.4s\n"
+    "fmax v28.4s, v28.4s, v1.4s\n"
+    "fmax v27.4s, v27.4s, v1.4s\n"
+    "fmax v26.4s, v26.4s, v1.4s\n"
+    "fmax v25.4s, v25.4s, v1.4s\n"
+    "fmax v24.4s, v24.4s, v1.4s\n"
+    "fmax v23.4s, v23.4s, v1.4s\n"
+    "fmax v22.4s, v22.4s, v1.4s\n"
+    "fmax v21.4s, v21.4s, v1.4s\n"
+    "fmax v20.4s, v20.4s, v1.4s\n"
+    "fmax v19.4s, v19.4s, v1.4s\n"
+    "fmax v18.4s, v18.4s, v1.4s\n"
+    "fmax v17.4s, v17.4s, v1.4s\n"
+    "fmax v16.4s, v16.4s, v1.4s\n"
+    "fmin v31.4s, v31.4s, v0.4s\n"
+    "fmin v30.4s, v30.4s, v0.4s\n"
+    "fmin v29.4s, v29.4s, v0.4s\n"
+    "fmin v28.4s, v28.4s, v0.4s\n"
+    "fmin v27.4s, v27.4s, v0.4s\n"
+    "fmin v26.4s, v26.4s, v0.4s\n"
+    "fmin v25.4s, v25.4s, v0.4s\n"
+    "fmin v24.4s, v24.4s, v0.4s\n"
+    "fmin v23.4s, v23.4s, v0.4s\n"
+    "fmin v22.4s, v22.4s, v0.4s\n"
+    "fmin v21.4s, v21.4s, v0.4s\n"
+    "fmin v20.4s, v20.4s, v0.4s\n"
+    "fmin v19.4s, v19.4s, v0.4s\n"
+    "fmin v18.4s, v18.4s, v0.4s\n"
+    "fmin v17.4s, v17.4s, v0.4s\n"
+    "fmin v16.4s, v16.4s, v0.4s\n"
+    "blt 8f\n"
+    "mov x20, %x[dst]\n"
+    "str q31, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q30, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q29, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q28, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q27, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q26, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q25, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q24, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q23, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q22, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q21, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q20, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q19, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q18, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q17, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "str q16, [x20, #0x0]\n"
+    "b 13f\n"
+    "8:" // Partial output
+    "mov x28, %x[dst]\n"
+    "add x26, x28, %x[dst_stride_row], LSL #2\n"
+    "add x25, x26, %x[dst_stride_row], LSL #1\n"
+    "add x24, x26, %x[dst_stride_row]\n"
+    "add x23, x25, %x[dst_stride_row]\n"
+    "add x22, x28, %x[dst_stride_row], LSL #1\n"
+    "add x21, x28, %x[dst_stride_row]\n"
+    "add x20, x22, %x[dst_stride_row]\n"
+    "add x27, x23, %x[dst_stride_row]\n"
+    "tbz x10, #1, 9f\n"
+    "st1 { v24.d }[0], [x23], #0x8\n"
+    "st1 { v25.d }[0], [x25], #0x8\n"
+    "st1 { v26.d }[0], [x24], #0x8\n"
+    "st1 { v27.d }[0], [x26], #0x8\n"
+    "st1 { v28.d }[0], [x20], #0x8\n"
+    "st1 { v29.d }[0], [x22], #0x8\n"
+    "st1 { v30.d }[0], [x21], #0x8\n"
+    "st1 { v31.d }[0], [x28], #0x8\n"
+    "tbz x10, #0, 10f\n"
+    "st1 { v24.s }[2], [x23]\n"
+    "st1 { v25.s }[2], [x25]\n"
+    "st1 { v26.s }[2], [x24]\n"
+    "st1 { v27.s }[2], [x26]\n"
+    "st1 { v28.s }[2], [x20]\n"
+    "st1 { v29.s }[2], [x22]\n"
+    "st1 { v30.s }[2], [x21]\n"
+    "st1 { v31.s }[2], [x28]\n"
+    "b 10f\n"
+    "9:" // Output block 0: partial_1_0
+    "st1 { v24.s }[0], [x23]\n"
+    "st1 { v25.s }[0], [x25]\n"
+    "st1 { v26.s }[0], [x24]\n"
+    "st1 { v27.s }[0], [x26]\n"
+    "st1 { v28.s }[0], [x20]\n"
+    "st1 { v29.s }[0], [x22]\n"
+    "st1 { v30.s }[0], [x21]\n"
+    "st1 { v31.s }[0], [x28]\n"
+    "10:" // Output block 0: Done
+    "add x26, x27, %x[dst_stride_row], LSL #2\n"
+    "add x25, x27, %x[dst_stride_row], LSL #1\n"
+    "add x24, x26, %x[dst_stride_row], LSL #1\n"
+    "add x23, x27, %x[dst_stride_row]\n"
+    "add x22, x25, %x[dst_stride_row]\n"
+    "add x21, x26, %x[dst_stride_row]\n"
+    "add x20, x24, %x[dst_stride_row]\n"
+    "tbz x10, #1, 11f\n"
+    "st1 { v16.d }[0], [x20], #0x8\n"
+    "st1 { v17.d }[0], [x24], #0x8\n"
+    "st1 { v18.d }[0], [x21], #0x8\n"
+    "st1 { v19.d }[0], [x26], #0x8\n"
+    "st1 { v20.d }[0], [x22], #0x8\n"
+    "st1 { v21.d }[0], [x25], #0x8\n"
+    "st1 { v22.d }[0], [x23], #0x8\n"
+    "st1 { v23.d }[0], [x27], #0x8\n"
+    "tbz x10, #0, 12f\n"
+    "st1 { v16.s }[2], [x20]\n"
+    "st1 { v17.s }[2], [x24]\n"
+    "st1 { v18.s }[2], [x21]\n"
+    "st1 { v19.s }[2], [x26]\n"
+    "st1 { v20.s }[2], [x22]\n"
+    "st1 { v21.s }[2], [x25]\n"
+    "st1 { v22.s }[2], [x23]\n"
+    "st1 { v23.s }[2], [x27]\n"
+    "b 12f\n"
+    "11:" // Output block 1: partial_1_0
+    "st1 { v16.s }[0], [x20]\n"
+    "st1 { v17.s }[0], [x24]\n"
+    "st1 { v18.s }[0], [x21]\n"
+    "st1 { v19.s }[0], [x26]\n"
+    "st1 { v20.s }[0], [x22]\n"
+    "st1 { v21.s }[0], [x25]\n"
+    "st1 { v22.s }[0], [x23]\n"
+    "st1 { v23.s }[0], [x27]\n"
+    "12:" // Output block 1: Done
+    "13:" // Output stage exit
+    "subs x10, x10, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 2b\n"
+    "mov x20, #0x4\n"
+    "sub x13, x13, #0x10\n"
+    "cmp x13, #0x10\n"
+    "mov %x[dst], x9\n"
+    "madd %x[lhs_packed], x20, x12, %x[lhs_packed]\n"
+    "bge 1b\n"
+    "14:" // Row loop skip
+    "cbz x13, 23f\n"
+    "15:" // Row tail: Row loop
+    "mov x26, %x[rhs_packed]\n"
+    "mov x25, %x[n]\n"
+    "add x24, %x[dst], %x[dst_stride_row], LSL #2\n"
+    "16:" // Row tail: Column loop
+    "mov x27, %x[lhs_packed]\n"
+    "movi v31.4s, #0x0\n"
+    "movi v30.4s, #0x0\n"
+    "mov x20, %x[num_blocks]\n"
+    "movi v29.4s, #0x0\n"
+    "movi v28.4s, #0x0\n"
+    "17:" // Row tail: Sub block loop
+    "ldr q19, [x26, #0x0]\n"
+    "ldr q18, [x26, #0x10]\n"
+    "subs x20, x20, #0x1\n"
+    "ldr q17, [x27, #0x0]\n"
+    "ldr q16, [x27, #0x10]\n"
+    "ldr q27, [x26, #0x20]\n"
+    "ldr q26, [x26, #0x30]\n"
+    "ldr q25, [x27, #0x20]\n"
+    "ldr q24, [x27, #0x30]\n"
+    "ldr q23, [x26, #0x40]\n"
+    "ldr q22, [x26, #0x50]\n"
+    ".inst 0x4e93a63f  // smmla v31.4s, v17.16b, v19.16b\n"
+    ".inst 0x4e92a63e  // smmla v30.4s, v17.16b, v18.16b\n"
+    "ldr q21, [x27, #0x40]\n"
+    "ldr q20, [x27, #0x50]\n"
+    ".inst 0x4e93a61d  // smmla v29.4s, v16.16b, v19.16b\n"
+    ".inst 0x4e92a61c  // smmla v28.4s, v16.16b, v18.16b\n"
+    "ldr q19, [x26, #0x60]\n"
+    "ldr q18, [x26, #0x70]\n"
+    "add x26, x26, #0x80\n"
+    "ldr q17, [x27, #0x60]\n"
+    "ldr q16, [x27, #0x70]\n"
+    "add x27, x27, #0x80\n"
+    ".inst 0x4e9ba73f  // smmla v31.4s, v25.16b, v27.16b\n"
+    ".inst 0x4e9aa73e  // smmla v30.4s, v25.16b, v26.16b\n"
+    ".inst 0x4e9ba71d  // smmla v29.4s, v24.16b, v27.16b\n"
+    ".inst 0x4e9aa71c  // smmla v28.4s, v24.16b, v26.16b\n"
+    ".inst 0x4e97a6bf  // smmla v31.4s, v21.16b, v23.16b\n"
+    ".inst 0x4e96a6be  // smmla v30.4s, v21.16b, v22.16b\n"
+    ".inst 0x4e97a69d  // smmla v29.4s, v20.16b, v23.16b\n"
+    ".inst 0x4e96a69c  // smmla v28.4s, v20.16b, v22.16b\n"
+    ".inst 0x4e93a63f  // smmla v31.4s, v17.16b, v19.16b\n"
+    ".inst 0x4e92a63e  // smmla v30.4s, v17.16b, v18.16b\n"
+    ".inst 0x4e93a61d  // smmla v29.4s, v16.16b, v19.16b\n"
+    ".inst 0x4e92a61c  // smmla v28.4s, v16.16b, v18.16b\n"
+    "bgt 17b\n"
+    "ldr q18, [x26, #0x0]\n"
+    "ld1 { v17.4s }, [x27]\n"
+    "uzp1 v24.2d, v31.2d, v30.2d\n"
+    "uzp2 v23.2d, v31.2d, v30.2d\n"
+    "ldr q22, [x26, #0x10]\n"
+    "uzp1 v21.2d, v29.2d, v28.2d\n"
+    "uzp2 v20.2d, v29.2d, v28.2d\n"
+    "add x27, x27, #0x10\n"
+    "ldr q16, [x27, #0x0]\n"
+    "add x26, x26, #0x20\n"
+    "mla v24.4s, v18.4s, v17.s[0]\n"
+    "mla v23.4s, v18.4s, v17.s[1]\n"
+    "mla v21.4s, v18.4s, v17.s[2]\n"
+    "mla v20.4s, v18.4s, v17.s[3]\n"
+    "fmul v19.4s, v22.4s, v16.s[0]\n"
+    "fmul v18.4s, v22.4s, v16.s[1]\n"
+    "fmul v17.4s, v22.4s, v16.s[2]\n"
+    "fmul v16.4s, v22.4s, v16.s[3]\n"
+    "scvtf v24.4s, v24.4s\n"
+    "scvtf v23.4s, v23.4s\n"
+    "scvtf v21.4s, v21.4s\n"
+    "scvtf v20.4s, v20.4s\n"
+    "fmul v31.4s, v24.4s, v19.4s\n"
+    "fmul v30.4s, v23.4s, v18.4s\n"
+    "fmul v29.4s, v21.4s, v17.4s\n"
+    "fmul v28.4s, v20.4s, v16.4s\n"
+    "ldr q18, [x26, #0x0]\n"
+    "ld1r { v17.4s }, [%x[clamp_vals]]\n"
+    "add x20, %x[clamp_vals], #0x4\n"
+    "cmp x25, #0x4\n"
+    "ld1r { v16.4s }, [x20]\n"
+    "add x26, x26, #0x10\n"
+    "fadd v31.4s, v31.4s, v18.4s\n"
+    "fadd v30.4s, v30.4s, v18.4s\n"
+    "fadd v29.4s, v29.4s, v18.4s\n"
+    "fadd v28.4s, v28.4s, v18.4s\n"
+    "fmax v31.4s, v31.4s, v17.4s\n"
+    "fmax v30.4s, v30.4s, v17.4s\n"
+    "fmax v29.4s, v29.4s, v17.4s\n"
+    "fmax v28.4s, v28.4s, v17.4s\n"
+    "fmin v31.4s, v31.4s, v16.4s\n"
+    "fmin v30.4s, v30.4s, v16.4s\n"
+    "fmin v29.4s, v29.4s, v16.4s\n"
+    "fmin v28.4s, v28.4s, v16.4s\n"
+    "blt 19f\n"
+    "mov x20, %x[dst]\n"
+    "cmp x13, #0x1\n"
+    "str q31, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "cmp x13, #0x2\n"
+    "str q30, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "cmp x13, #0x3\n"
+    "str q29, [x20, #0x0]\n"
+    "add x20, x20, %x[dst_stride_row]\n"
+    "ble 22f\n"
+    "str q28, [x20, #0x0]\n"
+    "b 22f\n"
+    "19:" // Row tail: Partial output
+    "mov x23, %x[dst]\n"
+    "cmp x13, #0x1\n"
+    "add x22, x23, %x[dst_stride_row]\n"
+    "csel x22, x22, x23, GT\n"
+    "cmp x13, #0x2\n"
+    "add x21, x23, %x[dst_stride_row], LSL #1\n"
+    "csel x21, x21, x22, GT\n"
+    "cmp x13, #0x3\n"
+    "add x20, x21, %x[dst_stride_row]\n"
+    "csel x20, x20, x21, GT\n"
+    "tbz x25, #1, 20f\n"
+    "st1 { v28.d }[0], [x20], #0x8\n"
+    "st1 { v29.d }[0], [x21], #0x8\n"
+    "st1 { v30.d }[0], [x22], #0x8\n"
+    "st1 { v31.d }[0], [x23], #0x8\n"
+    "tbz x25, #0, 21f\n"
+    "st1 { v28.s }[2], [x20]\n"
+    "st1 { v29.s }[2], [x21]\n"
+    "st1 { v30.s }[2], [x22]\n"
+    "st1 { v31.s }[2], [x23]\n"
+    "b 21f\n"
+    "20:" // Row tail: Output block 0: partial_1_0
+    "st1 { v28.s }[0], [x20]\n"
+    "st1 { v29.s }[0], [x21]\n"
+    "st1 { v30.s }[0], [x22]\n"
+    "st1 { v31.s }[0], [x23]\n"
+    "21:" // Row tail: Output block 0: Done
+    "22:" // Row tail: Output stage exit
+    "subs x25, x25, #0x4\n"
+    "add %x[dst], %x[dst], #0x10\n"
+    "bgt 16b\n"
+    "subs x13, x13, #0x4\n"
+    "add %x[lhs_packed], %x[lhs_packed], x12\n"
+    "mov %x[dst], x24\n"
+    "bgt 15b\n"
+    "23:" // Row tail: Row loop skip
+    : [dst] "+&r"(dst), [lhs_packed] "+&r"(lhs_packed)
+    : [clamp_vals] "r"(clamp_vals), [dst_stride_row] "r"(dst_stride_row),
+      [m] "r"(m), [n] "r"(n), [num_blocks] "r"(num_blocks),
+      [rhs_packed] "r"(rhs_packed)
+    : "cc", "memory", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8",
+      "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18",
+      "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28",
+      "v29", "v30", "v31", "x9", "x10", "x11", "x12", "x13", "x20", "x21",
+      "x22", "x23", "x24", "x25", "x26", "x27", "x28");
+}
+
+#endif // Architectural features check.

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h
@@ -1,0 +1,164 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h
+ * copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/// Micro-kernel dependencies
+///
+/// -# @ref kai_lhs_quant_pack_qai8dxp_f32 to dynamically quantize and pack the
+/// LHS matrix in a single step.
+/// -# @ref kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon to pack the RHS NxK matrix.
+/// -# @ref kai_rhs_pack_kxn_qsi8cxp_qsi8cx_neon to pack the RHS KxN matrix.
+
+/// --------------------------------------------------
+
+/// Gets the m step value.
+/// The micro-kernel can process any M values. However, the starting M index to
+/// be processed must be a multiple of m step.
+///
+/// @return the m step value
+size_t
+kai_get_m_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @return the n step
+size_t
+kai_get_n_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the mr value, which must be used to pack the LHS matrix
+///
+/// @return the mr value
+size_t kai_get_mr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the nr value, which must be used to pack the RHS matrix.
+///
+/// @return the nr value
+size_t kai_get_nr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the kr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the kr value
+size_t kai_get_kr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the sr value, which must be used to pack the LHS and RHS matrices
+///
+/// @return the sr value
+size_t kai_get_sr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(void);
+
+/// Gets the offset in bytes for the packed LHS matrix,
+/// which contains the packed Quantized Asymmetric Signed 8-bit with per-row
+/// quantization (qai8dx) values.
+///
+/// This function should be called before passing the pointer to the packed LHS
+/// matrix to the micro-kernel.
+///
+/// @param[in] m_idx Row index in the LHS matrix (not packed). It must be a
+/// multiple of 16
+/// @param[in] k     Total number of columns in the LHS matrix (not packed).
+///
+/// @return the offset in bytes to the packed LHS matrix
+size_t
+kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the packed RHS matrix,
+/// which contains the packed Quantized Symmetric Signed 8-bit with per-channel
+/// quantization (qsi8cx) values.
+///
+/// @param[in] n_idx Row index in the RHS matrix (not packed). It must be a
+/// multiple of 4.
+/// @param[in] k     The common dimension between the LHS and RHS matrix (K).
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t
+kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t n_idx, //
+  size_t k);    //
+
+/// Gets the offset in bytes for the DST matrix
+///
+/// @param[in] m_idx      Row index in the DST matrix. It must be a multiple
+/// of 16.
+/// @param[in] n_idx      Column index in the DST matrix. It must be multiple
+/// of 4.
+/// @param[in] dst_stride The number of bytes in in each row of the DST matrix
+///
+/// @return the DST offset in bytes
+size_t kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m_idx,       //
+  size_t n_idx,       //
+  size_t dst_stride); //
+
+/// Gets the size in bytes for the destination (DST) matrix.
+///
+/// @param[in] m Number of rows in the destination (DST) matrix.
+/// @param[in] n Number of columns in the destination (DST) matrix.
+///
+/// @return the destination (DST) matrix size in bytes
+size_t kai_get_dst_size_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m,  //
+  size_t n); //
+
+/// Runs the matrix multiplication (matmul) micro-kernel followed by a clamp
+/// (min-max) operation.
+///
+/// LHS matrix: Quantized Asymmetric Signed 8-bit with per-row quantization
+/// (qai8dx) and packed RHS matrix: Quantized Symmetric Signed 8-bit with
+/// per-channel quantization (qsi8cx) and packed. Output tile: (rows x cols) =
+/// 16 x 4
+///
+/// Features used: i8mm
+///
+/// @param[in]  m              The number of output rows written.
+/// @param[in]  n              The number of output columns written.
+/// @param[in]  k              The number of channels. The common dimension
+/// between the LHS and RHS matrix.
+/// @param[in]  lhs_packed     The LHS packed matrix. The micro-kernel to pack
+/// the native LHS matrix is reported at the top of this file.
+/// @param[in]  rhs_packed     The RHS packed matrix. The micro-kernel to pack
+/// the native RHS matrix is reported at the top of this file.
+/// @param[out] dst            The DST matrix.
+/// @param[in]  dst_stride_row Stride in bytes between two rows of the DST
+/// matrix.
+/// @param[in]  dst_stride_col Stride in bytes between two columns of the DST
+/// matrix. It must be sizeof(float) bytes.
+/// @param[in]  scalar_min     Min value used to clamp the final result.
+/// @param[in]  scalar_max     Max value used to clamp the final result.
+void kai_run_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm(
+  size_t m,               //
+  size_t n,               //
+  size_t k,               //
+  const void *lhs_packed, //
+  const void *rhs_packed, //
+  float *dst,             //
+  size_t dst_stride_row,  //
+  size_t dst_stride_col,  //
+  float scalar_min,       //
+  float scalar_max);      //
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h
@@ -1,0 +1,69 @@
+/**
+ * @file kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// All micro-kernels variants of the same type share the same interfaces
+// In this case, the micro-kernel type is: matmul_clamp_f32_qai8dxp_qsi8cxp
+
+/// Micro-kernel helper functions ("get" methods)
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_m_step_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_n_step_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_mr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_nr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_kr_func_t)(void);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_sr_func_t)(void);
+typedef size_t (
+  *kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_lhs_packed_offset_func_t)(
+  size_t m_idx, size_t k);
+typedef size_t (
+  *kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_rhs_packed_offset_func_t)(
+  size_t n_idx, size_t k);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_dst_offset_func_t)(
+  size_t m_idx, size_t n_idx, size_t dst_stride);
+typedef size_t (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_dst_size_func_t)(
+  size_t m, size_t n);
+
+/// Micro-kernel core function ("run" method)
+typedef void (*kai_matmul_clamp_f32_qai8dxp_qsi8cxp_run_matmul_func_t)(
+  size_t m, size_t n, size_t k, const void *lhs_p, const void *rhs_p,
+  float *dst, size_t dst_stride_row, size_t dst_stride_col, float scalar_min,
+  float scalar_max);
+
+/// Micro-kernel interface
+struct kai_matmul_clamp_f32_qai8dxp_qsi8cxp_ukernel {
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_m_step_func_t get_m_step;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_n_step_func_t get_n_step;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_mr_func_t get_mr;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_nr_func_t get_nr;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_kr_func_t get_kr;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_sr_func_t get_sr;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_lhs_packed_offset_func_t
+    get_lhs_packed_offset;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_rhs_packed_offset_func_t
+    get_rhs_packed_offset;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_dst_offset_func_t get_dst_offset;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_get_dst_size_func_t get_dst_size;
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_run_matmul_func_t run_matmul;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/matmul_clamp_f32_qai8dxp_qsi8cxp/meson.build
@@ -1,0 +1,22 @@
+matmul_clamp_f32_qai8dxp_qsi8cxp_headers = [
+    'kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h',
+    'kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h',
+    'kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h',
+    'kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h',
+    'kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h',
+]
+
+matmul_clamp_f32_qai8dxp_qsi8cxp_sources = [
+    'kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.c',
+    'kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.c',
+    'kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.c',
+    'kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.c',
+]
+
+foreach s : matmul_clamp_f32_qai8dxp_qsi8cxp_sources
+  nntrainer_sources += meson.current_source_dir() / s
+endforeach
+
+foreach h : matmul_clamp_f32_qai8dxp_qsi8cxp_headers
+  nntrainer_headers += meson.current_source_dir() / h
+endforeach

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/meson.build
@@ -12,6 +12,10 @@ subdir('matmul_clamp_f32_qai8dxp_qsi4cxp')
 nntrainer_inc += include_directories('matmul_clamp_f32_qai8dxp_qsi4cxp')
 nntrainer_inc_abs += meson.current_source_dir() / 'matmul_clamp_f32_qai8dxp_qsi4cxp'
 
+subdir('matmul_clamp_f32_qai8dxp_qsi8cxp')
+nntrainer_inc += include_directories('matmul_clamp_f32_qai8dxp_qsi8cxp')
+nntrainer_inc_abs += meson.current_source_dir() / 'matmul_clamp_f32_qai8dxp_qsi8cxp'
+
 subdir('matmul_clamp_f32_qsi8d32p_qsi4c32p')
 nntrainer_inc += include_directories('matmul_clamp_f32_qsi8d32p_qsi4c32p')
 nntrainer_inc_abs += meson.current_source_dir() / 'matmul_clamp_f32_qsi8d32p_qsi4c32p'

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.c
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.c
@@ -1,0 +1,161 @@
+/**
+ * @file kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.c
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.c copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "kai/kai_common.h"
+
+static const size_t kai_num_bytes_sum_rhs = sizeof(int32_t);
+static const size_t kai_num_bytes_multiplier_rhs = sizeof(float);
+static const size_t kai_num_bytes_bias = sizeof(float);
+
+inline static size_t kai_k_roundedup(size_t k) {
+  // Round up k to be a multiple of 32.
+  size_t kai_k_multiple_of = 32;
+  return kai_roundup(k, kai_k_multiple_of);
+}
+
+size_t kai_get_n_step_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t nr) { return nr; }
+
+size_t kai_get_rhs_offset_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t n_idx,
+                                                           size_t rhs_stride) {
+  return n_idx * rhs_stride;
+}
+
+size_t kai_get_rhs_packed_stride_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t k,
+                                                                  size_t nr,
+                                                                  size_t kr,
+                                                                  size_t sr) {
+  KAI_UNUSED(kr);
+  KAI_UNUSED(sr);
+  const size_t k_internal = kai_k_roundedup(k);
+
+  return nr * (k_internal + kai_num_bytes_multiplier_rhs +
+               kai_num_bytes_sum_rhs + kai_num_bytes_bias);
+}
+
+size_t kai_get_rhs_packed_offset_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t n_idx, size_t k, size_t nr, size_t kr, size_t sr) {
+  KAI_ASSERT((n_idx % nr) == 0);
+
+  return (n_idx / nr) *
+         kai_get_rhs_packed_stride_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(k, nr, kr,
+                                                                    sr);
+}
+
+size_t kai_get_rhs_packed_size_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t n, size_t k, size_t nr, size_t kr, size_t sr) {
+  const size_t num_rows = kai_roundup(n, nr) / nr;
+
+  return num_rows * kai_get_rhs_packed_stride_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+                      k, nr, kr, sr);
+}
+
+void kai_run_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t num_groups,  //
+  size_t n,           //
+  size_t k,           //
+  size_t nr,          //
+  size_t kr,          //
+  size_t sr,          //
+  const int8_t *rhs,  //
+  const float *bias,  //
+  const float *scale, //
+  void *rhs_packed,   //
+  size_t extra_bytes, const struct kai_rhs_pack_qsi8cx_params *params) {
+  KAI_ASSERT(num_groups == 1);
+  KAI_ASSERT(extra_bytes == 0);
+  KAI_ASSERT(sr == 1);
+  KAI_ASSERT(rhs != NULL);
+  KAI_ASSERT(scale != NULL);
+  KAI_ASSERT(rhs_packed != NULL);
+  KAI_ASSERT(params != NULL);
+
+  const int32_t lhs_zero_point = params->lhs_zero_point;
+  const size_t rhs_packed_stride =
+    kai_get_rhs_packed_stride_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(k, nr, kr, sr);
+  const size_t k_internal = kai_k_roundedup(k);
+  const size_t dst_num_rows = kai_roundup(n, nr) / nr;
+  const size_t dst_num_bytes_per_row = nr * k_internal;
+  const size_t rhs_stride = k;
+
+  for (size_t dst_row_idx = 0; dst_row_idx < dst_num_rows; ++dst_row_idx) {
+    uint8_t *dst_row = (uint8_t *)rhs_packed + dst_row_idx * rhs_packed_stride;
+
+    int32_t *sums = (int32_t *)(dst_row + nr * k_internal);
+
+    // Initialize to zero the RHS reduction sums
+    memset(sums, 0, nr * sizeof(int32_t));
+
+    for (size_t dst_offset = 0; dst_offset < dst_num_bytes_per_row;
+         dst_offset += kr) {
+      const size_t block_idx = dst_offset / kr;
+      const size_t nr_idx = block_idx % nr;
+      const size_t super_block_idx = block_idx / nr;
+
+      const size_t k0_idx = super_block_idx * kr;
+      const size_t n0_idx = dst_row_idx * nr + nr_idx;
+
+      // Clamp the index to avoid out-of-bound reads
+      const size_t n0_valid_idx = KAI_MIN(n0_idx, n - 1);
+
+      const size_t src_offset = n0_valid_idx * rhs_stride;
+
+      int32_t partial_sum = 0;
+
+      // Get the partial reduction sum
+      for (size_t i = 0; i < kr; i++) {
+        const size_t k0_valid_idx = k0_idx + i;
+        int8_t v = 0;
+        if (k0_valid_idx < k) {
+          v = rhs[src_offset + k0_valid_idx];
+        }
+        ((int8_t *)dst_row)[i] = v;
+        partial_sum += v;
+      }
+
+      sums[nr_idx] += partial_sum * lhs_zero_point;
+
+      dst_row += kr;
+    }
+
+    // Adjust the reduction sums
+    for (size_t i = 0; i < nr; ++i) {
+      dst_row += sizeof(int32_t);
+    }
+
+    // Adjust the scales
+    for (size_t i = 0; i < nr; ++i) {
+      // Clamp the row index to avoid out-of-bound reads
+      const size_t src_row_idx = KAI_MIN(dst_row_idx * nr + i, n - 1);
+      *((float *)(dst_row)) = scale[src_row_idx];
+      dst_row += sizeof(float);
+    }
+
+    // Set the bias
+    if (bias == NULL) {
+      memset(dst_row, 0, nr * kai_num_bytes_bias);
+    } else {
+      for (size_t i = 0; i < nr; ++i) {
+        // Clamp the row index to avoid out-of-bound reads
+        const size_t src_row_idx = KAI_MIN(dst_row_idx * nr + i, n - 1);
+        ((float *)dst_row)[i] = bias[src_row_idx];
+      }
+    }
+  }
+}

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h
@@ -1,0 +1,128 @@
+/**
+ * @file kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ * @bug    No known bugs except for NYI items
+ * @brief  kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h copied from kleidiai
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "kai/kai_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Get the n step value.
+/// The micro-kernel can process any N values. However, the starting N index to
+/// be processed must be a multiple of n step.
+///
+/// @param[in] nr The number of columns written by the matmul micro-kernel
+///
+/// @return the n step value
+size_t kai_get_n_step_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t nr);
+
+/// Gets the offset in bytes for the RHS matrix (not packed).
+///
+/// @note  The int8 values are stored in a N x K matrix.
+///
+/// @param[in] n_idx      Row index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] rhs_stride The number of bytes in in each row of the RHS matrix
+/// (not packed)
+///
+/// @return the offset in bytes to the RHS matrix (not packed)
+size_t kai_get_rhs_offset_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t n_idx,
+                                                           size_t rhs_stride);
+
+/// Get the row stride in bytes to the packed RHS matrix
+///
+/// @param[in] k     In the RHS matrix (not packed), K is the number of columns.
+/// @param[in] nr    The number of columns written by the matmul micro-kernel.
+/// @param[in] kr    The number of columns loaded in the single inner most loop
+/// of the matmul micro-kernel.
+/// @param[in] sr    The number of kr splits. It must be 1.
+///
+/// @return the stride in bytes to the packed RHS matrix
+size_t kai_get_rhs_packed_stride_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(size_t k,
+                                                                  size_t nr,
+                                                                  size_t kr,
+                                                                  size_t sr);
+
+/// Gets the offset in bytes for the packed RHS matrix, which contains the
+/// packed 8-bit quantized symmetric per-channel (qs8cx) values.
+///
+/// @param[in] n_idx Row index in the RHS matrix (not packed). It must be a
+/// multiple of n_step.
+/// @param[in] k     In the RHS matrix (not packed), K is the number of columns.
+/// @param[in] nr    The number of columns written by the matmul micro-kernel
+/// @param[in] kr    The number of columns loaded in the single inner most loop
+/// of the matmul micro-kernel.
+/// @param[in] sr    The number of kr splits. It must be 1.
+///
+/// @return the offset in bytes to the packed RHS matrix
+size_t kai_get_rhs_packed_offset_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t n_idx, size_t k, size_t nr, size_t kr, size_t sr);
+
+/// @brief Gets the size in bytes for the packed RHS matrix
+///
+/// @param[in] n The number of rows in the RHS matrix (not packed)
+/// @param[in] k The number of columns in the RHS matrix (not packed).
+/// @param[in] nr The number of columns written by the matmul micro-kernel
+/// @param[in] kr The number of columns loaded in the single inner most loop of
+/// the matmul micro-kernel.
+/// @param[in] sr The number of kr splits. It must be 1.
+///
+/// @return the packed RHS matrix size in bytes
+size_t kai_get_rhs_packed_size_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t n, size_t k, size_t nr, size_t kr, size_t sr);
+
+/// Run the micro-kernel to pack the RHS matrix.
+///
+/// @note  The int8 values are stored in a N x K matrix.
+///
+/// @param[in]  num_groups  The number of groups. It must be 1.
+/// @param[in]  n           The number of rows.
+/// @param[in]  k           The common dimension between the LHS and RHS matrix
+/// (K). It must be an even value.
+/// @param[in]  nr          The number of N rows to interleave on the same
+/// output output row.
+/// @param[in]  kr          The number of K values loaded in the single inner
+/// most loop of the matmul micro-kernel.
+/// @param[in]  sr          The number of kr splits. It must be 1.
+/// @param[in]  rhs         The RHS matrix containing the 8-bit values.
+///                         Size in bytes is expected to be equal to or greater
+///                         than n * k * sizeof(uint8_t).
+/// @param[in]  bias        The biases.
+/// @param[in]  scale       The scale for each output channel.
+/// @param[out] rhs_packed  The packed RHS matrix.
+/// @param[in]  extra_bytes Extra bytes to append to the end of each row of the
+/// packed RHS matrix.
+/// @param[in]  params      Parameters for the micro-kernel.
+void kai_run_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+  size_t num_groups,  //
+  size_t n,           //
+  size_t k,           //
+  size_t nr,          //
+  size_t kr,          //
+  size_t sr,          //
+  const int8_t *rhs,  //
+  const float *bias,  //
+  const float *scale, //
+  void *rhs_packed,   //
+  size_t extra_bytes, //
+  const struct kai_rhs_pack_qsi8cx_params *params);
+
+#ifdef __cplusplus
+}
+#endif

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kai/pack/meson.build
@@ -8,6 +8,7 @@ pack_sources = [
     'kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.c',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.c',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.c',
+    'kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.c',
 ]
 
 pack_headers = [
@@ -18,6 +19,7 @@ pack_headers = [
     'kai_rhs_pack_kxn_qsi4cxp_qs4cxs1s0.h',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h',
     'kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h',
+    'kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h',
 ]
 
 if get_option('enable-fp16')

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface.h
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface.h
@@ -217,6 +217,93 @@ void __kai_gemm_f16_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                                     float lower_bound = -FLT_MAX,
                                     float upper_bound = FLT_MAX);
 #endif // ENABLE_FP16
+/**
+ * matmul_clamp_f32_qai8dxp_qsi8cxp
+ */
+
+/**
+ * @brief get name of ukernel
+ *
+ * @param[in] idx_variant index of ukernel
+ * @return std::string name of ukernel
+ */
+std::string __kai_get_num_ukernel_name_qai8dxp_qsi8cxp(size_t idx_variant);
+
+/**
+ * @brief get number of ukernels
+ *
+ * @return size_t number of ukernels
+ */
+size_t __kai_get_num_ukernel_variants_qai8dxp_qsi8cxp();
+
+/**
+ * @brief get size of memory to allocate for packed rhs from nxk qsi8cx to
+ * qsi8cxp
+ * Note that nxk is the format of quantized rhs, not the shape of rhs
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] idx_variant index of ukernel to use
+ * @return size_t size of memory to allocate
+ */
+size_t __kai_get_rhs_packed_size_qsi8cxp_qsi8cx(size_t n, size_t k,
+                                                size_t idx_variant);
+
+/**
+ * @brief rhs matrix packing from nxk qsi8cx to qsi8cxp
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[out] rhs_packed_mtx_qs8cx packed rhs
+ * @param[in] rhs_native_mtx_qs8cx quantized matrix data (int8, nxk)
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[in] idx_variant index of ukernel to use
+ */
+void __kai_rhs_pack_qsi8cxp_qsi8cx(size_t n, size_t k,
+                                   void *rhs_packed_mtx_qs8cx,
+                                   void *rhs_native_mtx_qs8cx,
+                                   void *rhs_scales_f32, size_t idx_variant);
+
+/**
+ * @brief run qai8dxp_qsi8cxp GEMM with online rhs packing
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f32 matrix data
+ * @param[in] rhs_native_mtx_qs8cx quantized matrix data (int8, nxk)
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[out] dst_act_mtx_f32 output data
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void __kai_gemm_qai8dxp_qsi8cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
+  void *rhs_native_mtx_qs8cx, void *rhs_scales_f32, float *dst_act_mtx_f32,
+  size_t idx_variant, float lower_bound = -FLT_MAX,
+  float upper_bound = FLT_MAX);
+
+/**
+ * @brief run qai8dxp_qsi8cxp GEMM with offline packed rhs
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f32 matrix data
+ * @param[in] rhs_packed_mtx_qs8cx quantized matrix data, packed already
+ * @param[out] dst_act_mtx_f32 output data
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void __kai_gemm_qai8dxp_qsi8cxp(size_t m, size_t n, size_t k,
+                                void *lhs_native_mtx_f32,
+                                void *rhs_packed_mtx_qs8cx,
+                                float *dst_act_mtx_f32, size_t idx_variant,
+                                float lower_bound = -FLT_MAX,
+                                float upper_bound = FLT_MAX);
+
 } // namespace nntrainer
 
 /**

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi8cxp.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/kleidiai_interface_qai8dxp_qsi8cxp.cpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2024 Arm Limited and/or its affiliates
+ *
+ * @file   kleidiai_interface_qai8dxp_qsi8cxp.cpp
+ * @date   23 July 2026
+ * @see    https://github.com/ARM-software/kleidiai
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Jaemin Shin <jaemin980311@gmail.com>
+ *
+ * @brief  Modified computational backend components of
+ * kleidiai. Portions of this file are derived from Arm
+ * Limited code licensed under the Apache License, Version 2.0, with
+ * modifications
+ *
+ * @note   Licensed under the Apache License, Version 2.0 (the "License");
+ *         you may not use this file except in compliance with the License.
+ *         You may obtain a copy of the License at
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @bug    No known bugs except for NYI items
+ */
+//
+// SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates
+// <open-source-office@arm.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <algorithm>
+
+#include <kleidiai_interface.h>
+#include <thread_manager.h>
+
+#include "kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h"
+
+// Include micro-kernel variants
+#include "kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h"
+#include "kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h"
+#include "kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h"
+
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+#include "kai/matmul_clamp_f32_qai8dxp_qsi8cxp/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h"
+#endif
+
+// Include packing kernels
+#include "kai/pack/kai_lhs_quant_pack_qai8dxp_f32.h"
+#include "kai/pack/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h"
+
+namespace {
+
+// Micro-kernel interface
+/**
+ * @brief kai_matmul_ukernel_f32_qa8dxp_qs8cxp
+ */
+struct kai_matmul_ukernel_f32_qa8dxp_qs8cxp {
+  kai_matmul_clamp_f32_qai8dxp_qsi8cxp_ukernel ukernel;
+  std::string name = {};
+};
+
+kai_matmul_ukernel_f32_qa8dxp_qs8cxp ukernel_variants[] = {
+  {kai_get_m_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   kai_run_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod,
+   "matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod"},
+  {kai_get_m_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   kai_run_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod,
+   "matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod"},
+  {kai_get_m_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_n_step_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_mr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_nr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_kr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_sr_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_get_dst_size_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   kai_run_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod,
+   "matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod"},
+#if defined(__ARM_FEATURE_MATMUL_INT8)
+  {kai_get_m_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_n_step_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_mr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_nr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_kr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_sr_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_lhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_rhs_packed_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_dst_offset_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_get_dst_size_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   kai_run_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm,
+   "matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm"},
+#endif
+
+};
+
+const size_t num_ukernel_variants =
+  sizeof(ukernel_variants) / sizeof(ukernel_variants[0]);
+} // namespace
+
+namespace nntrainer {
+std::string __kai_get_num_ukernel_name_qai8dxp_qsi8cxp(size_t idx_variant) {
+  return ukernel_variants[idx_variant].name;
+}
+
+size_t __kai_get_num_ukernel_variants_qai8dxp_qsi8cxp() {
+  return num_ukernel_variants;
+}
+
+size_t __kai_get_rhs_packed_size_qsi8cxp_qsi8cx(size_t n, size_t k,
+                                                size_t idx_variant) {
+  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  return kai_get_rhs_packed_size_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(n, k, nr, kr,
+                                                                  sr);
+}
+
+void __kai_rhs_pack_qsi8cxp_qsi8cx(size_t n, size_t k,
+                                   void *rhs_packed_mtx_qs8cx,
+                                   void *rhs_native_mtx_qs8cx,
+                                   void *rhs_scales_f32, size_t idx_variant) {
+  const size_t nr = ukernel_variants[idx_variant].ukernel.get_nr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  struct kai_rhs_pack_qsi8cx_params params;
+  params.lhs_zero_point = 1;
+  params.scale_multiplier = 1.0f;
+
+  kai_run_rhs_pack_nxk_qsi8cxp_qsi8cx_neon(
+    1, n, k, nr, kr, sr,                    // Packing arguments
+    (const int8_t *)(rhs_native_mtx_qs8cx), // RHS
+    NULL,                                   // Bias
+    (const float *)(rhs_scales_f32),        // Scale
+    rhs_packed_mtx_qs8cx,                   // RHS packed
+    0, &params);
+}
+
+void __kai_gemm_qai8dxp_qsi8cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f32,
+  void *rhs_native_mtx_qs8cx, void *rhs_scales_f32, float *dst_act_mtx_f32,
+  size_t idx_variant, float lower_bound, float upper_bound) {
+  // Get the size in bytes for the packed matrices
+  const size_t rhs_packed_size =
+    __kai_get_rhs_packed_size_qsi8cxp_qsi8cx(n, k, idx_variant);
+
+  // Allocate the matrices
+  uint8_t *rhs_packed_mtx_qs8cx = new uint8_t[rhs_packed_size];
+
+  // RHS packing
+  __kai_rhs_pack_qsi8cxp_qsi8cx(n, k, rhs_packed_mtx_qs8cx,
+                                rhs_native_mtx_qs8cx, rhs_scales_f32,
+                                idx_variant);
+
+  // call packed gemm
+  __kai_gemm_qai8dxp_qsi8cxp(m, n, k, lhs_native_mtx_f32, rhs_packed_mtx_qs8cx,
+                             dst_act_mtx_f32, idx_variant, lower_bound,
+                             upper_bound);
+
+  delete[] rhs_packed_mtx_qs8cx;
+}
+
+void __kai_gemm_qai8dxp_qsi8cxp(size_t m, size_t n, size_t k,
+                                void *lhs_native_mtx_f32,
+                                void *rhs_packed_mtx_qs8cx,
+                                float *dst_act_mtx_f32, size_t idx_variant,
+                                float lower_bound, float upper_bound) {
+  const size_t mr = ukernel_variants[idx_variant].ukernel.get_mr();
+  const size_t kr = ukernel_variants[idx_variant].ukernel.get_kr();
+  const size_t sr = ukernel_variants[idx_variant].ukernel.get_sr();
+
+  // LHS packing
+  const size_t lhs_packed_size =
+    kai_get_lhs_packed_size_lhs_quant_pack_qai8dxp_f32(m, k, mr, kr, sr);
+  uint8_t *lhs_packed_mtx_qa8dx = new uint8_t[lhs_packed_size];
+
+  size_t m_step = ukernel_variants[idx_variant].ukernel.get_m_step();
+  size_t m_loop = (m + m_step - 1) / m_step;
+
+  size_t n_step = ukernel_variants[idx_variant].ukernel.get_n_step();
+  size_t n_loop = (n + n_step - 1) / n_step;
+
+  auto &tm = nntrainer::ThreadManager::Global();
+
+  const size_t dst_stride = n * sizeof(float);
+
+  // LHS quantize + pack, parallel over rows
+  tm.parallel_for(0, m_loop, [&](size_t i) {
+    size_t m_start = i * m_step;
+    size_t m_to_process = std::min(m_step, m - m_start);
+
+    size_t lhs_offset = m_start * k;
+    float *lhs_ptr = (float *)lhs_native_mtx_f32 + lhs_offset;
+
+    const size_t lhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+    uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+
+    // LHS packing
+    kai_run_lhs_quant_pack_qai8dxp_f32(m_to_process, k,   // Dimensions
+                                       mr, kr, sr, 0,     // Packing arguments
+                                       lhs_ptr,           // LHS
+                                       k * sizeof(float), // LHS stride
+                                       lhs_packed_ptr);   // LHS packed
+  });
+
+  if (m <= m_step) {
+    // GEMV-like shape: LHS stays cached, parallelize over n only
+    tm.parallel_for(0, n_loop, [&](size_t i) {
+      size_t n_start = i * n_step;
+      size_t n_to_process = std::min(n_step, n - n_start);
+
+      const size_t rhs_packed_offset =
+        ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_start, k);
+      const void *rhs_packed_ptr =
+        (const void *)((const char *)rhs_packed_mtx_qs8cx + rhs_packed_offset);
+
+      const size_t dst_offset =
+        ukernel_variants[idx_variant].ukernel.get_dst_offset(0, n_start,
+                                                             dst_stride);
+      float *dst_ptr = (float *)((uint8_t *)dst_act_mtx_f32 + dst_offset);
+
+      ukernel_variants[idx_variant].ukernel.run_matmul(
+        m, n_to_process, k,      // Dimensions
+        lhs_packed_mtx_qa8dx,    // LHS packed
+        rhs_packed_ptr,          // RHS packed
+        dst_ptr,                 // DST
+        dst_stride,              // DST stride (row)
+        sizeof(float),           // DST stride (col)
+        lower_bound, upper_bound // Min and max for the clamp operation
+      );
+    });
+
+    delete[] lhs_packed_mtx_qa8dx;
+    return;
+  }
+
+  // Cache-aware 2D tiling
+  // - The kernel re-reads the whole RHS panel every m_step rows, so the panel
+  //   must stay L2-resident.
+  auto ceil_div = [](size_t a, size_t b) { return (a + b - 1) / b; };
+
+  const size_t n_block_bytes =
+    ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_step, k);
+  const size_t m_block_bytes =
+    ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_step, k);
+
+  // Assume that per-core L2 size is 1MB
+  constexpr size_t l2_cache_bytes = 1024 * 1024;
+
+  // n: fewest tiles whose RHS panel fits ~2/3 of L2, split evenly
+  constexpr size_t rhs_l2_budget = l2_cache_bytes * 2 / 3;
+  size_t n_tiles = std::clamp<size_t>(
+    ceil_div(n_loop * n_block_bytes, rhs_l2_budget), 1, n_loop);
+  size_t n_blocks = ceil_div(n_loop, n_tiles);
+  n_tiles = ceil_div(n_loop, n_blocks);
+
+  // m: enough tiles for work stealing to balance uneven cores
+  constexpr size_t tasks_per_thread = 16;
+  const size_t num_threads = tm.getComputeThreadCount();
+  const size_t target_tasks = tasks_per_thread * num_threads;
+  size_t m_tiles =
+    std::clamp<size_t>(ceil_div(target_tasks, n_tiles), 1, m_loop);
+  size_t m_blocks = ceil_div(m_loop, m_tiles);
+
+  // reduce m block so the LHS panel also fits in L2
+  const size_t rhs_panel_bytes = n_blocks * n_block_bytes;
+  if (rhs_panel_bytes < l2_cache_bytes) {
+    m_blocks = std::min(
+      m_blocks,
+      std::max<size_t>((l2_cache_bytes - rhs_panel_bytes) / m_block_bytes, 1));
+  }
+  m_tiles = ceil_div(m_loop, m_blocks);
+
+  // increase n block to reach the task target for small m
+  if (m_tiles * n_tiles < target_tasks && n_tiles < n_loop) {
+    n_tiles = std::min(ceil_div(target_tasks, m_tiles), n_loop);
+    n_blocks = ceil_div(n_loop, n_tiles);
+    n_tiles = ceil_div(n_loop, n_blocks);
+  }
+
+  const size_t m_chunk = m_blocks * m_step;
+  const size_t n_chunk = n_blocks * n_step;
+
+  // row-major: consecutive tasks share the LHS panel
+  tm.parallel_for(0, m_tiles * n_tiles, [&](size_t t) {
+    const size_t ti = t / n_tiles;
+    const size_t tj = t % n_tiles;
+
+    const size_t m_start = ti * m_chunk;
+    const size_t m_to_process = std::min(m_chunk, m - m_start);
+    const size_t n_start = tj * n_chunk;
+    const size_t n_to_process = std::min(n_chunk, n - n_start);
+
+    const size_t lhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_lhs_packed_offset(m_start, k);
+    const uint8_t *lhs_packed_ptr = lhs_packed_mtx_qa8dx + lhs_packed_offset;
+
+    const size_t rhs_packed_offset =
+      ukernel_variants[idx_variant].ukernel.get_rhs_packed_offset(n_start, k);
+    const void *rhs_packed_ptr =
+      (const void *)((const char *)rhs_packed_mtx_qs8cx + rhs_packed_offset);
+
+    const size_t dst_offset =
+      ukernel_variants[idx_variant].ukernel.get_dst_offset(m_start, n_start,
+                                                           dst_stride);
+    float *dst_ptr = (float *)((uint8_t *)dst_act_mtx_f32 + dst_offset);
+
+    ukernel_variants[idx_variant].ukernel.run_matmul(
+      m_to_process, n_to_process, k, // Dimensions
+      lhs_packed_ptr,                // LHS packed
+      rhs_packed_ptr,                // RHS packed
+      dst_ptr,                       // DST
+      dst_stride,                    // DST stride (row)
+      sizeof(float),                 // DST stride (col)
+      lower_bound, upper_bound       // Min and max for the clamp operation
+    );
+  });
+
+  delete[] lhs_packed_mtx_qa8dx;
+}
+
+} // namespace nntrainer

--- a/nntrainer/tensor/cpu_backend/arm/kai_interface/meson.build
+++ b/nntrainer/tensor/cpu_backend/arm/kai_interface/meson.build
@@ -3,6 +3,7 @@ kai_interface_headers = [
 ]
 kai_interface_sources = [
     'kleidiai_interface_qai8dxp_qsi4cxp.cpp',
+    'kleidiai_interface_qai8dxp_qsi8cxp.cpp',
     'kleidiai_interface_qsi8d32p_qsi4c32p.cpp',
 ]
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -636,6 +636,11 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp4x8_8x4x32_neon_i8mm.h
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_4x8x32_neon_i8mm.h
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp4x8_qsi4cxp8x8_8x8x32_neon_i8mm.h
+%{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp_qsi8cxp_interface.h
+%{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp1x4_qsi8cxp4x4_1x4_neon_dotprod.h
+%{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp1x8_qsi8cxp4x8_1x4_neon_dotprod.h
+%{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp4x4_qsi8cxp4x4_16x4_neon_dotprod.h
+%{_includedir}/nntrainer/kai_matmul_clamp_f32_qai8dxp4x8_qsi8cxp4x8_16x4_neon_i8mm.h
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qsi8d32p_qsi4c32p_interface.h
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qsi8d32p1x4_qsi4c32p4x4_1x4_neon_dotprod.h
 %{_includedir}/nntrainer/kai_matmul_clamp_f32_qsi8d32p1x8_qsi4c32p4x8_1x4x32_neon_dotprod.h
@@ -649,6 +654,7 @@ cp -r result %{buildroot}%{_datadir}/nntrainer/unittest/
 %{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4c32pscalef16_qsu4c32s16s0.h
 %{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0.h
 %{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi4cxp_qs4cxs1s0_neon.h
+%{_includedir}/nntrainer/kai_rhs_pack_nxk_qsi8cxp_qsi8cx_neon.h
 %{_includedir}/nntrainer/kai_common.h
 %{_includedir}/nntrainer/kleidiai_interface.h
 %if 0%{?enable_fp16}


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[kleidiai] Add matmul_clamp_f32_qai8dxp_qsi8cxp</summary><br />

- Add matmul_clamp_f32_qai8dxp_qsi8cxp ukernels
- Add rhs pack kernel
- Add interface

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

Let's add kleidiai kernel for
- activation: fp32 -> channelwise int8
- weight: channelwise int8

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
