### PR TITLE
[CausalLM] Support VisionEmbeddingLayer for image embedding blending

### DIFF
--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -80,6 +80,7 @@ LOCAL_SRC_FILES := \
     ../huggingface_tokenizer.cpp \
     ../llm_util.cpp \
     ../layers/embedding_layer.cpp \
+    ../layers/vision_embedding_layer.cpp \
     ../layers/embedding_pooling_layer.cpp \
     ../layers/embedding_normalize_layer.cpp \
     ../layers/per_layer_slice.cpp \
@@ -197,6 +198,7 @@ LOCAL_SRC_FILES := ../quantize.cpp \
     ../models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.cpp \
     ../llm_util.cpp \
     ../layers/embedding_layer.cpp \
+    ../layers/vision_embedding_layer.cpp \
     ../layers/embedding_pooling_layer.cpp \
     ../layers/embedding_normalize_layer.cpp \
     ../layers/per_layer_slice.cpp \

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -116,7 +116,7 @@ causallm_vision_embedding_layer = shared_library(
     'vision_embedding_layer',
     causallm_vision_embedding_src_abs,
     include_directories: causallm_layer_inc,
-    dependencies: [nntrainer_dep, nntrainer_ccapi_dep, openmp_dep],
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep],
     install: true,
     install_dir: application_install_dir
 )

