### PR TITLE
[layer_devel] Fix Layer comment and drop unused forward decl

### DIFF
--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -33,10 +33,6 @@
 #include <layer_context.h>
 #include <tensor_dim.h>
 
-namespace ml::train {
-class Layer;
-}
-
 namespace nntrainer {
 
 class InitLayerContext;
@@ -76,8 +72,10 @@ enum class InPlaceDirection {
  * @class   Layer Base class for layers
  * @brief   Base class for all layers
  *
- * @details nntrainer::Layer inherits ml::train::Layer but has been omitted to
- * disallow static_cast between nntrainer::Layer and ml::train::Layer objects.
+ * @details Internal (devel API) base class for all layer implementations. It is
+ * independent from the public ml::train::Layer interface; the two are bridged
+ * by nntrainer::LayerNode, which inherits ml::train::Layer and wraps a
+ * nntrainer::Layer via composition.
  */
 class Layer {
 


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[layer_devel] Fix Layer comment and drop unused forward decl</summary><br />

nntrainer::Layer does not inherit ml::train::Layer; they are independent
and bridged by LayerNode via composition. Fix the misleading comment and
remove the unused ml::train::Layer forward declaration.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
Let's remove unused forward declaration and fix wrong comment.


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
