### PR TITLE
[kleidiai] Add cpu_backend f16 qai8dxp_qsi4cxp wrappers

### DIFF
--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend.h
@@ -1613,6 +1613,82 @@ void gemm_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
                           float lower_bound = -FLT_MAX,
                           float upper_bound = FLT_MAX);
 
+#if defined(ENABLE_FP16)
+/**
+ * @brief get size of memory to allocate for packed rhs from nxk qs4cxs1s0 to
+ * qsi4cxp, for the f16 qai8dxp_qsi4cxp GEMM
+ * Note that nxk is the format of quantized rhs, not the shape of rhs
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ * @return size_t size of memory to allocate
+ */
+size_t get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                                 size_t idx_variant,
+                                                 bool is_nxk);
+
+/**
+ * @brief rhs matrix packing from nxk qs4cxs1s0 to qsi4cxp, for the f16
+ * qai8dxp_qsi4cxp GEMM
+ * Note that rhs_qs4cx must be stored with UINT4 shape (zero point = 8)
+ *
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[out] rhs_packed_mtx_qs4cx packed rhs
+ * @param[in] rhs_native_mtx_qs4cx quantized matrix data
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ */
+void rhs_pack_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                    void *rhs_packed_mtx_qs4cx,
+                                    void *rhs_native_mtx_qs4cx,
+                                    void *rhs_scales_f32, size_t idx_variant,
+                                    bool is_nxk);
+
+/**
+ * @brief run f16 qai8dxp_qsi4cxp GEMM with online rhs packing
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f16 matrix data (F16)
+ * @param[in] rhs_native_mtx_qs4cx quantized matrix data
+ * @param[in] rhs_scales_f32 qparam data
+ * @param[out] dst_act_mtx_f16 output data (F16)
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] is_nxk true if rhs is in nxk format
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void gemm_f16_qai8dxp_qsi4cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f16,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, void *dst_act_mtx_f16,
+  size_t idx_variant, bool is_nxk, float lower_bound = -FLT_MAX,
+  float upper_bound = FLT_MAX);
+
+/**
+ * @brief run f16 qai8dxp_qsi4cxp GEMM with offline packed rhs
+ *
+ * @param[in] m M for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] n N for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] k K for (M, K) * (K, N) = (M, N) in noTrans GEMM
+ * @param[in] lhs_native_mtx_f16 matrix data (F16)
+ * @param[in] rhs_packed_mtx_qs4cx quantized matrix data, packed already
+ * @param[out] dst_act_mtx_f16 output data (F16)
+ * @param[in] idx_variant index of ukernel to use
+ * @param[in] lower_bound clipping param
+ * @param[in] upper_bound clipping param
+ */
+void gemm_f16_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                              void *lhs_native_mtx_f16,
+                              void *rhs_packed_mtx_qs4cx, void *dst_act_mtx_f16,
+                              size_t idx_variant, float lower_bound = -FLT_MAX,
+                              float upper_bound = FLT_MAX);
+#endif // ENABLE_FP16
+
 } /* namespace nntrainer */
 #endif /* __cplusplus */
 #endif /* __ARM_COMPUTE_BACKEND_H__ */

--- a/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
+++ b/nntrainer/tensor/cpu_backend/arm/arm_compute_backend_fp16.cpp
@@ -432,6 +432,42 @@ void rms_norm_wrt_width_fp16_intrinsic(const float *__restrict X,
   neon::rms_norm_wrt_width_fp16_intrinsic(X, Y, H, W, epsilon);
 }
 