--- a/Applications/CausalLM/layers/meson.build
+++ b/Applications/CausalLM/layers/meson.build
@@ -8,6 +8,7 @@ causallm_tie_word_embedding_src_abs = [meson.current_source_dir() / 'tie_word_em
 causallm_lmhead_src_abs = [meson.current_source_dir() / 'lm_head.cpp']
 causallm_mha_core_abs = [meson.current_source_dir()/ 'mha_core.cpp']
 causallm_embedding_src_abs = [meson.current_source_dir() / 'embedding_layer.cpp']
+causallm_vision_embedding_src_abs = [meson.current_source_dir() / 'vision_embedding_layer.cpp']
 causallm_reshaped_rms_norm_src_abs = [meson.current_source_dir() / 'reshaped_rms_norm.cpp']
 causallm_qkv_layer_src_abs = [meson.current_source_dir() / 'qkv_layer.cpp']
 causallm_rms_reverse_norm_src_abs = [meson.current_source_dir() / 'rms_reverse_norm.cpp']
@@ -108,6 +109,19 @@ causallm_embedding_layer = shared_library(
 )
 causallm_embedding_layer_dep = declare_dependency(
     link_with: causallm_embedding_layer,
+    include_directories: causallm_layer_inc
+)
+
+causallm_vision_embedding_layer = shared_library(
+    'vision_embedding_layer',
+    causallm_vision_embedding_src_abs,
+    include_directories: causallm_layer_inc,
+    dependencies: [nntrainer_dep, nntrainer_ccapi_dep, openmp_dep],
+    install: true,
+    install_dir: application_install_dir
+)
+causallm_vision_embedding_layer_dep = declare_dependency(
+    link_with: causallm_vision_embedding_layer,
     include_directories: causallm_layer_inc
 )
 

--- a/Applications/CausalLM/layers/vision_embedding_layer.cpp
+++ b/Applications/CausalLM/layers/vision_embedding_layer.cpp
@@ -118,16 +118,14 @@ void VisionEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
 
     size_t image_start_token_idx = 0;
 
-#pragma omp parallel for
-    for (int i = 0; i < tokens.width(); ++i) {
+    for (int i = 0; i < (int)tokens.width(); ++i) {
       size_t embed_idx = static_cast<size_t>(tokens_data[i]);
       if (embed_idx == image_start_token) {
         image_start_token_idx = i;
       }
     }
 
-#pragma omp parallel for
-    for (int i = 0; i < tokens.width(); ++i) {
+    for (int i = 0; i < (int)tokens.width(); ++i) {
       size_t embed_idx = static_cast<size_t>(tokens_data[i]);
       if (embed_idx >= in_dim) {
         throw std::invalid_argument("input word index is greater than in_dim");
@@ -190,8 +188,6 @@ void VisionEmbeddingLayer::incremental_forwarding(
     std::get<nntrainer::props::Scale>(vision_embedding_props).empty()
       ? 1.0f
       : std::get<nntrainer::props::Scale>(vision_embedding_props).get();
-  unsigned int _from = from;
-
   nntrainer::Tensor &weight = context.getWeight(weight_idx);
   nntrainer::Tensor &hidden_ = context.getOutput(OUT_IDX);
   nntrainer::Tensor &tokens = context.getInput(TOKEN_IDX);
@@ -213,25 +209,24 @@ void VisionEmbeddingLayer::incremental_forwarding(
 
     size_t image_start_token_idx = 0;
 
-#pragma omp parallel for
-    for (int i = 0; i < tokens.width(); ++i) {
+    for (int i = 0; i < (int)tokens.width(); ++i) {
       size_t embed_idx = static_cast<size_t>(tokens_data[i]);
       if (embed_idx == image_start_token) {
         image_start_token_idx = i;
       }
     }
 
-#pragma omp parallel for
     for (int i = 0; i < iter; ++i) {
-      size_t embed_idx = static_cast<size_t>(tokens_data[i]);
+      size_t embed_idx = static_cast<size_t>(tokens_data[from + i]);
       if (embed_idx >= in_dim) {
         throw std::invalid_argument("input word index is greater than in_dim");
       }
 
+      unsigned int out_slot = from + i;
       nntrainer::Tensor out_tensor = batchsliced_hidden.getSharedDataTensor(
-        out_token_dim, i <= image_start_token_idx
-                         ? i * out_dim
-                         : (i + image.height()) * out_dim);
+        out_token_dim, out_slot <= image_start_token_idx
+                         ? out_slot * out_dim
+                         : (out_slot + image.height()) * out_dim);
       nntrainer::Tensor cur_weight =
         weight.getSharedDataTensor(out_token_dim, out_dim * embed_idx);
 
@@ -260,7 +255,7 @@ void VisionEmbeddingLayer::incremental_forwarding(
       if (embed_idx == image_start_token) {
         nntrainer::Tensor out_image_tensor =
           batchsliced_hidden.getSharedDataTensor(out_image_dim,
-                                                 (i + 1) * out_dim);
+                                                 (out_slot + 1) * out_dim);
         out_image_tensor.copyData(image);
 
         if (scale != 1.0f) {
@@ -288,7 +283,8 @@ void VisionEmbeddingLayer::save(std::ofstream &file,
                                 nntrainer::RunLayerContext &run_context,
                                 bool opt_var, ml::train::ExecutionMode mode,
                                 bool trainable,
-                                nntrainer::TensorDim::DataType dtype) const {
+                                nntrainer::TensorDim::DataType dtype,
+                                ml::train::ISA target_isa) const {
   // @note shared weights are only be saved at the first access
   for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
     if (run_context.isGradientFirstAccess(i)) {

--- a/Applications/CausalLM/layers/vision_embedding_layer.cpp
+++ b/Applications/CausalLM/layers/vision_embedding_layer.cpp
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Hyeonseok Lee <hs89.lee@samsung.com>
+ *
+ * @file   vision_embedding_layer.cpp
+ * @date   17 April 2026
+ * @brief  This is Embedding Layer Class of Neural Network
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Hyeonseok Lee <hs89.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ * @note   This embedding layer supports FP32/FP16/Q6_K data type only.
+ */
+
+#include <layer_context.h>
+#include <nntrainer_error.h>
+#include <nntrainer_log.h>
+#include <node_exporter.h>
+#include <util_func.h>
+#include <vision_embedding_layer.h>
+
+namespace causallm {
+
+static constexpr size_t OUT_IDX = 0;
+static constexpr size_t TOKEN_IDX = 0;
+static constexpr size_t IMAGE_IDX = 1;
+
+enum EmbeddingParams { weight };
+
+VisionEmbeddingLayer::VisionEmbeddingLayer() :
+  LayerImpl(),
+  vision_embedding_props(nntrainer::props::InDim(), nntrainer::props::OutDim(),
+                         props::ImageStartToken(), nntrainer::props::Scale()),
+  weight_idx(std::numeric_limits<unsigned>::max()) {}
+
+void VisionEmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 2, std::invalid_argument)
+    << "VisionEmbedding layer takes 2 input";
+
+  const nntrainer::TensorDim &token_dim =
+    context.getInputDimensions()[TOKEN_IDX];
+  NNTR_THROW_IF(token_dim.channel() != 1, std::invalid_argument)
+    << "VisionEmbedding layer takes only one for channel size for token input";
+
+  const nntrainer::TensorDim &image_dim =
+    context.getInputDimensions()[IMAGE_IDX];
+  NNTR_THROW_IF(image_dim.channel() != 1, std::invalid_argument)
+    << "VisionEmbedding layer takes only one for channel size for image input";
+
+  auto &weight_regularizer =
+    std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
+  auto &weight_regularizer_constant =
+    std::get<nntrainer::props::WeightRegularizerConstant>(*layer_impl_props);
+  auto weight_initializer = nntrainer::props::InitializerInfo::Enum::NONE;
+  auto &weight_decay =
+    std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
+
+  size_t in_dim = static_cast<size_t>(
+    std::get<nntrainer::props::InDim>(vision_embedding_props));
+  size_t out_dim = static_cast<size_t>(
+    std::get<nntrainer::props::OutDim>(vision_embedding_props));
+
+  nntrainer::TensorDim output_dim = token_dim;
+
+  output_dim.height(token_dim.width() + image_dim.height());
+
+  output_dim.width(out_dim);
+  output_dim.setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+  context.setOutputDimensions({output_dim});
+
+  nntrainer::TensorDim dim = output_dim;
+
+  dim.setTensorType({context.getFormat(), context.getWeightDataType()});
+
+  dim.height(in_dim);
+  dim.width(out_dim);
+  dim.batch(1);
+
+  weight_idx = context.requestWeight(
+    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
+    weight_decay, "VisionEmbedding", true);
+}
+
+void VisionEmbeddingLayer::setProperty(const std::vector<std::string> &values) {
+  auto remain_props = loadProperties(values, vision_embedding_props);
+  LayerImpl::setProperty(remain_props);
+}
+
+void VisionEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
+                                      bool training) {
+  unsigned int in_dim =
+    std::get<nntrainer::props::InDim>(vision_embedding_props);
+  unsigned int out_dim =
+    std::get<nntrainer::props::OutDim>(vision_embedding_props);
+  unsigned int image_start_token =
+    std::get<props::ImageStartToken>(vision_embedding_props);
+  float scale =
+    std::get<nntrainer::props::Scale>(vision_embedding_props).empty()
+      ? 1.0f
+      : std::get<nntrainer::props::Scale>(vision_embedding_props).get();
+
+  nntrainer::Tensor &weight = context.getWeight(weight_idx);
+  nntrainer::Tensor &hidden_ = context.getOutput(OUT_IDX);
+  nntrainer::Tensor &tokens = context.getInput(TOKEN_IDX);
+  nntrainer::Tensor &image = context.getInput(IMAGE_IDX);
+
+  nntrainer::TensorDim out_token_dim =
+    nntrainer::TensorDim({1, 1, 1, out_dim}, hidden_.getTensorType());
+  nntrainer::TensorDim out_image_dim = nntrainer::TensorDim(
+    {1, 1, image.height(), out_dim}, hidden_.getTensorType());
+
+  unsigned int b_size = tokens.batch();
+
+  for (unsigned int b = 0; b < b_size; ++b) {
+    float *tokens_data =
+      tokens.getAddress<float>(b * tokens.getDim().getFeatureLen());
+    nntrainer::Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
+
+    size_t image_start_token_idx = 0;
+
+#pragma omp parallel for
+    for (int i = 0; i < tokens.width(); ++i) {
+      size_t embed_idx = static_cast<size_t>(tokens_data[i]);
+      if (embed_idx == image_start_token) {
+        image_start_token_idx = i;
+      }
+    }
+
+#pragma omp parallel for
+    for (int i = 0; i < tokens.width(); ++i) {
+      size_t embed_idx = static_cast<size_t>(tokens_data[i]);
+      if (embed_idx >= in_dim) {
+        throw std::invalid_argument("input word index is greater than in_dim");
+      }
+
+      nntrainer::Tensor out_tensor = batchsliced_hidden.getSharedDataTensor(
+        out_token_dim, i <= image_start_token_idx
+                         ? i * out_dim
+                         : (i + image.height()) * out_dim);
+      nntrainer::Tensor cur_weight =
+        weight.getSharedDataTensor(out_token_dim, out_dim * embed_idx);
+
+      if (weight.getDataType() == nntrainer::TensorDim::DataType::Q6_K) {
+        ///@note this should be replaced with quantizer operation
+        int num_blocks_per_row = (weight.width() + 256 - 1) / 256;
+        nntrainer::dequantize_row_q6_K(
+          (void *)((char *)weight.getData<uint8_t>() +
+                   (210 * num_blocks_per_row) * embed_idx),
+          out_tensor.getData(), out_dim);
+      } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
+        ///@note this should be replaced with quantizer operation
+        int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
+        nntrainer::dequantize_row_q4_0(
+          (void *)((char *)weight.getData<uint8_t>() +
+                   (18 * num_blocks_per_row) * embed_idx),
+          out_tensor.getData(), out_dim);
+      } else {
+        out_tensor.copyData(cur_weight);
+      }
+
+      if (scale != 1.0f) {
+        out_tensor.multiply_i(scale);
+      }
+
+      if (embed_idx == image_start_token) {
+        nntrainer::Tensor out_image_tensor =
+          batchsliced_hidden.getSharedDataTensor(out_image_dim,
+                                                 (i + 1) * out_dim);
+        out_image_tensor.copyData(image);
+
+        if (scale != 1.0f) {
+          out_image_tensor.multiply_i(scale);
+        }
+      }
+    }
+  }
+}
+
+void VisionEmbeddingLayer::incremental_forwarding(
+  nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
+  bool training) {
+
+  unsigned int in_dim =
+    std::get<nntrainer::props::InDim>(vision_embedding_props);
+  unsigned int out_dim =
+    std::get<nntrainer::props::OutDim>(vision_embedding_props);
+  unsigned int image_start_token =
+    std::get<props::ImageStartToken>(vision_embedding_props);
+  float scale =
+    std::get<nntrainer::props::Scale>(vision_embedding_props).empty()
+      ? 1.0f
+      : std::get<nntrainer::props::Scale>(vision_embedding_props).get();
+  unsigned int _from = from;
+
+  nntrainer::Tensor &weight = context.getWeight(weight_idx);
+  nntrainer::Tensor &hidden_ = context.getOutput(OUT_IDX);
+  nntrainer::Tensor &tokens = context.getInput(TOKEN_IDX);
+  nntrainer::Tensor &image = context.getInput(IMAGE_IDX);
+
+  nntrainer::TensorDim out_token_dim =
+    nntrainer::TensorDim({1, 1, 1, out_dim}, hidden_.getTensorType());
+  nntrainer::TensorDim out_image_dim = nntrainer::TensorDim(
+    {1, 1, image.height(), out_dim}, hidden_.getTensorType());
+
+  unsigned int b_size = tokens.batch();
+
+  for (unsigned int b = 0; b < b_size; ++b) {
+    float *tokens_data =
+      tokens.getAddress<float>(b * tokens.getDim().getFeatureLen());
+    nntrainer::Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
+
+    int iter = to - from;
+
+    size_t image_start_token_idx = 0;
+
+#pragma omp parallel for
+    for (int i = 0; i < tokens.width(); ++i) {
+      size_t embed_idx = static_cast<size_t>(tokens_data[i]);
+      if (embed_idx == image_start_token) {
+        image_start_token_idx = i;
+      }
+    }
+
+#pragma omp parallel for
+    for (int i = 0; i < iter; ++i) {
+      size_t embed_idx = static_cast<size_t>(tokens_data[i]);
+      if (embed_idx >= in_dim) {
+        throw std::invalid_argument("input word index is greater than in_dim");
+      }
+
+      nntrainer::Tensor out_tensor = batchsliced_hidden.getSharedDataTensor(
+        out_token_dim, i <= image_start_token_idx
+                         ? i * out_dim
+                         : (i + image.height()) * out_dim);
+      nntrainer::Tensor cur_weight =
+        weight.getSharedDataTensor(out_token_dim, out_dim * embed_idx);
+
+      if (weight.getDataType() == nntrainer::TensorDim::DataType::Q6_K) {
+        ///@note this should be replaced with quantizer operation
+        int num_blocks_per_row = (weight.width() + 256 - 1) / 256;
+        nntrainer::dequantize_row_q6_K(
+          (void *)((char *)weight.getData<uint8_t>() +
+                   (210 * num_blocks_per_row) * embed_idx),
+          out_tensor.getData(), out_dim);
+      } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
+        ///@note this should be replaced with quantizer operation
+        int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
+        nntrainer::dequantize_row_q4_0(
+          (void *)((char *)weight.getData<uint8_t>() +
+                   (18 * num_blocks_per_row) * embed_idx),
+          out_tensor.getData(), out_dim);
+      } else {
+        out_tensor.copyData(cur_weight);
+      }
+
+      if (scale != 1.0f) {
+        out_tensor.multiply_i(scale);
+      }
+
+      if (embed_idx == image_start_token) {
+        nntrainer::Tensor out_image_tensor =
+          batchsliced_hidden.getSharedDataTensor(out_image_dim,
+                                                 (i + 1) * out_dim);
+        out_image_tensor.copyData(image);
+
+        if (scale != 1.0f) {
+          out_image_tensor.multiply_i(scale);
+        }
+      }
+    }
+  }
+}
+
+void VisionEmbeddingLayer::calcDerivative(nntrainer::RunLayerContext &context) {
+  throw nntrainer::exception::not_supported(
+    "calcDerivative for VisionEmbedding layer is not supported");
+}
+
+void VisionEmbeddingLayer::calcGradient(nntrainer::RunLayerContext &context) {}
+
+void VisionEmbeddingLayer::exportTo(
+  nntrainer::Exporter &exporter, const ml::train::ExportMethods &method) const {
+  LayerImpl::exportTo(exporter, method);
+  exporter.saveResult(vision_embedding_props, method, this);
+}
+
+void VisionEmbeddingLayer::save(std::ofstream &file,
+                                nntrainer::RunLayerContext &run_context,
+                                bool opt_var, ml::train::ExecutionMode mode,
+                                bool trainable,
+                                nntrainer::TensorDim::DataType dtype) const {
+  // @note shared weights are only be saved at the first access
+  for (unsigned int i = 0; i < run_context.getNumWeights(); ++i) {
+    if (run_context.isGradientFirstAccess(i)) {
+      auto &weight = run_context.getWeight(i);
+      if (dtype == nntrainer::TensorDim::DataType::NONE ||
+          weight.getDataType() == dtype)
+        weight.save(file);
+      else {
+        NNTR_THROW_IF(weight.getDataType() !=
+                        nntrainer::TensorDim::DataType::FP32,
+                      std::runtime_error)
+          << "Save with quantization only supports for FP32 weight.";
+        ///@note The codelines below can be replaced with quantizer's
+        /// quantize()
+        nntrainer::TensorDim dim = weight.getDim();
+        unsigned int K = dim.height();
+        unsigned int N = dim.width();
+
+        if (dtype == nntrainer::TensorDim::DataType::Q4_0) {
+
+          // Skip quantization for bias-like tensors (1D with height == 1)
+          // as they are not suitable for Q4_0 block quantization
+          if (K == 1) {
+            weight.save(file);
+          } else {
+            NNTR_THROW_IF(N % 32 != 0 || K % 32 != 0, std::invalid_argument)
+              << "Q4_0 quantization requires both width and height to be "
+                 "divisible by 32, but got height="
+              << K << ", width=" << N;
+            //////////////////////////////////////////////////////////////////
+            ///@note Please note that VisionEmbedding layer doesn't need to be
+            /// transposed!
+            //////////////////////////////////////////////////////////////////
+            nntrainer::Tensor quant_weight(dim.batch(), dim.channel(), K, N,
+                                           {nntrainer::Tformat::NCHW, dtype});
+            nntrainer::quantize_q4_0(weight.getData<float>(),
+                                     quant_weight.getData<uint8_t>(), K, N,
+                                     nullptr);
+            quant_weight.save(file);
+          }
+        } else if (dtype == nntrainer::TensorDim::DataType::Q6_K) {
+          //////////////////////////////////////////////////////////////////
+          ///@note Please note that VisionEmbedding layer doesn't need to be
+          /// transposed!
+          //////////////////////////////////////////////////////////////////
+          nntrainer::Tensor quant_weight(dim.batch(), dim.channel(), K, N,
+                                         {nntrainer::Tformat::NCHW, dtype});
+          nntrainer::quantize_q6_K(weight.getData<float>(),
+                                   quant_weight.getData<uint8_t>(), K, N,
+                                   nullptr);
+          quant_weight.save(file);
+        } else {
+          NNTR_THROW_IF(true, std::runtime_error)
+            << "This dtype is not supported in save with quantization";
+        }
+      }
+    }
+  }
+}
+
+void VisionEmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::RunLayerContext &context,
+  std::vector<nntrainer::TensorDim> input_dimensions) {
+  nntrainer::TensorDim token_dim = context.getInput(TOKEN_IDX).getDim();
+  nntrainer::TensorDim image_dim = context.getInput(IMAGE_IDX).getDim();
+  nntrainer::TensorDim out_dim = context.getOutput(OUT_IDX).getDim();
+
+  unsigned int token_len = input_dimensions[TOKEN_IDX].width();
+  unsigned int image_len = input_dimensions[IMAGE_IDX].height();
+
+  token_dim.width(token_len);
+  image_dim.height(image_len);
+  out_dim.height(token_len + image_len);
+
+  context.updateInput(TOKEN_IDX, token_dim);
+  context.updateInput(IMAGE_IDX, image_dim);
+  context.updateOutput(OUT_IDX, out_dim);
+}
+
+#ifdef PLUGGABLE
+
+nntrainer::Layer *create_vision_embedding_layer() {
+  auto layer = new VisionEmbeddingLayer();
+  std::cout << "vision embedding layer created\n";
+  return layer;
+}
+
+void destroy_vision_embedding_layer(nntrainer::Layer *layer) {
+  std::cout << "vision embeddinglayer is deleted\n";
+  delete layer;
+}
+
+extern "C" {
+nntrainer::LayerPluggable ml_train_layer_pluggable{
+  create_vision_embedding_layer, destroy_vision_embedding_layer};
+}
+
+#endif
+
+} // namespace causallm

--- a/Applications/CausalLM/layers/vision_embedding_layer.cpp
+++ b/Applications/CausalLM/layers/vision_embedding_layer.cpp
@@ -115,6 +115,7 @@ void VisionEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
     float *tokens_data =
       tokens.getAddress<float>(b * tokens.getDim().getFeatureLen());
     nntrainer::Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
+    nntrainer::Tensor batchsliced_image = image.getBatchSlice(b, 1);
 
     size_t image_start_token_idx = 0;
 
@@ -141,17 +142,35 @@ void VisionEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
       if (weight.getDataType() == nntrainer::TensorDim::DataType::Q6_K) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 256 - 1) / 256;
-        nntrainer::dequantize_row_q6_K(
-          (void *)((char *)weight.getData<uint8_t>() +
-                   (210 * num_blocks_per_row) * embed_idx),
-          out_tensor.getData(), out_dim);
+        const void *src = (void *)((char *)weight.getData<uint8_t>() +
+                                   (210 * num_blocks_per_row) * embed_idx);
+        if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
+          nntrainer::dequantize_row_q6_K(src, out_tensor.getData(), out_dim);
+        } else {
+          nntrainer::TensorDim fp32_dim(
+            {1, 1, 1, out_dim},
+            nntrainer::TensorDim::TensorType(
+              out_token_dim.getFormat(), nntrainer::TensorDim::DataType::FP32));
+          nntrainer::Tensor tmp(fp32_dim, true);
+          nntrainer::dequantize_row_q6_K(src, tmp.getData(), out_dim);
+          out_tensor.copyData(tmp);
+        }
       } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
-        nntrainer::dequantize_row_q4_0(
-          (void *)((char *)weight.getData<uint8_t>() +
-                   (18 * num_blocks_per_row) * embed_idx),
-          out_tensor.getData(), out_dim);
+        const void *src = (void *)((char *)weight.getData<uint8_t>() +
+                                   (18 * num_blocks_per_row) * embed_idx);
+        if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
+          nntrainer::dequantize_row_q4_0(src, out_tensor.getData(), out_dim);
+        } else {
+          nntrainer::TensorDim fp32_dim(
+            {1, 1, 1, out_dim},
+            nntrainer::TensorDim::TensorType(
+              out_token_dim.getFormat(), nntrainer::TensorDim::DataType::FP32));
+          nntrainer::Tensor tmp(fp32_dim, true);
+          nntrainer::dequantize_row_q4_0(src, tmp.getData(), out_dim);
+          out_tensor.copyData(tmp);
+        }
       } else {
         out_tensor.copyData(cur_weight);
       }
@@ -164,7 +183,7 @@ void VisionEmbeddingLayer::forwarding(nntrainer::RunLayerContext &context,
         nntrainer::Tensor out_image_tensor =
           batchsliced_hidden.getSharedDataTensor(out_image_dim,
                                                  (i + 1) * out_dim);
-        out_image_tensor.copyData(image);
+        out_image_tensor.copyData(batchsliced_image);
 
         if (scale != 1.0f) {
           out_image_tensor.multiply_i(scale);
@@ -204,6 +223,7 @@ void VisionEmbeddingLayer::incremental_forwarding(
     float *tokens_data =
       tokens.getAddress<float>(b * tokens.getDim().getFeatureLen());
     nntrainer::Tensor batchsliced_hidden = hidden_.getBatchSlice(b, 1);
+    nntrainer::Tensor batchsliced_image = image.getBatchSlice(b, 1);
 
     int iter = to - from;
 
@@ -233,17 +253,35 @@ void VisionEmbeddingLayer::incremental_forwarding(
       if (weight.getDataType() == nntrainer::TensorDim::DataType::Q6_K) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 256 - 1) / 256;
-        nntrainer::dequantize_row_q6_K(
-          (void *)((char *)weight.getData<uint8_t>() +
-                   (210 * num_blocks_per_row) * embed_idx),
-          out_tensor.getData(), out_dim);
+        const void *src = (void *)((char *)weight.getData<uint8_t>() +
+                                   (210 * num_blocks_per_row) * embed_idx);
+        if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
+          nntrainer::dequantize_row_q6_K(src, out_tensor.getData(), out_dim);
+        } else {
+          nntrainer::TensorDim fp32_dim(
+            {1, 1, 1, out_dim},
+            nntrainer::TensorDim::TensorType(
+              out_token_dim.getFormat(), nntrainer::TensorDim::DataType::FP32));
+          nntrainer::Tensor tmp(fp32_dim, true);
+          nntrainer::dequantize_row_q6_K(src, tmp.getData(), out_dim);
+          out_tensor.copyData(tmp);
+        }
       } else if (weight.getDataType() == nntrainer::TensorDim::DataType::Q4_0) {
         ///@note this should be replaced with quantizer operation
         int num_blocks_per_row = (weight.width() + 32 - 1) / 32;
-        nntrainer::dequantize_row_q4_0(
-          (void *)((char *)weight.getData<uint8_t>() +
-                   (18 * num_blocks_per_row) * embed_idx),
-          out_tensor.getData(), out_dim);
+        const void *src = (void *)((char *)weight.getData<uint8_t>() +
+                                   (18 * num_blocks_per_row) * embed_idx);
+        if (out_tensor.getDataType() == nntrainer::TensorDim::DataType::FP32) {
+          nntrainer::dequantize_row_q4_0(src, out_tensor.getData(), out_dim);
+        } else {
+          nntrainer::TensorDim fp32_dim(
+            {1, 1, 1, out_dim},
+            nntrainer::TensorDim::TensorType(
+              out_token_dim.getFormat(), nntrainer::TensorDim::DataType::FP32));
+          nntrainer::Tensor tmp(fp32_dim, true);
+          nntrainer::dequantize_row_q4_0(src, tmp.getData(), out_dim);
+          out_tensor.copyData(tmp);
+        }
       } else {
         out_tensor.copyData(cur_weight);
       }
@@ -256,7 +294,7 @@ void VisionEmbeddingLayer::incremental_forwarding(
         nntrainer::Tensor out_image_tensor =
           batchsliced_hidden.getSharedDataTensor(out_image_dim,
                                                  (out_slot + 1) * out_dim);
-        out_image_tensor.copyData(image);
+        out_image_tensor.copyData(batchsliced_image);
 
         if (scale != 1.0f) {
           out_image_tensor.multiply_i(scale);

--- a/Applications/CausalLM/layers/vision_embedding_layer.h
+++ b/Applications/CausalLM/layers/vision_embedding_layer.h
@@ -131,13 +131,11 @@ public:
   /**
    * @copydic Layer::save()
    */
-  WIN_EXPORT void save(std::ofstream &file,
-                       nntrainer::RunLayerContext &run_context, bool opt_var,
-                       ml::train::ExecutionMode mode, bool trainable,
-                       nntrainer::TensorDim::DataType dtype =
-                         nntrainer::TensorDim::DataType::NONE,
-                       ml::train::ISA target_isa =
-                         ml::train::ISA::DEFAULT) const override;
+  WIN_EXPORT void save(
+    std::ofstream &file, nntrainer::RunLayerContext &run_context, bool opt_var,
+    ml::train::ExecutionMode mode, bool trainable,
+    nntrainer::TensorDim::DataType dtype = nntrainer::TensorDim::DataType::NONE,
+    ml::train::ISA target_isa = ml::train::ISA::DEFAULT) const override;
 
   WIN_EXPORT void updateTensorsByInputDimensions(
     nntrainer::RunLayerContext &context,

--- a/Applications/CausalLM/layers/vision_embedding_layer.h
+++ b/Applications/CausalLM/layers/vision_embedding_layer.h
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Hyeonseok Lee <hs89.lee@samsung.com>
+ *
+ * @file   vision_embedding_layer.h
+ * @date   17 April 2026
+ * @brief  This is Vision Embedding Layer Class of Neural Network
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author Hyeonseok Lee <hs89.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ */
+
+#ifndef __VISION_EMBEDDING_LAYER_H__
+#define __VISION_EMBEDDING_LAYER_H__
+#ifdef __cplusplus
+
+#pragma once
+#ifdef _WIN32
+#define WIN_EXPORT __declspec(dllexport)
+#else
+#define WIN_EXPORT
+#endif
+
+#include <common_properties.h>
+#include <layer_impl.h>
+
+namespace causallm {
+
+namespace props {
+/**
+ * @brief Special token for image property
+ *
+ */
+class ImageStartToken : public nntrainer::PositiveIntegerProperty {
+public:
+  static constexpr const char *key =
+    "image_start_token";                     /**< unique key to access */
+  using prop_tag = nntrainer::uint_prop_tag; /**< property type */
+};
+} // namespace props
+
+/**
+ * @class   VisionEmbeddingLayer
+ * @brief   VisionEmbeddingLayer
+ * @todo    Support setBatch for VisionEmbeddingLayer
+ */
+WIN_EXPORT class VisionEmbeddingLayer : public nntrainer::LayerImpl {
+public:
+  /**
+   * @brief     Constructor of Embedding Layer
+   */
+  WIN_EXPORT VisionEmbeddingLayer();
+
+  /**
+   * @brief     Destructor of Embedding Layer
+   */
+  WIN_EXPORT ~VisionEmbeddingLayer() = default;
+
+  /**
+   *  @brief  Move constructor.
+   *  @param[in] VisionEmbeddingLayer &&
+   */
+  WIN_EXPORT
+  VisionEmbeddingLayer(VisionEmbeddingLayer &&rhs) noexcept = default;
+
+  /**
+   * @brief  Move assignment operator.
+   * @parma[in] rhs VisionEmbeddingLayer to be moved.
+   */
+  WIN_EXPORT VisionEmbeddingLayer &
+  operator=(VisionEmbeddingLayer &&rhs) = default;
+
+  /**
+   * @copydoc Layer::finalize(InitLayerContext &context)
+   */
+  WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
+   */
+  WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
+                             bool training) override;
+
+  /**
+￼   * @copydoc Layer::incremental_forwarding(RunLayerContext &context, unsigned
+￼   * int from, unsigned int to, bool training)
+￼   */
+  WIN_EXPORT void incremental_forwarding(nntrainer::RunLayerContext &context,
+                                         unsigned int from, unsigned int to,
+                                         bool training) override;
+
+  /**
+   * @copydoc Layer::calcDerivative(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   */
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::exportTo(Exporter &exporter, ml::train::ExportMethods
+   * method)
+   */
+  WIN_EXPORT void
+  exportTo(nntrainer::Exporter &exporter,
+           const ml::train::ExportMethods &method) const override;
+
+  /**
+   * @copydoc Layer::getType()
+   */
+  WIN_EXPORT const std::string getType() const override {
+    return VisionEmbeddingLayer::type;
+  };
+
+  /**
+   * @copydoc Layer::supportBackwarding()
+   */
+  WIN_EXPORT bool supportBackwarding() const override { return false; }
+
+  using Layer::setProperty;
+
+  /**
+   * @copydoc Layer::setProperty(const PropertyType type, const std::string
+   * &value)
+   */
+  WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
+
+  /**
+   * @copydic Layer::save()
+   */
+  WIN_EXPORT void save(std::ofstream &file,
+                       nntrainer::RunLayerContext &run_context, bool opt_var,
+                       ml::train::ExecutionMode mode, bool trainable,
+                       nntrainer::TensorDim::DataType dtype =
+                         nntrainer::TensorDim::DataType::NONE) const override;
+
+  WIN_EXPORT void updateTensorsByInputDimensions(
+    nntrainer::RunLayerContext &context,
+    std::vector<nntrainer::TensorDim> input_dimensions) override;
+
+  inline static const std::string type = "vision_embedding_layer";
+
+private:
+  std::tuple<nntrainer::props::InDim, nntrainer::props::OutDim,
+             props::ImageStartToken, nntrainer::props::Scale>
+    vision_embedding_props;
+  unsigned int weight_idx;
+};
+} // namespace causallm
+
+#endif /* __cplusplus */
+#endif /* __VISION_EMBEDDING_H__ */

--- a/Applications/CausalLM/layers/vision_embedding_layer.h
+++ b/Applications/CausalLM/layers/vision_embedding_layer.h
@@ -135,7 +135,9 @@ public:
                        nntrainer::RunLayerContext &run_context, bool opt_var,
                        ml::train::ExecutionMode mode, bool trainable,
                        nntrainer::TensorDim::DataType dtype =
-                         nntrainer::TensorDim::DataType::NONE) const override;
+                         nntrainer::TensorDim::DataType::NONE,
+                       ml::train::ISA target_isa =
+                         ml::train::ISA::DEFAULT) const override;
 
   WIN_EXPORT void updateTensorsByInputDimensions(
     nntrainer::RunLayerContext &context,
@@ -152,4 +154,4 @@ private:
 } // namespace causallm
 
 #endif /* __cplusplus */
-#endif /* __VISION_EMBEDDING_H__ */
+#endif /* __VISION_EMBEDDING_LAYER_H__ */

--- a/Applications/CausalLM/layers/vision_embedding_layer.h
+++ b/Applications/CausalLM/layers/vision_embedding_layer.h
@@ -4,7 +4,11 @@
  *
  * @file   vision_embedding_layer.h
  * @date   17 April 2026
- * @brief  This is Vision Embedding Layer Class of Neural Network
+ * @brief  This is the Vision Embedding Layer Class of Neural Network.
+ * @details The Vision Embedding Layer maps a sequence of token IDs into their
+ *          corresponding word embeddings and dynamically blends in precomputed
+ *          image embeddings (e.g., from a Vision Transformer/ViT) wherever
+ *          the token ID matches the configured `image_start_token`.
  * @see    https://github.com/nntrainer/nntrainer
  * @author Hyeonseok Lee <hs89.lee@samsung.com>
  * @bug    No known bugs except for NYI items

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -30,6 +30,7 @@ causallm_layer_dependencies += [
     causallm_swiglu_dep,
     causallm_mha_core_dep,
     causallm_embedding_layer_dep,
+    causallm_vision_embedding_layer_dep,
     causallm_lm_head_dep,
     causallm_reshaped_rms_norm_dep,
     causallm_qkv_layer_dep,


### PR DESCRIPTION
## Dependency of the PR

- None (Directly rebased on top of the latest upstream/main branch)

## Commits to be reviewed in this PR

<details><summary>43b0b7e4</summary><br />

**[causallm] add vision embedding layer**

This commit introduces the VisionEmbeddingLayer to the CausalLM application.
This layer is designed to dynamically blend/splice precomputed vision/image
embeddings (e.g., from a Vision Transformer/ViT encoder) into the standard
text token embedding sequence.

Key Features:
- Dual-Input Splicing: Accepts both a token ID sequence of shape [batch, 1, 1, seq_len] and
  precomputed image embeddings of shape [batch, 1, num_patches, out_dim].
- Dynamic Image Insertion: Automatically detects the designated image_start_token in the text
  token stream and replaces its corresponding word embedding slot with the precomputed image
  embeddings.
- Support for Multi-Patch Images: Properly handles multi-patch image inputs to generate
  unified outputs of shape [batch, 1, seq_len, out_dim] without size mismatches.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>

<details><summary>7a7e442f</summary><br />

**[causallm] fix vision_embedding_layer compile defects**

Add ml::train::ISA target_isa parameter to save() override to match the
7-argument base Layer::save virtual signature in layer_devel.h. Remove
undefined openmp_dep from vision_embedding_layer build target and drop
illegal throw-inside-omp-region by removing #pragma omp directives from
both forwarding and incremental_forwarding. Fix incremental_forwarding to
index tokens with from+i offset and apply out_slot for output placement.
Wire causallm_vision_embedding_layer_dep into causallm_layer_dependencies
so the shared library is actually linked. Fix include-guard close comment
from \_\_VISION\_EMBEDDING\_H\_\_ to \_\_VISION\_EMBEDDING\_LAYER\_H\_\_.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>

</details>

<details><summary>3da74169</summary><br />

**[CausalLM] Apply clang-format 14 to vision_embedding_layer.h**

Reformat the save() method declaration in vision_embedding_layer.h to
match the project clang-format style. The parameter list line-breaking
did not conform to the .clang-format rules checked by cpp-linter CI,
causing the clang-format-14 changed-lines check to fail on the PR.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: SeungBaek Hong <sb92.hong@samsung.com>

</details>

<details><summary>10039c50</summary><br />

**[layer] add detailed description to vision_embedding_layer.h**

Document VisionEmbeddingLayer class detailing its inputs, outputs, properties, and blending
mechanism in the file-level header of vision_embedding_layer.h as requested.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>

### Summary

- **[CausalLM] Introduce Vision Embedding Splicing Layer**: Adds the specialized
  `VisionEmbeddingLayer` enabling the seamless, zero-copy dynamic blending of precomputed image
  embeddings into standard text token streams.
- **Compiler and OpenMP Integration Fixes**: Resolves critical C++ virtual signature mismatch
  in `save()` overrides, removes invalid build-system OpenMP variables, cleans up thread-unsafe
  exception trapping under parallel zones, and establishes complete target linking into
  `causallm_layer_dependencies`.
- **Clang Formatting & Documentation**: Reformats the layer header to ensure 100% compliance
  with CI cpp-linter and documents complete class mechanics, parameters, and input/output
  tensor shapes.

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>