+size_t get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                                 size_t idx_variant,
+                                                 bool is_nxk) {
+  return __kai_get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(n, k, idx_variant,
+                                                         is_nxk);
+}
+
+void rhs_pack_f16_qsi4cxp_qs4cxs1s0(size_t n, size_t k,
+                                    void *rhs_packed_mtx_qs4cx,
+                                    void *rhs_native_mtx_qs4cx,
+                                    void *rhs_scales_f32, size_t idx_variant,
+                                    bool is_nxk) {
+  __kai_rhs_pack_f16_qsi4cxp_qs4cxs1s0(n, k, rhs_packed_mtx_qs4cx,
+                                       rhs_native_mtx_qs4cx, rhs_scales_f32,
+                                       idx_variant, is_nxk);
+}
+
+void gemm_f16_qai8dxp_qsi4cxp_rhs_unpacked(
+  size_t m, size_t n, size_t k, void *lhs_native_mtx_f16,
+  void *rhs_native_mtx_qs4cx, void *rhs_scales_f32, void *dst_act_mtx_f16,
+  size_t idx_variant, bool is_nxk, float lower_bound, float upper_bound) {
+  __kai_gemm_f16_qai8dxp_qsi4cxp_rhs_unpacked(
+    m, n, k, lhs_native_mtx_f16, rhs_native_mtx_qs4cx, rhs_scales_f32,
+    dst_act_mtx_f16, idx_variant, is_nxk, lower_bound, upper_bound);
+}
+
+void gemm_f16_qai8dxp_qsi4cxp(size_t m, size_t n, size_t k,
+                              void *lhs_native_mtx_f16,
+                              void *rhs_packed_mtx_qs4cx, void *dst_act_mtx_f16,
+                              size_t idx_variant, float lower_bound,
+                              float upper_bound) {
+  __kai_gemm_f16_qai8dxp_qsi4cxp(m, n, k, lhs_native_mtx_f16,
+                                 rhs_packed_mtx_qs4cx, dst_act_mtx_f16,
+                                 idx_variant, lower_bound, upper_bound);
+}
+
 void nntr_quant_qs4c32_f32(size_t n, size_t k, size_t bl,
                            void *rhs_native_mtx_f32,
                            void *rhs_native_mtx_qs4c32) {

--- a/test/unittest/unittest_nntrainer_kleidiai.cpp
+++ b/test/unittest/unittest_nntrainer_kleidiai.cpp
@@ -330,6 +330,7 @@ static void evict_from_caches(const void *buf, size_t bytes) {
  * Compares latency of:
  * - nntr_gemm_qai8dxp_qsi4cxp_packed (KleidiAI with channel-wise quant)
  * - gemm_q4_0<float> (GGML-style Q4_0 GEMM)
+ * - nntr_gemm_f16_qai8dxp_qsi4cxp_packed (KleidiAI, F16 I/O; ENABLE_FP16 only)
  */
 void run_gemm_benchmark_comparison(const size_t M, const size_t N,
                                    const size_t K,
@@ -382,6 +383,33 @@ void run_gemm_benchmark_comparison(const size_t M, const size_t N,
   }
 
   std::vector<uint8_t> packed_weight_qai8dxp(max_rhs_packed_size);
+
+#ifdef ENABLE_FP16
+  // ============================================================
+  // Setup 3: f16 qai8dxp_qsi4cxp (KleidiAI, F16 I/O)
+  //   Reuses the same qs4cx-quantized weight as Setup 2, but packs it with
+  //   the F16 rhs packer and feeds an F16 activation / F16 output.
+  // ============================================================
+  std::vector<__fp16> activation_f16(M * K);
+  for (size_t i = 0; i < M * K; i++) {
+    activation_f16[i] = static_cast<__fp16>(activation[i]);
+  }
+  std::vector<__fp16> dst_f16(M * N);
+
+  const size_t num_idx_variants_f16 =
+    nntrainer::__kai_get_num_ukernel_variants_f16_qai8dxp_qsi4cxp();
+  size_t max_rhs_packed_size_f16 = 0;
+  for (size_t idx_variant = 0; idx_variant < num_idx_variants_f16;
+       idx_variant++) {
+    size_t rhs_packed_size =
+      nntrainer::get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(N, K, idx_variant,
+                                                           true);
+    max_rhs_packed_size_f16 =
+      std::max(max_rhs_packed_size_f16, rhs_packed_size);
+  }
+
+  std::vector<uint8_t> packed_weight_f16(max_rhs_packed_size_f16);
+#endif // ENABLE_FP16
 
   // ============================================================
   // Benchmark: gemm_q4_0<float>
@@ -445,6 +473,47 @@ void run_gemm_benchmark_comparison(const size_t M, const size_t N,
     total_time_qai8dxp[idx_variant] = local_time;
   }
 
+#ifdef ENABLE_FP16
+  // ============================================================
+  // Benchmark: f16 qai8dxp_qsi4cxp_packed
+  // ============================================================
+  std::vector<nanoseconds> total_time_f16(num_idx_variants_f16, nanoseconds(0));
+
+  for (size_t idx_variant = 0; idx_variant < num_idx_variants_f16;
+       idx_variant++) {
+    // rhs pack (F16 packer)
+    nntrainer::rhs_pack_f16_qsi4cxp_qs4cxs1s0(
+      N, K, packed_weight_f16.data(), rhs_native_mtx_qs4cx.data(),
+      rhs_scales_f32.data(), idx_variant, true);
+
+    // cold-RHS eviction, same scheme as the benchmarks above
+    const size_t rhs_packed_size =
+      nntrainer::get_rhs_packed_size_f16_qsi4cxp_qs4cxs1s0(N, K, idx_variant,
+                                                           true);
+
+    // warm up
+    for (size_t i = 0; i < warmup_iters; ++i) {
+      evict_from_caches(packed_weight_f16.data(), rhs_packed_size);
+      nntrainer::gemm_f16_qai8dxp_qsi4cxp(M, N, K, activation_f16.data(),
+                                          packed_weight_f16.data(),
+                                          dst_f16.data(), idx_variant);
+    }
+
+    nanoseconds local_time = nanoseconds(0);
+
+    for (size_t i = 0; i < test_iters; ++i) {
+      evict_from_caches(packed_weight_f16.data(), rhs_packed_size);
+      auto t1 = steady_clock::now();
+      nntrainer::gemm_f16_qai8dxp_qsi4cxp(M, N, K, activation_f16.data(),
+                                          packed_weight_f16.data(),
+                                          dst_f16.data(), idx_variant);
+      auto t2 = steady_clock::now();
+      local_time += duration_cast<nanoseconds>(t2 - t1);
+    }
+    total_time_f16[idx_variant] = local_time;
+  }
+#endif // ENABLE_FP16
+
   // ============================================================
   // Print results
   // ============================================================
@@ -466,6 +535,18 @@ void run_gemm_benchmark_comparison(const size_t M, const size_t N,
               << avg_ns_qai8dxp / 1'000 << " us, " << avg_ns_qai8dxp / 1'000'000
               << " ms)" << std::endl;
   }
+#ifdef ENABLE_FP16
+  for (size_t i = 0; i < num_idx_variants_f16; i++) {
+    auto avg_ns_f16 = total_time_f16[i].count() / test_iters;
+    std::cout << "-----------------------------------------" << std::endl;
+    std::cout << "ukernel[" << i << "] "
+              << nntrainer::__kai_get_num_ukernel_name_f16_qai8dxp_qsi4cxp(i)
+              << std::endl;
+    std::cout << "  f16_qai8dxp_qsi4cxp_packed: " << avg_ns_f16 << " ns ("
+              << avg_ns_f16 / 1'000 << " us, " << avg_ns_f16 / 1'000'000
+              << " ms)" << std::endl;
+  }
+#endif // ENABLE_FP16
 }
 
 // Benchmarks, not correctness tests: DISABLED from the default


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[kleidiai] Add cpu_backend f16 qai8dxp_qsi4cxp wrappers</summary><br />

- Add arm_compute_backend wrappers for the f16 matmul_clamp_qai8dxp_qsi4cxp
  ukernels: rhs packed size, rhs pack, and GEMM with both online (rhs
  unpacked) and offline (rhs packed) weight packing
- Benchmark the f16 qai8dxp_qsi4cxp path in run_gemm_benchmark_comparison
  alongside q4_0 and f32 qai8dxp_qsi4cxp, reusing the same qs4cx-quantized
  weight and following the existing cold-RHS eviction scheme (ENABLE_FP16)

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

</details>

### Summary

Let's add wrappers for kleidiai fp16 qs4cx.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

