### PR TITLE
[Graph/Layer] Support dynamic tensor resizing via getLayerDimensions

### DIFF
--- a/Applications/CausalLM/layers/causal_conv1d_layer.cpp
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.cpp
@@ -46,37 +46,19 @@ void CausalConv1DLayer::finalize(nntrainer::InitLayerContext &context) {
     << "[CausalConv1DLayer] requires exactly 1 input, got "
     << context.getNumInputs();
 
-  const nntrainer::TensorDim &in_dim = context.getInputDimensions()[0];
-  validateInputShape(in_dim);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
 
-  const unsigned int B = in_dim.batch();
-  const unsigned int W = in_dim.width(); // number of features/channels
-
-  // Weight: [1, 1, KERNEL_SIZE, W] FP32
-  //   Row k  (offset k*W) = kernel weights for position k:
-  //     k=0 → w0: applied to current token x_t
-  //     k=1 → w1: applied to x_{t-1}
-  //     k=2 → w2: applied to x_{t-2}
-  nntrainer::TensorDim weight_dim(
-    {1, 1, KERNEL_SIZE, W},
-    {context.getFormat(), ml::train::TensorDim::DataType::FP32});
   weight_idx[weight] =
-    context.requestWeight(weight_dim, nntrainer::Initializer::NONE,
+    context.requestWeight(weight_dims[weight], nntrainer::Initializer::NONE,
                           nntrainer::WeightRegularizer::NONE, 0.0f, 0.0f,
                           "causal_conv1d_weight", false);
 
-  // Conv-state cache: [B, 1, KERNEL_SIZE-1, W] FP32
-  //   state[b, 0, 0, f] = x_{t-2}
-  //   state[b, 0, 1, f] = x_{t-1}
-  nntrainer::TensorDim state_dim(
-    {B, 1, KERNEL_SIZE - 1, W},
-    {context.getFormat(), ml::train::TensorDim::DataType::FP32});
   tensor_idx[conv_state] = context.requestTensor(
-    state_dim, "conv_state", nntrainer::Initializer::ZEROS, false,
+    tensor_dims[0], "conv_state", nntrainer::Initializer::ZEROS, false,
     nntrainer::TensorLifespan::MAX_LIFESPAN);
 
-  // Output has same shape as input
-  context.setOutputDimensions({in_dim});
+  context.setOutputDimensions(output_dims);
 }
 
 void CausalConv1DLayer::forwarding(nntrainer::RunLayerContext &context,
@@ -155,16 +137,52 @@ void CausalConv1DLayer::calcGradient(nntrainer::RunLayerContext &context) {
     "[CausalConv1DLayer] calcGradient() not implemented (inference only).");
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+CausalConv1DLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  validateInputShape(context.getInputDimensions()[0]);
+
+  const nntrainer::TensorDim &in_dim = context.getInputDimensions()[0];
+  const unsigned int B = in_dim.batch();
+  const unsigned int W = in_dim.width();
+
+  // Weight: [1, 1, KERNEL_SIZE, W] FP32
+  //   Row k  (offset k*W) = kernel weights for position k:
+  //     k=0 → w0: applied to current token x_t
+  //     k=1 → w1: applied to x_{t-1}
+  //     k=2 → w2: applied to x_{t-2}
+  nntrainer::TensorDim weight_dim(
+    {1, 1, KERNEL_SIZE, W},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP32});
+
+  // Conv-state cache: [B, 1, KERNEL_SIZE-1, W] FP32
+  //   state[b, 0, 0, f] = x_{t-2}
+  //   state[b, 0, 1, f] = x_{t-1}
+  nntrainer::TensorDim state_dim(
+    {B, 1, KERNEL_SIZE - 1, W},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP32});
+
+  std::vector<nntrainer::TensorDim> output_dims = {in_dim};
+  std::vector<nntrainer::TensorDim> weight_dims = {weight_dim};
+  std::vector<nntrainer::TensorDim> tensor_dims = {state_dim};
+
+  return std::array<std::vector<nntrainer::TensorDim>, 3>{
+    output_dims, weight_dims, tensor_dims};
+}
+
 std::vector<nntrainer::TensorDim>
 CausalConv1DLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
-  auto input_dimensions = init_context.getInputDimensions();
-  run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
-  run_context.updateOutput(SINGLE_INOUT_IDX,
-                           input_dimensions[SINGLE_INOUT_IDX]);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
 
-  return {input_dimensions[SINGLE_INOUT_IDX]};
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  run_context.updateTensor(tensor_idx[conv_state], tensor_dims[0]);
+
+  return output_dims;
 }
 
 void CausalConv1DLayer::exportTo(nntrainer::Exporter &exporter,

--- a/Applications/CausalLM/layers/causal_conv1d_layer.cpp
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.cpp
@@ -155,12 +155,14 @@ void CausalConv1DLayer::calcGradient(nntrainer::RunLayerContext &context) {
     "[CausalConv1DLayer] calcGradient() not implemented (inference only).");
 }
 
-std::vector<nntrainer::TensorDim> CausalConv1DLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+CausalConv1DLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   auto input_dimensions = init_context.getInputDimensions();
   run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
-  run_context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX,
+                           input_dimensions[SINGLE_INOUT_IDX]);
 
   return {input_dimensions[SINGLE_INOUT_IDX]};
 }

--- a/Applications/CausalLM/layers/causal_conv1d_layer.cpp
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.cpp
@@ -155,10 +155,14 @@ void CausalConv1DLayer::calcGradient(nntrainer::RunLayerContext &context) {
     "[CausalConv1DLayer] calcGradient() not implemented (inference only).");
 }
 
-void CausalConv1DLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  // No dynamic updates needed
+std::vector<nntrainer::TensorDim> CausalConv1DLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  auto input_dimensions = init_context.getInputDimensions();
+  run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
+
+  return {input_dimensions[SINGLE_INOUT_IDX]};
 }
 
 void CausalConv1DLayer::exportTo(nntrainer::Exporter &exporter,

--- a/Applications/CausalLM/layers/causal_conv1d_layer.h
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.h
@@ -68,9 +68,9 @@ public:
   void calcDerivative(nntrainer::RunLayerContext &context) override;
   void calcGradient(nntrainer::RunLayerContext &context) override;
 
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   const std::string getType() const override { return type; }
 

--- a/Applications/CausalLM/layers/causal_conv1d_layer.h
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.h
@@ -53,6 +53,19 @@ public:
 
   void finalize(nntrainer::InitLayerContext &context) override;
 
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext &context, RunLayerContext &run_context)
+   */
+  std::vector<nntrainer::TensorDim>
+  updateTensorsByInputDimensions(nntrainer::InitLayerContext &init_context,
+                                 nntrainer::RunLayerContext &run_context) override;
+
   /** Full forwarding is unused; use incremental_forwarding. */
   void forwarding(nntrainer::RunLayerContext &context, bool training) override;
 
@@ -67,10 +80,6 @@ public:
 
   void calcDerivative(nntrainer::RunLayerContext &context) override;
   void calcGradient(nntrainer::RunLayerContext &context) override;
-
-  std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
-    nntrainer::InitLayerContext &init_context,
-    nntrainer::RunLayerContext &run_context) override;
 
   const std::string getType() const override { return type; }
 

--- a/Applications/CausalLM/layers/causal_conv1d_layer.h
+++ b/Applications/CausalLM/layers/causal_conv1d_layer.h
@@ -60,11 +60,12 @@ public:
   getLayerDimensions(nntrainer::InitLayerContext &context) override;
 
   /**
-   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext &context, RunLayerContext &run_context)
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext &context,
+   * RunLayerContext &run_context)
    */
-  std::vector<nntrainer::TensorDim>
-  updateTensorsByInputDimensions(nntrainer::InitLayerContext &init_context,
-                                 nntrainer::RunLayerContext &run_context) override;
+  std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   /** Full forwarding is unused; use incremental_forwarding. */
   void forwarding(nntrainer::RunLayerContext &context, bool training) override;

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -1011,7 +1011,8 @@ void DebertaAttentionLayer::setBatch(nntrainer::RunLayerContext &context,
   context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
 }
 
-std::vector<nntrainer::TensorDim> DebertaAttentionLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+DebertaAttentionLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -1011,10 +1011,13 @@ void DebertaAttentionLayer::setBatch(nntrainer::RunLayerContext &context,
   context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
 }
 
-void DebertaAttentionLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
+std::vector<nntrainer::TensorDim> DebertaAttentionLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
 
+  auto input_dimensions = init_context.getInputDimensions();
   ml::train::TensorDim q_dim = input_dimensions[INPUT_IDX_Q];
   ml::train::TensorDim k_dim = input_dimensions[INPUT_IDX_K];
   ml::train::TensorDim v_dim = input_dimensions[INPUT_IDX_V];
@@ -1027,16 +1030,18 @@ void DebertaAttentionLayer::updateTensorsByInputDimensions(
   v_dim.setDataType(input_dimensions[INPUT_IDX_V].getDataType());
 #endif
 
-  context.updateInput(INPUT_IDX_Q, input_dimensions[INPUT_IDX_Q]);
-  context.updateInput(INPUT_IDX_K, input_dimensions[INPUT_IDX_K]);
-  context.updateInput(INPUT_IDX_V, input_dimensions[INPUT_IDX_V]);
-  context.updateOutput(OUTPUT_IDX, input_dimensions[INPUT_IDX_Q]);
+  run_context.updateInput(INPUT_IDX_Q, input_dimensions[INPUT_IDX_Q]);
+  run_context.updateInput(INPUT_IDX_K, input_dimensions[INPUT_IDX_K]);
+  run_context.updateInput(INPUT_IDX_V, input_dimensions[INPUT_IDX_V]);
+  run_context.updateOutput(OUTPUT_IDX, output_dims[OUTPUT_IDX]);
 
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], k_dim);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], v_dim);
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_key], k_dim);
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_value], v_dim);
 
   prepare_bucket_table(std::max<unsigned int>(
     input_dimensions[INPUT_IDX_Q].height(), max_position_embeddings));
+
+  return output_dims;
 }
 
 void DebertaAttentionLayer::calcDerivative(

--- a/Applications/CausalLM/layers/deberta_attention_layer.cpp
+++ b/Applications/CausalLM/layers/deberta_attention_layer.cpp
@@ -222,6 +222,9 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
     << "DebertaAttentionLayer expects " << expected_inputs
     << " inputs, but got " << context.getNumInputs();
 
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+
   const auto &input_dims = context.getInputDimensions();
   const auto &query_dim = input_dims[INPUT_IDX_Q];
   const auto &key_dim = input_dims[INPUT_IDX_K];
@@ -261,32 +264,14 @@ void DebertaAttentionLayer::finalize(nntrainer::InitLayerContext &context) {
 
   attn_logit_softcapping = 0.0f;
 
-#ifdef ENABLE_FP16
-  ml::train::TensorDim cache_key_dim(
-    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
-    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
-  ml::train::TensorDim cache_value_dim(
-    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
-    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
-#else
-  ml::train::TensorDim cache_key_dim(
-    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
-    {context.getFormat(), key_dim.getDataType()});
-  ml::train::TensorDim cache_value_dim(
-    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
-    {context.getFormat(), value_dim.getDataType()});
-#endif
-
   tensor_idx[AttentionParams::cache_key] = context.requestTensor(
-    cache_key_dim, "cache_key", nntrainer::Initializer::NONE, false,
+    tensor_dims[0], "cache_key", nntrainer::Initializer::NONE, false,
     nntrainer::TensorLifespan::MAX_LIFESPAN);
 
   tensor_idx[AttentionParams::cache_value] = context.requestTensor(
-    cache_value_dim, "cache_value", nntrainer::Initializer::NONE, false,
+    tensor_dims[1], "cache_value", nntrainer::Initializer::NONE, false,
     nntrainer::TensorLifespan::MAX_LIFESPAN);
 
-  std::vector<nntrainer::TensorDim> output_dims(1);
-  output_dims[0] = query_dim;
   context.setOutputDimensions(output_dims);
 
   prepare_bucket_table(
@@ -1011,6 +996,41 @@ void DebertaAttentionLayer::setBatch(nntrainer::RunLayerContext &context,
   context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+DebertaAttentionLayer::getLayerDimensions(
+  nntrainer::InitLayerContext &context) {
+  const auto &input_dims = context.getInputDimensions();
+  const auto &query_dim = input_dims[INPUT_IDX_Q];
+  const auto &key_dim = input_dims[INPUT_IDX_K];
+  const auto &value_dim = input_dims[INPUT_IDX_V];
+
+#ifdef ENABLE_FP16
+  ml::train::TensorDim cache_key_dim(
+    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+  ml::train::TensorDim cache_value_dim(
+    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+#else
+  ml::train::TensorDim cache_key_dim(
+    {query_dim.batch(), 1, query_dim.height(), key_dim.width()},
+    {context.getFormat(), key_dim.getDataType()});
+  ml::train::TensorDim cache_value_dim(
+    {query_dim.batch(), 1, query_dim.height(), value_dim.width()},
+    {context.getFormat(), value_dim.getDataType()});
+#endif
+
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[0] = query_dim;
+
+  std::vector<nntrainer::TensorDim> tensor_dims(2);
+  tensor_dims[0] = cache_key_dim;   // cache_key is index 0
+  tensor_dims[1] = cache_value_dim; // cache_value is index 1
+
+  return std::array<std::vector<nntrainer::TensorDim>, 3>{
+    output_dims, {}, tensor_dims};
+}
+
 std::vector<nntrainer::TensorDim>
 DebertaAttentionLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
@@ -1019,25 +1039,16 @@ DebertaAttentionLayer::updateTensorsByInputDimensions(
     getLayerDimensions(init_context);
 
   auto input_dimensions = init_context.getInputDimensions();
-  ml::train::TensorDim q_dim = input_dimensions[INPUT_IDX_Q];
-  ml::train::TensorDim k_dim = input_dimensions[INPUT_IDX_K];
-  ml::train::TensorDim v_dim = input_dimensions[INPUT_IDX_V];
-
-#ifdef ENABLE_FP16
-  k_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-  v_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-#else
-  k_dim.setDataType(input_dimensions[INPUT_IDX_K].getDataType());
-  v_dim.setDataType(input_dimensions[INPUT_IDX_V].getDataType());
-#endif
 
   run_context.updateInput(INPUT_IDX_Q, input_dimensions[INPUT_IDX_Q]);
   run_context.updateInput(INPUT_IDX_K, input_dimensions[INPUT_IDX_K]);
   run_context.updateInput(INPUT_IDX_V, input_dimensions[INPUT_IDX_V]);
   run_context.updateOutput(OUTPUT_IDX, output_dims[OUTPUT_IDX]);
 
-  run_context.updateTensor(tensor_idx[AttentionParams::cache_key], k_dim);
-  run_context.updateTensor(tensor_idx[AttentionParams::cache_value], v_dim);
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_key],
+                           tensor_dims[0]);
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_value],
+                           tensor_dims[1]);
 
   prepare_bucket_table(std::max<unsigned int>(
     input_dimensions[INPUT_IDX_Q].height(), max_position_embeddings));

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -195,9 +195,9 @@ public:
   /**
    * @copydoc Layer::updateTensorsByInputDimensions(...)
    */
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   /**
    * @brief wrapper around nntrainer::compute_kcaches

--- a/Applications/CausalLM/layers/deberta_attention_layer.h
+++ b/Applications/CausalLM/layers/deberta_attention_layer.h
@@ -193,6 +193,12 @@ public:
                 unsigned int batch) override;
 
   /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
+
+  /**
    * @copydoc Layer::updateTensorsByInputDimensions(...)
    */
   std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -455,6 +455,8 @@ EmbeddingLayer::EmbeddingLayer() :
   weight_idx(std::numeric_limits<unsigned>::max()) {}
 
 void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
+  context.setInputDataType(nntrainer::TensorDim::DataType::FP32);
+
   [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
     getLayerDimensions(context);
 
@@ -820,10 +822,6 @@ EmbeddingLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
     context.getInputDimensions()[SINGLE_INOUT_IDX];
   NNTR_THROW_IF(input_dim.channel() != 1, std::invalid_argument)
     << "Embedding layer takes only one for channel size";
-
-  NNTR_THROW_IF(input_dim.getDataType() != nntrainer::TensorDim::DataType::FP32,
-                std::invalid_argument)
-    << "Embedding layer takes only FP32 input data";
 
   size_t in_dim =
     static_cast<size_t>(std::get<nntrainer::props::InDim>(embedding_props));

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -502,6 +502,20 @@ void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
                                      "Embedding", true);
 }
 
+std::vector<nntrainer::TensorDim>
+EmbeddingLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, embedding_props);
   LayerImpl::setProperty(remain_props);

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -455,17 +455,8 @@ EmbeddingLayer::EmbeddingLayer() :
   weight_idx(std::numeric_limits<unsigned>::max()) {}
 
 void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
-  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
-    << "Embedding layer takes only one input";
-
-  auto &quantized_lut_path = std::get<props::QuantizedLutPath>(embedding_props);
-  const bool has_quantized_lut = !quantized_lut_path.empty();
-  context.setInputDataType(nntrainer::TensorDim::DataType::FP32);
-
-  const nntrainer::TensorDim &input_dim =
-    context.getInputDimensions()[SINGLE_INOUT_IDX];
-  NNTR_THROW_IF(input_dim.channel() != 1, std::invalid_argument)
-    << "Embedding layer takes only one for channel size";
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
 
   auto &weight_regularizer =
     std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
@@ -474,6 +465,11 @@ void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
   auto weight_initializer = nntrainer::props::InitializerInfo::Enum::NONE;
   auto &weight_decay =
     std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
+
+  context.setOutputDimensions(output_dims);
+
+  auto &quantized_lut_path = std::get<props::QuantizedLutPath>(embedding_props);
+  const bool has_quantized_lut = !quantized_lut_path.empty();
 
   size_t in_dim =
     static_cast<size_t>(std::get<nntrainer::props::InDim>(embedding_props));
@@ -497,47 +493,13 @@ void EmbeddingLayer::finalize(nntrainer::InitLayerContext &context) {
       << "Raw UINT16 LUT requires UINT16 activation/output dtype";
   }
 
-  nntrainer::TensorDim output_dim = input_dim;
-
-  // output_dim expected as hidden x num input (batch size)
-  output_dim.height(input_dim.width());
-  output_dim.width(out_dim);
-  output_dim.setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
-  context.setOutputDimensions({output_dim});
-
   if (quant_lut)
     return;
 
-  nntrainer::TensorDim dim = output_dim;
-
-  dim.setTensorType({context.getFormat(), context.getWeightDataType()});
-
-  dim.batch(1);
-
-  /**
-   * @note nntrainer's per-channel quantized tensor is in following shape
-   * - quantized data: (H, W)
-   * - scales: (W)
-   *
-   * For embedding, there are in_dim elements in scale.
-   * So we should use (out_dim, in_dim) dimension although actual tensor
-   * shape is (in_dim, out_dim)
-   *
-   * @todo Add other types that needs to be transposed
-   * @todo Allow other axis can be a quantization axis
-   */
-  if (context.getWeightDataType() == nntrainer::TensorDim::DataType::QS4CX) {
-    dim.height(out_dim);
-    dim.width(in_dim);
-  } else {
-    dim.height(in_dim);
-    dim.width(out_dim);
-  }
-
-  weight_idx = context.requestWeight(
-    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    weight_decay, "Embedding", true);
+  weight_idx = context.requestWeight(weight_dims[EmbeddingParams::weight],
+                                     weight_initializer, weight_regularizer,
+                                     weight_regularizer_constant, weight_decay,
+                                     "Embedding", true);
 }
 
 void EmbeddingLayer::setProperty(const std::vector<std::string> &values) {
@@ -868,10 +830,16 @@ EmbeddingLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
   nntrainer::TensorDim weight_dim = output_dim;
 
   weight_dim.setTensorType({context.getFormat(), context.getWeightDataType()});
-
-  weight_dim.height(in_dim);
-  weight_dim.width(out_dim);
   weight_dim.batch(1);
+
+  if (context.getWeightDataType() == nntrainer::TensorDim::DataType::QS4CX) {
+    weight_dim.height(out_dim);
+    weight_dim.width(in_dim);
+  } else {
+    weight_dim.height(in_dim);
+    weight_dim.width(out_dim);
+  }
+
   weight_dims.push_back(weight_dim);
 
   return {output_dims, weight_dims, {}};

--- a/Applications/CausalLM/layers/embedding_layer.cpp
+++ b/Applications/CausalLM/layers/embedding_layer.cpp
@@ -835,6 +835,48 @@ void EmbeddingLayer::save(std::ofstream &file,
   }
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+EmbeddingLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "Embedding layer takes only one input";
+
+  const nntrainer::TensorDim &input_dim =
+    context.getInputDimensions()[SINGLE_INOUT_IDX];
+  NNTR_THROW_IF(input_dim.channel() != 1, std::invalid_argument)
+    << "Embedding layer takes only one for channel size";
+
+  NNTR_THROW_IF(input_dim.getDataType() != nntrainer::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "Embedding layer takes only FP32 input data";
+
+  size_t in_dim =
+    static_cast<size_t>(std::get<nntrainer::props::InDim>(embedding_props));
+  size_t out_dim =
+    static_cast<size_t>(std::get<nntrainer::props::OutDim>(embedding_props));
+
+  std::vector<nntrainer::TensorDim> output_dims;
+  nntrainer::TensorDim output_dim = input_dim;
+
+  // output_dim expected as hidden x num input (batch size)
+  output_dim.height(input_dim.width());
+  output_dim.width(out_dim);
+  output_dim.setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+  output_dims.push_back(output_dim);
+
+  std::vector<nntrainer::TensorDim> weight_dims;
+  nntrainer::TensorDim weight_dim = output_dim;
+
+  weight_dim.setTensorType({context.getFormat(), context.getWeightDataType()});
+
+  weight_dim.height(in_dim);
+  weight_dim.width(out_dim);
+  weight_dim.batch(1);
+  weight_dims.push_back(weight_dim);
+
+  return {output_dims, weight_dims, {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_embedding_layer() {

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -149,6 +149,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,

--- a/Applications/CausalLM/layers/embedding_layer.h
+++ b/Applications/CausalLM/layers/embedding_layer.h
@@ -221,6 +221,12 @@ private:
     embedding_props;
   unsigned int weight_idx;
   std::shared_ptr<QuantLut> quant_lut;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 } // namespace causallm
 

--- a/Applications/CausalLM/layers/lm_head.cpp
+++ b/Applications/CausalLM/layers/lm_head.cpp
@@ -49,62 +49,23 @@ void LmHeadLayer::finalize(nntrainer::InitLayerContext &context) {
   auto &disable_bias =
     std::get<nntrainer::props::DisableBias>(*layer_impl_props);
 
-  auto unit = std::get<nntrainer::props::Unit>(lmhead_props).get();
   if (!std::get<nntrainer::props::SkipPrefill>(*layer_impl_props).empty())
     skip_prefill =
       std::get<nntrainer::props::SkipPrefill>(*layer_impl_props).get();
 
-  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
-    << "lm head layer takes only one input";
-
-  std::vector<ml::train::TensorDim> output_dims(1);
-
-  /// @todo fc actaully supports multidimensions.
-  /// EffDimFlag shouldn't be fixed like this.
-  context.setEffDimFlagInputDimension(0, 0b1001);
-  context.setDynDimFlagInputDimension(0, 0b1000);
-  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
-
-  /** set output dimensions */
-  ///@note lm_head's output dimension (height is always 1 !)
-  auto const &in_dim = context.getInputDimensions()[0];
-  output_dims[0] = in_dim;
-  if (is_nchw)
-    output_dims[0].width(unit);
-  else
-    output_dims[0].channel(unit);
-  output_dims[0].height(1);
-
-  output_dims[0].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
 
   context.setOutputDimensions(output_dims);
 
-  /** set weight specifications */
-  ml::train::TensorDim bias_dim(
-    1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
-    ml::train::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0001 : 0b0100);
-
-  ///@note LMHead layer's tensor dim is transposed dim of user-defined
-  /// dim
-  /// so it can reuse embedding layer.
-  ml::train::TensorDim weight_dim(
-    1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
-    is_nchw ? unit : in_dim.channel(),
-    ml::train::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
-
   weight_idx[LmHeadParams::weight] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
+    weight_dims[LmHeadParams::weight], weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "weight", true);
 
   if (disable_bias.empty() || disable_bias.get() == false) {
     weight_idx[LmHeadParams::bias] = context.requestWeight(
-      bias_dim, bias_initializer, nntrainer::WeightRegularizer::NONE, 1.0f,
-      bias_decay, "bias", true);
+      weight_dims[LmHeadParams::bias], bias_initializer,
+      nntrainer::WeightRegularizer::NONE, 1.0f, bias_decay, "bias", true);
   }
 }
 

--- a/Applications/CausalLM/layers/lm_head.cpp
+++ b/Applications/CausalLM/layers/lm_head.cpp
@@ -191,6 +191,62 @@ void LmHeadLayer::updateTensorsByInputDimensions(
   context.updateInput(SINGLE_INOUT_IDX, in_dim);
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+LmHeadLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  auto &disable_bias =
+    std::get<nntrainer::props::DisableBias>(*layer_impl_props);
+
+  auto unit = std::get<nntrainer::props::Unit>(lmhead_props).get();
+
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "lm head layer takes only one input";
+
+  std::vector<ml::train::TensorDim> output_dims(1);
+  std::vector<ml::train::TensorDim> weight_dims;
+
+  /// @todo fc actaully supports multidimensions.
+  /// EffDimFlag shouldn't be fixed like this.
+  context.setEffDimFlagInputDimension(0, 0b1001);
+  context.setDynDimFlagInputDimension(0, 0b1000);
+  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
+
+  /** set output dimensions */
+  ///@note lm_head's output dimension (height is always 1 !)
+  auto const &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  if (is_nchw)
+    output_dims[SINGLE_INOUT_IDX].width(unit);
+  else
+    output_dims[SINGLE_INOUT_IDX].channel(unit);
+  output_dims[SINGLE_INOUT_IDX].height(1);
+
+  output_dims[SINGLE_INOUT_IDX].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  ///@note LMHead layer's tensor dim is transposed dim of user-defined
+  /// dim
+  /// so it can reuse embedding layer.
+  ml::train::TensorDim weight_dim(
+    1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
+    is_nchw ? unit : in_dim.channel(),
+    ml::train::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+  weight_dims.push_back(weight_dim);
+
+  if (disable_bias.empty() || disable_bias.get() == false) {
+    /** set weight specifications */
+    ml::train::TensorDim bias_dim(
+      1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
+      ml::train::TensorDim::TensorType(context.getFormat(),
+                                       context.getWeightDataType()),
+      is_nchw ? 0b0001 : 0b0100);
+    weight_dims.push_back(bias_dim);
+  }
+
+  return {output_dims, weight_dims, {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_tie_word_embedding() {

--- a/Applications/CausalLM/layers/lm_head.cpp
+++ b/Applications/CausalLM/layers/lm_head.cpp
@@ -69,6 +69,19 @@ void LmHeadLayer::finalize(nntrainer::InitLayerContext &context) {
   }
 }
 
+std::vector<nntrainer::TensorDim> LmHeadLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void LmHeadLayer::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, lmhead_props);
   LayerImpl::setProperty(remain_props);
@@ -138,18 +151,6 @@ void LmHeadLayer::exportTo(nntrainer::Exporter &exporter,
                            const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);
   exporter.saveResult(lmhead_props, method, this);
-}
-
-void LmHeadLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  nntrainer::TensorDim in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
-
-  unsigned int height = input_dimensions[0].height();
-
-  // output dim's height is always 1 !
-  in_dim.height(height);
-  context.updateInput(SINGLE_INOUT_IDX, in_dim);
 }
 
 std::array<std::vector<nntrainer::TensorDim>, 3>

--- a/Applications/CausalLM/layers/lm_head.h
+++ b/Applications/CausalLM/layers/lm_head.h
@@ -62,6 +62,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -104,10 +112,6 @@ public:
    * @copydoc Layer::supportBackwarding()
    */
   WIN_EXPORT bool supportBackwarding() const override { return false; }
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   using Layer::setProperty;
 

--- a/Applications/CausalLM/layers/lm_head.h
+++ b/Applications/CausalLM/layers/lm_head.h
@@ -123,6 +123,12 @@ private:
   std::tuple<nntrainer::props::Unit> lmhead_props;
   std::array<unsigned int, 2> weight_idx; /**< indices of the weights */
   bool skip_prefill = false;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 } // namespace causallm
 

--- a/Applications/CausalLM/layers/logit_softcapping.cpp
+++ b/Applications/CausalLM/layers/logit_softcapping.cpp
@@ -110,7 +110,8 @@ void LogitSoftCappingLayer::applyOnRange(nntrainer::RunLayerContext &context,
   }
 }
 
-std::vector<nntrainer::TensorDim> LogitSoftCappingLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+LogitSoftCappingLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   auto input_dimensions = init_context.getInputDimensions();

--- a/Applications/CausalLM/layers/logit_softcapping.cpp
+++ b/Applications/CausalLM/layers/logit_softcapping.cpp
@@ -110,11 +110,14 @@ void LogitSoftCappingLayer::applyOnRange(nntrainer::RunLayerContext &context,
   }
 }
 
-void LogitSoftCappingLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+std::vector<nntrainer::TensorDim> LogitSoftCappingLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  auto input_dimensions = init_context.getInputDimensions();
+  run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+
+  return {input_dimensions[0]};
 }
 
 void LogitSoftCappingLayer::calcDerivative(

--- a/Applications/CausalLM/layers/logit_softcapping.h
+++ b/Applications/CausalLM/layers/logit_softcapping.h
@@ -103,9 +103,9 @@ public:
            std::to_string(remain_props.size());
   };
 
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   inline static const std::string type = "logit_softcapping";
 

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -225,13 +225,15 @@ std::vector<nntrainer::TensorDim> MHACoreLayer::updateTensorsByInputDimensions(
 
   max_timestep = height + max_new_tokens;
 
-  tensor_dims[AttentionParams::cache_key].height(max_timestep);
-  tensor_dims[AttentionParams::cache_value].height(max_timestep);
+  if (!use_external_cache) {
+    tensor_dims[AttentionParams::cache_key].height(max_timestep);
+    tensor_dims[AttentionParams::cache_value].height(max_timestep);
 
-  run_context.updateTensor(tensor_idx[AttentionParams::cache_key],
-                           tensor_dims[AttentionParams::cache_key]);
-  run_context.updateTensor(tensor_idx[AttentionParams::cache_value],
-                           tensor_dims[AttentionParams::cache_value]);
+    run_context.updateTensor(tensor_idx[AttentionParams::cache_key],
+                             tensor_dims[AttentionParams::cache_key]);
+    run_context.updateTensor(tensor_idx[AttentionParams::cache_value],
+                             tensor_dims[AttentionParams::cache_value]);
+  }
 
   return output_dims;
 }
@@ -1471,8 +1473,10 @@ void MHACoreLayer::setBatch(nntrainer::RunLayerContext &context,
 
   const float dropout_rate =
     std::get<nntrainer::props::DropOutRate>(mha_core_props).get();
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], batch);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
+  if (!use_external_cache) {
+    context.updateTensor(tensor_idx[AttentionParams::cache_key], batch);
+    context.updateTensor(tensor_idx[AttentionParams::cache_value], batch);
+  }
   // context.updateTensor(tensor_idx[AttentionParams::attention_weight], batch);
   if (dropout_rate > epsilon) {
     context.updateTensor(tensor_idx[AttentionParams::dropout_mask], batch);

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -133,26 +133,7 @@ MHACoreLayer::~MHACoreLayer() {}
 /************************************************************** */
 
 void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
-
-  NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 5,
-                std::invalid_argument)
-    << "Multi head Attention layer needs 3, 4, or 5 inputs. "
-       "(query, key, value; mask is optional; external cache_key + cache_value "
-       "for external cache mode)";
-
   use_external_cache = (context.getNumInputs() >= 5);
-  ml::train::TensorDim::TensorType activation_type = {
-    context.getFormat(), context.getActivationDataType()};
-  ml::train::TensorDim empty_dim(activation_type);
-
-  const std::vector<ml::train::TensorDim> &input_dims =
-    context.getInputDimensions();
-  const ml::train::TensorDim &query_dim = input_dims[INOUT_INDEX::QUERY];
-  const ml::train::TensorDim &key_dim = input_dims[INOUT_INDEX::KEY];
-
-  /** max time step of this model */
-  const unsigned int max_timestep =
-    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
 
   /** max position embeddings */
   max_position_embeddings =
@@ -173,12 +154,6 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
     original_max_position_embeddings =
       std::get<props::RopeScalingMaxPositionEmbeddings>(mha_core_props).get();
 
-  /** query_dim = (B, 1, seq_len, H_Q * Head_Dim ) */
-  const unsigned int batch_size = query_dim.batch();
-  const unsigned int query_width = query_dim.width();
-  /** key_dim = (B, 1, max_seq_len, H_KV * Head_Dim ) */
-  const unsigned int key_width = key_dim.width();
-
   /**
    *  @note If NumHeads_KV is set, then use the value. Otherwise,
    *        we initialize num_heads_KV with num_heads_Q.
@@ -190,32 +165,6 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
       ? num_heads_Q
       : static_cast<size_t>(std::get<props::NumHeads_KV>(mha_core_props).get());
 
-  // head_dim
-  head_dim = static_cast<size_t>(query_width) / num_heads_Q;
-  NNTR_THROW_IF(head_dim != key_width / num_heads_KV, std::invalid_argument)
-    << "num_heads_Q and num_heads_KV are not properly given. Please check the "
-       "num_heads_* are set correctly so that the `head_dim`s are all same for "
-       "query / key / value";
-
-  /** Weight for Sink */
-  use_sink = std::get<props::UseSink>(mha_core_props).get();
-  if (use_sink) {
-#if ENABLE_FP16 && defined(__ANDROID__)
-    nntrainer::TensorDim sink_dim(
-      1, 1, 1, num_heads_Q,
-      nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       ml::train::TensorDim::DataType::FP16));
-#else
-    nntrainer::TensorDim sink_dim(
-      1, 1, 1, num_heads_Q,
-      nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       context.getActivationDataType()));
-#endif
-    sink_idx = context.requestWeight(sink_dim, nntrainer::Initializer::ZEROS,
-                                     nntrainer::WeightRegularizer::NONE, 0.0f,
-                                     0.0f, "sink");
-  }
-
   attn_logit_softcapping =
     std::get<props::AttnLogitSoftcapping>(mha_core_props).get();
 
@@ -226,42 +175,31 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
     skip_prefill =
       std::get<nntrainer::props::SkipPrefill>(*layer_impl_props).get();
 
-  /** Tensor for KV-Cache (only allocate internally when not using external
-   * cache) */
-  if (!use_external_cache) {
-#ifdef ENABLE_FP16
-    ml::train::TensorDim cache_key_dim(
-      {batch_size, 1, max_timestep, num_heads_KV * head_dim},
-      {context.getFormat(), ml::train::TensorDim::DataType::FP16});
-    ml::train::TensorDim cache_value_dim(
-      {batch_size, 1, max_timestep, num_heads_KV * head_dim},
-      {context.getFormat(), ml::train::TensorDim::DataType::FP16});
-#else
-    ml::train::TensorDim cache_key_dim(
-      {batch_size, 1, max_timestep, num_heads_KV * head_dim},
-      {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
-    ml::train::TensorDim cache_value_dim(
-      {batch_size, 1, max_timestep, num_heads_KV * head_dim},
-      {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
-#endif
-
-    tensor_idx[AttentionParams::cache_key] = context.requestTensor(
-      cache_key_dim, "cache_key", nntrainer::Initializer::NONE, false,
-      nntrainer::TensorLifespan::MAX_LIFESPAN);
-    tensor_idx[AttentionParams::cache_value] = context.requestTensor(
-      cache_value_dim, "cache_value", nntrainer::Initializer::NONE, false,
-      nntrainer::TensorLifespan::MAX_LIFESPAN);
-  }
-
   theta = (float)std::get<props::RopeTheta>(mha_core_props).get();
 
-  /** set Output dimension! - one output */
-  std::vector<nntrainer::TensorDim> output_dims(1);
-  output_dims[0] = input_dims[0];
-  output_dims[0].width(head_dim * num_heads_Q);
-  output_dims[0].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+
   context.setOutputDimensions(output_dims);
+
+  /** Weight for Sink */
+  use_sink = std::get<props::UseSink>(mha_core_props).get();
+  if (use_sink) {
+    sink_idx = context.requestWeight(
+      weight_dims[0], nntrainer::Initializer::ZEROS,
+      nntrainer::WeightRegularizer::NONE, 0.0f, 0.0f, "sink");
+  }
+
+  if (!use_external_cache) {
+    tensor_idx[AttentionParams::cache_key] =
+      context.requestTensor(tensor_dims[AttentionParams::cache_key], "cache_key",
+                            nntrainer::Initializer::NONE, false,
+                            nntrainer::TensorLifespan::MAX_LIFESPAN);
+    tensor_idx[AttentionParams::cache_value] =
+      context.requestTensor(tensor_dims[AttentionParams::cache_value],
+                            "cache_value", nntrainer::Initializer::NONE, false,
+                            nntrainer::TensorLifespan::MAX_LIFESPAN);
+  }
 }
 
 /************************************************************** */
@@ -1585,10 +1523,9 @@ size_t MHACoreLayer::calc_windowed_attn_index(size_t i) {
 
 std::array<std::vector<nntrainer::TensorDim>, 3>
 MHACoreLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
-  NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 4,
+  NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 5,
                 std::invalid_argument)
-    << "Multi head Attention layer needs 3 or 4 inputs. (query, key, value and "
-       "mask is optional)";
+    << "Multi head Attention layer needs 3, 4, or 5 inputs. (query, key, value; mask is optional; external cache_key + cache_value for external cache mode)";
 
   const std::vector<ml::train::TensorDim> &input_dims =
     context.getInputDimensions();

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -192,8 +192,8 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
 
   if (!use_external_cache) {
     tensor_idx[AttentionParams::cache_key] =
-      context.requestTensor(tensor_dims[AttentionParams::cache_key], "cache_key",
-                            nntrainer::Initializer::NONE, false,
+      context.requestTensor(tensor_dims[AttentionParams::cache_key],
+                            "cache_key", nntrainer::Initializer::NONE, false,
                             nntrainer::TensorLifespan::MAX_LIFESPAN);
     tensor_idx[AttentionParams::cache_value] =
       context.requestTensor(tensor_dims[AttentionParams::cache_value],
@@ -1531,7 +1531,9 @@ std::array<std::vector<nntrainer::TensorDim>, 3>
 MHACoreLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
   NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 5,
                 std::invalid_argument)
-    << "Multi head Attention layer needs 3, 4, or 5 inputs. (query, key, value; mask is optional; external cache_key + cache_value for external cache mode)";
+    << "Multi head Attention layer needs 3, 4, or 5 inputs. (query, key, "
+       "value; mask is optional; external cache_key + cache_value for external "
+       "cache mode)";
 
   const std::vector<ml::train::TensorDim> &input_dims =
     context.getInputDimensions();

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -202,6 +202,40 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
   }
 }
 
+std::vector<nntrainer::TensorDim> MHACoreLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(
+    INOUT_INDEX::QUERY, init_context.getInputDimensions()[INOUT_INDEX::QUERY]);
+  run_context.updateInput(INOUT_INDEX::KEY,
+                          init_context.getInputDimensions()[INOUT_INDEX::KEY]);
+  run_context.updateInput(
+    INOUT_INDEX::VALUE, init_context.getInputDimensions()[INOUT_INDEX::VALUE]);
+  run_context.updateOutput(INOUT_INDEX::OUTPUT,
+                           output_dims[INOUT_INDEX::OUTPUT]);
+
+  unsigned int height = init_context.getInputDimensions()[0].height();
+  unsigned int &max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+  unsigned int &max_new_tokens =
+    std::get<props::MaxNewTokens>(mha_core_props).get();
+
+  max_timestep = height + max_new_tokens;
+
+  tensor_dims[AttentionParams::cache_key].height(max_timestep);
+  tensor_dims[AttentionParams::cache_value].height(max_timestep);
+
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_key],
+                           tensor_dims[AttentionParams::cache_key]);
+  run_context.updateTensor(tensor_idx[AttentionParams::cache_value],
+                           tensor_dims[AttentionParams::cache_value]);
+
+  return output_dims;
+}
+
 /************************************************************** */
 
 /**
@@ -1443,38 +1477,6 @@ void MHACoreLayer::setBatch(nntrainer::RunLayerContext &context,
   if (dropout_rate > epsilon) {
     context.updateTensor(tensor_idx[AttentionParams::dropout_mask], batch);
   }
-}
-
-void MHACoreLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  unsigned int height = input_dimensions[0].height();
-  unsigned int &max_timestep =
-    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
-  unsigned int &max_new_tokens =
-    std::get<props::MaxNewTokens>(mha_core_props).get();
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
-  max_timestep = height + max_new_tokens;
-
-  ml::train::TensorDim kv_dim = input_dimensions[0];
-  kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));
-
-  ml::train::TensorDim kv_cache_dim = kv_dim;
-#ifdef ENABLE_FP16
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::FP16);
-#else
-  kv_cache_dim.setDataType(ml::train::TensorDim::DataType::UINT16);
-#endif
-  kv_cache_dim.height(max_timestep);
-
-  context.updateInput(INOUT_INDEX::QUERY, input_dimensions[0]);
-  context.updateInput(INOUT_INDEX::KEY, kv_dim);
-  context.updateInput(INOUT_INDEX::VALUE, kv_dim);
-  context.updateOutput(0, input_dimensions[0]);
-
-  context.updateTensor(tensor_idx[AttentionParams::cache_key], kv_cache_dim);
-  context.updateTensor(tensor_idx[AttentionParams::cache_value], kv_cache_dim);
 }
 
 void MHACoreLayer::calcDerivative(nntrainer::RunLayerContext &context) {}

--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -1583,6 +1583,85 @@ size_t MHACoreLayer::calc_windowed_attn_index(size_t i) {
   }
 };
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+MHACoreLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() < 3 || context.getNumInputs() > 4,
+                std::invalid_argument)
+    << "Multi head Attention layer needs 3 or 4 inputs. (query, key, value and "
+       "mask is optional)";
+
+  const std::vector<ml::train::TensorDim> &input_dims =
+    context.getInputDimensions();
+  const ml::train::TensorDim &query_dim = input_dims[INOUT_INDEX::QUERY];
+  const ml::train::TensorDim &key_dim = input_dims[INOUT_INDEX::KEY];
+
+  /** max time step of this model */
+  const unsigned int max_timestep =
+    std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
+
+  /** query_dim = (B, 1, seq_len, H_Q * Head_Dim ) */
+  const unsigned int batch_size = query_dim.batch();
+  const unsigned int query_width = query_dim.width();
+  /** key_dim = (B, 1, max_seq_len, H_KV * Head_Dim ) */
+  const unsigned int key_width = key_dim.width();
+
+  // head_dim
+  head_dim = static_cast<size_t>(query_width) / num_heads_Q;
+  NNTR_THROW_IF(head_dim != key_width / num_heads_KV, std::invalid_argument)
+    << "num_heads_Q and num_heads_KV are not properly given. Please check the "
+       "num_heads_* are set correctly so that the `head_dim`s are all same for "
+       "query / key / value";
+
+  /** set Output dimension! - one output */
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[OUTPUT] = input_dims[QUERY];
+  output_dims[OUTPUT].width(head_dim * num_heads_Q);
+  output_dims[OUTPUT].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  std::vector<nntrainer::TensorDim> weight_dims;
+
+  /** Weight for Sink */
+  use_sink = std::get<props::UseSink>(mha_core_props).get();
+  if (use_sink) {
+#if ENABLE_FP16 && defined(__ANDROID__)
+    nntrainer::TensorDim sink_dim(
+      1, 1, 1, num_heads_Q,
+      nntrainer::TensorDim::TensorType(context.getFormat(),
+                                       ml::train::TensorDim::DataType::FP16));
+#else
+    nntrainer::TensorDim sink_dim(
+      1, 1, 1, num_heads_Q,
+      nntrainer::TensorDim::TensorType(context.getFormat(),
+                                       context.getActivationDataType()));
+#endif
+    weight_dims.push_back(sink_dim);
+  }
+
+  std::vector<nntrainer::TensorDim> tensor_dims;
+
+  /** Tensor for KV-Cache */
+#ifdef ENABLE_FP16
+  ml::train::TensorDim cache_key_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+  ml::train::TensorDim cache_value_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::FP16});
+#else
+  ml::train::TensorDim cache_key_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+  ml::train::TensorDim cache_value_dim(
+    {batch_size, 1, max_timestep, num_heads_KV * head_dim},
+    {context.getFormat(), ml::train::TensorDim::DataType::UINT16});
+#endif
+  tensor_dims.push_back(cache_key_dim);
+  tensor_dims.push_back(cache_value_dim);
+
+  return {output_dims, weight_dims, tensor_dims};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_mha_core_layer() {

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -508,6 +508,12 @@ private:
   /************** END OF  ROTARY EMBEDDING *************/
 
   /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
+
+  /**
    * @brief calculate common derivative
    * @param context Context of the layer
    */

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -242,6 +242,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @brief forwarding function of MhaCore Layer
    *        Please note that forwarding function is used only for training.
    */
@@ -331,7 +339,6 @@ public:
    * @brief Get the current cache index
    */
   WIN_EXPORT unsigned int getCacheIndex() const { return cache_index; }
-
   inline static const std::string type = "mha_core";
 
 private:

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -324,10 +324,6 @@ public:
   WIN_EXPORT void setBatch(nntrainer::RunLayerContext &context,
                            unsigned int batch) override;
 
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
-
   /**
    * @brief Set the cache index for external cache mode.
    *        Must be called before forwarding() when use_external_cache is true.

--- a/Applications/CausalLM/layers/per_layer_slice.cpp
+++ b/Applications/CausalLM/layers/per_layer_slice.cpp
@@ -97,13 +97,17 @@ void PerLayerSliceLayer::incremental_forwarding(
   }
 }
 
-void PerLayerSliceLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
+std::vector<nntrainer::TensorDim> PerLayerSliceLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  auto input_dimensions = init_context.getInputDimensions();
   auto out_dim = input_dimensions[0];
   out_dim.width(std::get<props::FeatureSize>(slice_props).get());
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, out_dim);
+
+  run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, out_dim);
+
+  return {out_dim};
 }
 
 void PerLayerSliceLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/per_layer_slice.cpp
+++ b/Applications/CausalLM/layers/per_layer_slice.cpp
@@ -97,7 +97,8 @@ void PerLayerSliceLayer::incremental_forwarding(
   }
 }
 
-std::vector<nntrainer::TensorDim> PerLayerSliceLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+PerLayerSliceLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   auto input_dimensions = init_context.getInputDimensions();

--- a/Applications/CausalLM/layers/per_layer_slice.h
+++ b/Applications/CausalLM/layers/per_layer_slice.h
@@ -79,9 +79,9 @@ public:
            std::to_string(values.size());
   }
 
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   inline static const std::string type = "per_layer_slice";
 

--- a/Applications/CausalLM/layers/qkv_layer.cpp
+++ b/Applications/CausalLM/layers/qkv_layer.cpp
@@ -43,9 +43,6 @@ QKVLayer::QKVLayer() :
 }
 
 void QKVLayer::finalize(nntrainer::InitLayerContext &context) {
-  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
-    << "Fully connected layer takes only one input";
-
   auto &weight_regularizer =
     std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
   auto &weight_regularizer_constant =
@@ -54,65 +51,24 @@ void QKVLayer::finalize(nntrainer::InitLayerContext &context) {
   auto &weight_decay =
     std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
 
-  const auto &q_unit = std::get<props::QUnit>(qkv_props).get();
-  const auto &k_unit = std::get<props::KUnit>(qkv_props).get();
-  const auto &v_unit = std::get<props::VUnit>(qkv_props).get();
-
-  std::vector<nntrainer::TensorDim> output_dims(3);
-
-  /// @todo fc actaully supports multidimensions. EffDimFlag shouldn't be fixed
-  /// like this.
-  context.setEffDimFlagInputDimension(0, 0b1001);
-  context.setDynDimFlagInputDimension(0, 0b1000);
-
-  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
-  /** set output dimensions */
-  auto const &in_dim = context.getInputDimensions()[0];
-
-  /** Q out */
-  output_dims[QKVParams::Q] = in_dim;
-  is_nchw ? output_dims[QKVParams::Q].width(q_unit)
-          : output_dims[QKVParams::Q].channel(q_unit);
-  output_dims[QKVParams::Q].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
-
-  /** K out */
-  output_dims[QKVParams::K] = in_dim;
-  is_nchw ? output_dims[QKVParams::K].width(k_unit)
-          : output_dims[QKVParams::K].channel(k_unit);
-  output_dims[QKVParams::K].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
-
-  /** V out */
-  output_dims[QKVParams::V] = in_dim;
-  is_nchw ? output_dims[QKVParams::V].width(v_unit)
-          : output_dims[QKVParams::V].channel(v_unit);
-  output_dims[QKVParams::V].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
 
   context.setOutputDimensions(output_dims);
 
   /** Q */
-  nntrainer::TensorDim weight_dim(
-    1, is_nchw ? 1 : q_unit, is_nchw ? in_dim.width() : 1,
-    is_nchw ? q_unit : in_dim.channel(),
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
   weight_idx[QKVParams::Q] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
+    weight_dims[QKVParams::Q], weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "qweight", true);
 
   /** K */
-  weight_dim.width(k_unit);
   weight_idx[QKVParams::K] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
+    weight_dims[QKVParams::K], weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "kweight", true);
 
   /** V */
-  weight_dim.width(v_unit);
   weight_idx[QKVParams::V] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
+    weight_dims[QKVParams::V], weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "vweight", true);
 }
 

--- a/Applications/CausalLM/layers/qkv_layer.cpp
+++ b/Applications/CausalLM/layers/qkv_layer.cpp
@@ -200,4 +200,69 @@ void QKVLayer::updateTensorsByInputDimensions(
   context.updateOutput(QKVParams::K, Koutput_dim);
   context.updateOutput(QKVParams::V, Voutput_dim);
 }
+
+std::array<std::vector<nntrainer::TensorDim>, 3>
+QKVLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "Fully connected layer takes only one input";
+
+  const auto &q_unit = std::get<props::QUnit>(qkv_props).get();
+  const auto &k_unit = std::get<props::KUnit>(qkv_props).get();
+  const auto &v_unit = std::get<props::VUnit>(qkv_props).get();
+
+  std::vector<nntrainer::TensorDim> output_dims(3);
+  std::vector<nntrainer::TensorDim> weight_dims(3);
+
+  /// @todo fc actaully supports multidimensions. EffDimFlag shouldn't be fixed
+  /// like this.
+  context.setEffDimFlagInputDimension(0, 0b1001);
+  context.setDynDimFlagInputDimension(0, 0b1000);
+
+  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
+  /** set output dimensions */
+  auto const &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  /** Q out */
+  output_dims[QKVParams::Q] = in_dim;
+  is_nchw ? output_dims[QKVParams::Q].width(q_unit)
+          : output_dims[QKVParams::Q].channel(q_unit);
+  output_dims[QKVParams::Q].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  /** K out */
+  output_dims[QKVParams::K] = in_dim;
+  is_nchw ? output_dims[QKVParams::K].width(k_unit)
+          : output_dims[QKVParams::K].channel(k_unit);
+  output_dims[QKVParams::K].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  /** V out */
+  output_dims[QKVParams::V] = in_dim;
+  is_nchw ? output_dims[QKVParams::V].width(v_unit)
+          : output_dims[QKVParams::V].channel(v_unit);
+  output_dims[QKVParams::V].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  /** Q */
+  nntrainer::TensorDim q_weight_dim(
+    1, is_nchw ? 1 : q_unit, is_nchw ? in_dim.width() : 1,
+    is_nchw ? q_unit : in_dim.channel(),
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+  weight_dims[QKVParams::Q] = q_weight_dim;
+
+  /** K */
+  nntrainer::TensorDim k_weight_dim = q_weight_dim;
+  k_weight_dim.width(k_unit);
+  weight_dims[QKVParams::K] = k_weight_dim;
+
+  /** V */
+  nntrainer::TensorDim v_weight_dim = q_weight_dim;
+  v_weight_dim.width(v_unit);
+  weight_dims[QKVParams::V] = v_weight_dim;
+
+  return {output_dims, weight_dims, {}};
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/layers/qkv_layer.cpp
+++ b/Applications/CausalLM/layers/qkv_layer.cpp
@@ -72,6 +72,21 @@ void QKVLayer::finalize(nntrainer::InitLayerContext &context) {
     weight_regularizer_constant, weight_decay, "vweight", true);
 }
 
+std::vector<nntrainer::TensorDim> QKVLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(QKVParams::Q, output_dims[QKVParams::Q]);
+  run_context.updateOutput(QKVParams::K, output_dims[QKVParams::K]);
+  run_context.updateOutput(QKVParams::V, output_dims[QKVParams::V]);
+
+  return output_dims;
+}
+
 void QKVLayer::exportTo(nntrainer::Exporter &exporter,
                         const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);
@@ -137,25 +152,6 @@ void QKVLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 void QKVLayer::calcDerivative(nntrainer::RunLayerContext &context) { return; }
 
 void QKVLayer::calcGradient(nntrainer::RunLayerContext &context) { return; }
-
-void QKVLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
-  ml::train::TensorDim Qoutput_dim = context.getOutput(QKVParams::Q).getDim();
-  ml::train::TensorDim Koutput_dim = context.getOutput(QKVParams::K).getDim();
-  ml::train::TensorDim Voutput_dim = context.getOutput(QKVParams::V).getDim();
-
-  input_dim.height(input_dimensions[0].height());
-  Qoutput_dim.height(input_dimensions[0].height());
-  Koutput_dim.height(input_dimensions[0].height());
-  Voutput_dim.height(input_dimensions[0].height());
-
-  context.updateInput(SINGLE_INOUT_IDX, input_dim);
-  context.updateOutput(QKVParams::Q, Qoutput_dim);
-  context.updateOutput(QKVParams::K, Koutput_dim);
-  context.updateOutput(QKVParams::V, Voutput_dim);
-}
 
 std::array<std::vector<nntrainer::TensorDim>, 3>
 QKVLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {

--- a/Applications/CausalLM/layers/qkv_layer.h
+++ b/Applications/CausalLM/layers/qkv_layer.h
@@ -145,6 +145,12 @@ public:
 private:
   std::tuple<props::QUnit, props::KUnit, props::VUnit> qkv_props;
   std::array<unsigned int, 3> weight_idx; /**< indices of the weights */
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/qkv_layer.h
+++ b/Applications/CausalLM/layers/qkv_layer.h
@@ -84,6 +84,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -135,10 +143,6 @@ public:
    * &value)
    */
   WIN_EXPORT void setProperty(const std::vector<std::string> &values) override;
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "qkv_layer";
 

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -20,8 +20,6 @@ namespace causallm {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
-  std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
-  context.setOutputDimensions(dim);
   feature_size = std::get<props::FeatureSize>(rms_props);
   use_gamma = std::get<props::UseGamma>(rms_props).get();
 
@@ -31,19 +29,18 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  NNTR_THROW_IF(dim[0].width() % feature_size != 0, std::invalid_argument)
-    << "feature size must be a divisor of width";
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+
+  context.setOutputDimensions(output_dims);
 
   if (use_gamma) {
     // gamma is unquantized FP32 on disk; request FP32 regardless of activation
     // dtype (FP16 would reinterpret the FP32 bytes and corrupt gamma). The FP16
     // path casts gamma down at the multiply site.
-    nntrainer::TensorDim gamma_dim(
-      1, 1, 1, feature_size,
-      nntrainer::TensorDim::TensorType(context.getFormat(),
-                                       nntrainer::TensorDim::DataType::FP32));
+    weight_dims[RMSParams::gamma].setDataType(nntrainer::TensorDim::DataType::FP32);
     wt_idx[RMSParams::gamma] = context.requestWeight(
-      gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
+      weight_dims[RMSParams::gamma], nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);
   }
 }

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -38,9 +38,11 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     // gamma is unquantized FP32 on disk; request FP32 regardless of activation
     // dtype (FP16 would reinterpret the FP32 bytes and corrupt gamma). The FP16
     // path casts gamma down at the multiply site.
-    weight_dims[RMSParams::gamma].setDataType(nntrainer::TensorDim::DataType::FP32);
+    weight_dims[RMSParams::gamma].setDataType(
+      nntrainer::TensorDim::DataType::FP32);
     wt_idx[RMSParams::gamma] = context.requestWeight(
-      weight_dims[RMSParams::gamma], nntrainer::props::InitializerInfo::Enum::NONE,
+      weight_dims[RMSParams::gamma],
+      nntrainer::props::InitializerInfo::Enum::NONE,
       nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);
   }
 }

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -154,6 +154,33 @@ void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {
   std::throw_with_nested(std::runtime_error("Training is not supported yet."));
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+ReshapedRMSNormLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  std::vector<nntrainer::TensorDim> output_dims = context.getInputDimensions();
+
+  NNTR_THROW_IF(output_dims[SINGLE_INOUT_IDX].width() % feature_size != 0,
+                std::invalid_argument)
+    << "feature size must be a divisor of width, width of output: "
+    << output_dims[SINGLE_INOUT_IDX] << ", feature_size: " << feature_size;
+
+  if (output_dims[SINGLE_INOUT_IDX].getDataType() ==
+      ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = output_dims[SINGLE_INOUT_IDX];
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
+
+  std::vector<nntrainer::TensorDim> weight_dims;
+  nntrainer::TensorDim gamma_dim(
+    1, 1, 1, feature_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()));
+  weight_dims.push_back(gamma_dim);
+
+  return {output_dims, weight_dims, {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_rms_norm_layer() {

--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -45,6 +45,20 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
   }
 }
 
+std::vector<nntrainer::TensorDim>
+ReshapedRMSNormLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void ReshapedRMSNormLayer::forwarding(nntrainer::RunLayerContext &context,
                                       bool training) {}
 
@@ -138,13 +152,6 @@ void ReshapedRMSNormLayer::incremental_forwarding(
               << "output:" << out_step << std::endl;
 #endif
   }
-}
-
-void ReshapedRMSNormLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
 void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -124,10 +124,18 @@ private:
   std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon,
              props::FeatureSize, nntrainer::props::SkipPrefill, props::UseGamma>
     rms_props;
+  std::shared_ptr<nntrainer::Tensor> input_fp32;
+  std::shared_ptr<nntrainer::Tensor> output_fp32;
 
   unsigned int feature_size;
   bool skip_prefill = false;
   bool use_gamma;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -66,6 +66,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -112,10 +120,6 @@ public:
       << "[rms_norm] Unknown Layer Properties count " +
            std::to_string(values.size());
   };
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "reshaped_rms_norm";
 

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -31,7 +31,8 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
   // gamma is unquantized and stored as FP32 in the bin. Force request as FP32.
-  weight_dims[RMSParams::gamma].setDataType(nntrainer::TensorDim::DataType::FP32);
+  weight_dims[RMSParams::gamma].setDataType(
+    nntrainer::TensorDim::DataType::FP32);
 
   wt_idx[RMSParams::gamma] = context.requestWeight(
     weight_dims[RMSParams::gamma],

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -22,22 +22,20 @@ namespace causallm {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
-  std::vector<nntrainer::TensorDim> dim = context.getInputDimensions();
-  context.setOutputDimensions(dim);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+
+  context.setOutputDimensions(output_dims);
 
   if (!std::get<nntrainer::props::SkipPrefill>(rms_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(rms_props).get();
 
-  // gamma is unquantized and stored as FP32 in the bin. Request it as FP32
-  // regardless of the activation dtype; declaring it FP16 reinterprets the
-  // on-disk FP32 bytes as FP16 and corrupts gamma (≈FP16-max garbage). The
-  // FP16 forward path casts gamma down to FP16 at the multiply site.
-  nntrainer::TensorDim gamma_dim(
-    1, 1, 1, dim[0].width(),
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     nntrainer::TensorDim::DataType::FP32));
+  // gamma is unquantized and stored as FP32 in the bin. Force request as FP32.
+  weight_dims[RMSParams::gamma].setDataType(nntrainer::TensorDim::DataType::FP32);
+
   wt_idx[RMSParams::gamma] = context.requestWeight(
-    gamma_dim, nntrainer::props::InitializerInfo::Enum::NONE,
+    weight_dims[RMSParams::gamma],
+    nntrainer::props::InitializerInfo::Enum::NONE,
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);
 }
 

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -133,6 +133,26 @@ void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {
   std::throw_with_nested(std::runtime_error("Training is not supported yet."));
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+RMSNormLayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  std::vector<nntrainer::TensorDim> output_dims = context.getInputDimensions();
+
+  if (output_dims[SINGLE_INOUT_IDX].getDataType() ==
+      ml::train::TensorDim::DataType::FP16) {
+    ml::train::TensorDim in_out_fp32_dim = output_dims[SINGLE_INOUT_IDX];
+    in_out_fp32_dim.setDataType(ml::train::TensorDim::DataType::FP32);
+    input_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+    output_fp32 = std::make_shared<nntrainer::Tensor>(in_out_fp32_dim);
+  }
+
+  nntrainer::TensorDim gamma_dim(
+    1, 1, 1, output_dims[SINGLE_INOUT_IDX].width(),
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()));
+
+  return {output_dims, {gamma_dim}, {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_rms_norm_layer() {

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -39,6 +39,19 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
     nntrainer::WeightRegularizer::NONE, 1.0f, 0.0f, "gamma", true);
 }
 
+std::vector<nntrainer::TensorDim> RMSNormLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void RMSNormLayer::forwarding(nntrainer::RunLayerContext &context,
                               bool training) {}
 
@@ -118,13 +131,6 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
               << "output:" << out_step << "gamma:" << gamma << std::endl;
 #endif
   }
-}
-
-void RMSNormLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
 void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -57,6 +57,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -103,10 +111,6 @@ public:
       << "[rms_norm] Unknown Layer Properties count " +
            std::to_string(values.size());
   };
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "rms_norm";
 

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -115,7 +115,15 @@ private:
   std::tuple<props::RMS_NORM_GAMMA_INIT, nntrainer::props::Epsilon,
              nntrainer::props::SkipPrefill>
     rms_props;
+  std::shared_ptr<nntrainer::Tensor> input_fp32;
+  std::shared_ptr<nntrainer::Tensor> output_fp32;
   bool skip_prefill = false;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/rms_reverse_norm.cpp
+++ b/Applications/CausalLM/layers/rms_reverse_norm.cpp
@@ -170,12 +170,15 @@ void RMSReverseNormLayer::incremental_forwarding(
   }
 }
 
-std::vector<nntrainer::TensorDim> RMSReverseNormLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+RMSReverseNormLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   auto input_dimensions = init_context.getInputDimensions();
-  ml::train::TensorDim input_dim = run_context.getInput(SINGLE_INOUT_IDX).getDim();
-  ml::train::TensorDim output_dim = run_context.getOutput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim input_dim =
+    run_context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim =
+    run_context.getOutput(SINGLE_INOUT_IDX).getDim();
 
   input_dim.height(input_dimensions[0].height());
   output_dim.height(input_dimensions[0].height());

--- a/Applications/CausalLM/layers/rms_reverse_norm.cpp
+++ b/Applications/CausalLM/layers/rms_reverse_norm.cpp
@@ -170,18 +170,20 @@ void RMSReverseNormLayer::incremental_forwarding(
   }
 }
 
-void RMSReverseNormLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
-  ml::train::TensorDim output_dim =
-    context.getOutput(SINGLE_INOUT_IDX).getDim();
+std::vector<nntrainer::TensorDim> RMSReverseNormLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  auto input_dimensions = init_context.getInputDimensions();
+  ml::train::TensorDim input_dim = run_context.getInput(SINGLE_INOUT_IDX).getDim();
+  ml::train::TensorDim output_dim = run_context.getOutput(SINGLE_INOUT_IDX).getDim();
 
   input_dim.height(input_dimensions[0].height());
   output_dim.height(input_dimensions[0].height());
 
-  context.updateInput(SINGLE_INOUT_IDX, input_dim);
-  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+  run_context.updateInput(SINGLE_INOUT_IDX, input_dim);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dim);
+
+  return {output_dim};
 }
 
 void RMSReverseNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/rms_reverse_norm.h
+++ b/Applications/CausalLM/layers/rms_reverse_norm.h
@@ -148,9 +148,9 @@ public:
            std::to_string(values.size());
   };
 
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   inline static const std::string type = "rms_reverse_norm";
 

--- a/Applications/CausalLM/layers/scalar_multiply.cpp
+++ b/Applications/CausalLM/layers/scalar_multiply.cpp
@@ -115,7 +115,8 @@ void ScalarMultiplyLayer::incremental_forwarding(
   }
 }
 
-std::vector<nntrainer::TensorDim> ScalarMultiplyLayer::updateTensorsByInputDimensions(
+std::vector<nntrainer::TensorDim>
+ScalarMultiplyLayer::updateTensorsByInputDimensions(
   nntrainer::InitLayerContext &init_context,
   nntrainer::RunLayerContext &run_context) {
   auto input_dimensions = init_context.getInputDimensions();

--- a/Applications/CausalLM/layers/scalar_multiply.cpp
+++ b/Applications/CausalLM/layers/scalar_multiply.cpp
@@ -115,11 +115,14 @@ void ScalarMultiplyLayer::incremental_forwarding(
   }
 }
 
-void ScalarMultiplyLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+std::vector<nntrainer::TensorDim> ScalarMultiplyLayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  auto input_dimensions = init_context.getInputDimensions();
+  run_context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+
+  return {input_dimensions[0]};
 }
 
 void ScalarMultiplyLayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/scalar_multiply.h
+++ b/Applications/CausalLM/layers/scalar_multiply.h
@@ -133,9 +133,9 @@ public:
            std::to_string(values.size());
   };
 
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
 
   inline static const std::string type = "scalar_multiply";
 

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -39,6 +39,21 @@ void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(swiglu_props).get();
 }
 
+std::vector<nntrainer::TensorDim> SwiGLULayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(INPUT_IDX_1,
+                          init_context.getInputDimensions()[INPUT_IDX_1]);
+  run_context.updateInput(INPUT_IDX_2,
+                          init_context.getInputDimensions()[INPUT_IDX_2]);
+  run_context.updateOutput(OUT_IDX, output_dims[OUT_IDX]);
+
+  return output_dims;
+}
+
 void SwiGLULayer::forwarding(nntrainer::RunLayerContext &context,
                              bool training) {}
 
@@ -82,22 +97,6 @@ void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
     NNTR_THROW_IF(true, std::invalid_argument) << "enable-fp16 is not set!";
 #endif
   }
-}
-
-void SwiGLULayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  ml::train::TensorDim input_dim1 = context.getInput(INPUT_IDX_1).getDim();
-  ml::train::TensorDim input_dim2 = context.getInput(INPUT_IDX_2).getDim();
-  ml::train::TensorDim output_dim = context.getOutput(OUT_IDX).getDim();
-
-  input_dim1.height(input_dimensions[0].height());
-  input_dim2.height(input_dimensions[0].height());
-  output_dim.height(input_dimensions[0].height());
-
-  context.updateInput(INPUT_IDX_1, input_dim1);
-  context.updateInput(INPUT_IDX_2, input_dim2);
-  context.updateOutput(OUT_IDX, output_dim);
 }
 
 void SwiGLULayer::calcDerivative(nntrainer::RunLayerContext &context) {

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -31,7 +31,9 @@ float swiglu(float x) { return x / (1 + nntrainer::exp_util(-x)); }
 } // namespace ActivationOp
 
 void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
-  context.setOutputDimensions({context.getInputDimensions()[0]});
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+  context.setOutputDimensions(output_dims);
 
   if (!std::get<nntrainer::props::SkipPrefill>(swiglu_props).empty())
     skip_prefill = std::get<nntrainer::props::SkipPrefill>(swiglu_props).get();

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -103,6 +103,19 @@ void SwiGLULayer::calcDerivative(nntrainer::RunLayerContext &context) {
   // yet."));
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+SwiGLULayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  NNTR_THROW_IF(context.getInputDimensions()[INPUT_IDX_1] !=
+                  context.getInputDimensions()[INPUT_IDX_2],
+                std::invalid_argument)
+    << "2 input dimensions of SwiGLU layer SHOULD BE identical";
+
+  return {std::move(std::vector<nntrainer::TensorDim>{
+            (context.getInputDimensions()[INPUT_IDX_1])}),
+          {},
+          {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_swiglu_layer() {

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -53,6 +53,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -99,10 +107,6 @@ public:
       << "[swiglu] Unknown Layer Properties count " +
            std::to_string(values.size());
   };
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   inline static const std::string type = "swiglu";
 

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -109,6 +109,12 @@ public:
 private:
   std::tuple<nntrainer::props::SkipPrefill> swiglu_props;
   bool skip_prefill = false;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -539,6 +539,94 @@ void TieWordEmbedding::save(std::ofstream &file,
   }
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+TieWordEmbedding::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  return mode_ == mode::embedding ? getEmbeddingDimensions(context)
+                                  : getLMheadDimensions(context);
+}
+
+std::array<std::vector<nntrainer::TensorDim>, 3>
+TieWordEmbedding::getEmbeddingDimensions(nntrainer::InitLayerContext &context) {
+  unsigned int in_dim =
+    std::get<nntrainer::props::InDim>(tieword_embedding_props);
+  unsigned int out_dim =
+    std::get<nntrainer::props::OutDim>(tieword_embedding_props);
+
+  const nntrainer::TensorDim &input_dim =
+    context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  nntrainer::TensorDim output_dim = input_dim;
+
+  // output_dim expected as hidden x num input (batch size)
+  output_dim.height(input_dim.width());
+  output_dim.width(out_dim);
+  output_dim.setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  nntrainer::TensorDim weight_dim = output_dim;
+
+  weight_dim.setTensorType({context.getFormat(), context.getWeightDataType()});
+
+  weight_dim.height(in_dim);
+  weight_dim.width(out_dim);
+  weight_dim.batch(1);
+
+  return {std::move(std::vector<nntrainer::TensorDim>{output_dim}),
+          std::move(std::vector<nntrainer::TensorDim>{weight_dim}),
+          {}};
+}
+
+std::array<std::vector<nntrainer::TensorDim>, 3>
+TieWordEmbedding::getLMheadDimensions(nntrainer::InitLayerContext &context) {
+  auto &disable_bias =
+    std::get<nntrainer::props::DisableBias>(*layer_impl_props);
+
+  auto unit = std::get<nntrainer::props::Unit>(tieword_embedding_props).get();
+
+  std::vector<ml::train::TensorDim> output_dims(1);
+
+  /// @todo fc actaully supports multidimensions.
+  /// EffDimFlag shouldn't be fixed like this.
+  context.setEffDimFlagInputDimension(0, 0b1001);
+  context.setDynDimFlagInputDimension(0, 0b1000);
+  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
+
+  /** set output dimensions */
+  auto const &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  is_nchw ? output_dims[SINGLE_INOUT_IDX].width(unit)
+          : output_dims[SINGLE_INOUT_IDX].channel(unit);
+  output_dims[SINGLE_INOUT_IDX].height(1);
+
+  output_dims[SINGLE_INOUT_IDX].setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+
+  std::vector<nntrainer::TensorDim> weight_dims;
+
+  ///@note TieWordEmbedding layer's tensor dim is transposed dim of user-defined
+  /// dim
+  /// so it can reuse embedding layer.
+  ml::train::TensorDim weight_dim(
+    1, is_nchw ? 1 : in_dim.channel(), is_nchw ? unit : 1,
+    is_nchw ? in_dim.width() : unit,
+    ml::train::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+  weight_dims.push_back(weight_dim);
+
+  if (disable_bias.empty() || disable_bias.get() == false) {
+    /** set weight specifications */
+    ml::train::TensorDim bias_dim(
+      1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
+      ml::train::TensorDim::TensorType(context.getFormat(),
+                                       context.getWeightDataType()),
+      is_nchw ? 0b0001 : 0b0100);
+    weight_dims.push_back(bias_dim);
+  }
+
+  return {output_dims, weight_dims, {}};
+}
+
 #ifdef PLUGGABLE
 
 nntrainer::Layer *create_tie_word_embedding() {

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -79,31 +79,15 @@ void TieWordEmbedding::finalize_embedding(
   auto &weight_decay =
     std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
 
-  unsigned int in_dim =
-    std::get<nntrainer::props::InDim>(tieword_embedding_props);
-  unsigned int out_dim =
-    std::get<nntrainer::props::OutDim>(tieword_embedding_props);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getEmbeddingDimensions(context);
 
-  nntrainer::TensorDim output_dim = input_dim;
-
-  // output_dim expected as hidden x num input (batch size)
-  output_dim.height(input_dim.width());
-  output_dim.width(out_dim);
-  output_dim.setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
-  context.setOutputDimensions({output_dim});
-
-  nntrainer::TensorDim dim = output_dim;
-
-  dim.setTensorType({context.getFormat(), context.getWeightDataType()});
-
-  dim.height(in_dim);
-  dim.width(out_dim);
-  dim.batch(1);
+  context.setOutputDimensions(output_dims);
 
   weight_idx[TieWordEmbeddingParams::weight] = context.requestWeight(
-    dim, weight_initializer, weight_regularizer, weight_regularizer_constant,
-    weight_decay, "Embedding", true);
+    weight_dims[TieWordEmbeddingParams::weight], weight_initializer,
+    weight_regularizer, weight_regularizer_constant, weight_decay, "Embedding",
+    true);
 }
 
 void TieWordEmbedding::finalize_lmhead(nntrainer::InitLayerContext &context) {
@@ -120,60 +104,31 @@ void TieWordEmbedding::finalize_lmhead(nntrainer::InitLayerContext &context) {
   auto &disable_bias =
     std::get<nntrainer::props::DisableBias>(*layer_impl_props);
 
-  auto unit = std::get<nntrainer::props::Unit>(tieword_embedding_props).get();
-
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "lm head layer takes only one input";
 
-  std::vector<ml::train::TensorDim> output_dims(1);
-
-  /// @todo fc actaully supports multidimensions.
-  /// EffDimFlag shouldn't be fixed like this.
-  context.setEffDimFlagInputDimension(0, 0b1001);
-  context.setDynDimFlagInputDimension(0, 0b1000);
-  bool is_nchw = (context.getFormat() == nntrainer::Tformat::NCHW);
-
-  /** set output dimensions */
-  auto const &in_dim = context.getInputDimensions()[0];
-  output_dims[0] = in_dim;
-  is_nchw ? output_dims[0].width(unit) : output_dims[0].channel(unit);
-  output_dims[0].height(1);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLMheadDimensions(context);
 
   // The lm_head output is the logits; generate() reads them as float* for
   // argmax/sampling. Force FP32 regardless of the activation dtype — under FP16
   // activation an FP16 logits tensor is reinterpreted as FP32 and produces
   // garbage tokens. (The Q6_K/Q4_0 lmhead matmul writes FP32 directly; the FP16
   // activation is cast up to FP32 before the dot in incremental_forwarding.)
-  output_dims[0].setTensorType(
+  output_dims[SINGLE_INOUT_IDX].setTensorType(
     {context.getFormat(), nntrainer::TensorDim::DataType::FP32});
 
   context.setOutputDimensions(output_dims);
 
-  /** set weight specifications */
-  ml::train::TensorDim bias_dim(
-    1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
-    ml::train::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0001 : 0b0100);
-
-  ///@note TieWordEmbedding layer's tensor dim is transposed dim of user-defined
-  /// dim
-  /// so it can reuse embedding layer.
-  ml::train::TensorDim weight_dim(
-    1, is_nchw ? 1 : in_dim.channel(), is_nchw ? unit : 1,
-    is_nchw ? in_dim.width() : unit,
-    ml::train::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
-
   weight_idx[TieWordEmbeddingParams::weight] = context.requestWeight(
-    weight_dim, weight_initializer, weight_regularizer,
-    weight_regularizer_constant, weight_decay, "Embedding", true);
+    weight_dims[TieWordEmbeddingParams::weight], weight_initializer,
+    weight_regularizer, weight_regularizer_constant, weight_decay, "Embedding",
+    true);
 
   if (disable_bias.empty() || disable_bias.get() == false) {
     weight_idx[TieWordEmbeddingParams::bias] = context.requestWeight(
-      bias_dim, bias_initializer, nntrainer::WeightRegularizer::NONE, 1.0f,
-      bias_decay, "bias", true);
+      weight_dims[TieWordEmbeddingParams::bias], bias_initializer,
+      nntrainer::WeightRegularizer::NONE, 1.0f, bias_decay, "bias", true);
   }
 }
 

--- a/Applications/CausalLM/layers/tie_word_embedding.cpp
+++ b/Applications/CausalLM/layers/tie_word_embedding.cpp
@@ -132,6 +132,21 @@ void TieWordEmbedding::finalize_lmhead(nntrainer::InitLayerContext &context) {
   }
 }
 
+std::vector<nntrainer::TensorDim>
+TieWordEmbedding::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void TieWordEmbedding::setProperty(const std::vector<std::string> &values) {
   auto remain_props = loadProperties(values, tieword_embedding_props);
   LayerImpl::setProperty(remain_props);
@@ -369,25 +384,6 @@ void TieWordEmbedding::exportTo(nntrainer::Exporter &exporter,
                                 const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);
   exporter.saveResult(tieword_embedding_props, method, this);
-}
-
-void TieWordEmbedding::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  nntrainer::TensorDim in_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
-  nntrainer::TensorDim out_dim = context.getOutput(SINGLE_INOUT_IDX).getDim();
-
-  unsigned int height = input_dimensions[0].height();
-
-  if (mode_ == mode::embedding) {
-    in_dim.width(height);
-  } else {
-    in_dim.height(height);
-  }
-  out_dim.height(height);
-
-  context.updateInput(SINGLE_INOUT_IDX, in_dim);
-  context.updateOutput(SINGLE_INOUT_IDX, out_dim);
 }
 
 void TieWordEmbedding::read(

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -63,6 +63,14 @@ public:
   WIN_EXPORT void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  WIN_EXPORT std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   WIN_EXPORT void forwarding(nntrainer::RunLayerContext &context,
@@ -105,10 +113,6 @@ public:
    * @copydoc Layer::supportBackwarding()
    */
   WIN_EXPORT bool supportBackwarding() const override { return false; }
-
-  WIN_EXPORT void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   /**
    * @copydoc Layer::read()

--- a/Applications/CausalLM/layers/tie_word_embedding.h
+++ b/Applications/CausalLM/layers/tie_word_embedding.h
@@ -160,6 +160,26 @@ private:
   std::array<unsigned int, 4> weight_idx; /**< indices of the weights */
   bool skip_prefill = false;
 
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
+
+  /**
+   * @brief     get output, weight and tensor dimensions of embedding layer
+   * @param     context Context of the layer
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getEmbeddingDimensions(nntrainer::InitLayerContext &context);
+
+  /**
+   * @brief     get output, weight and tensor dimensions of lm head layer
+   * @param     context Context of the layer
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLMheadDimensions(nntrainer::InitLayerContext &context);
+
   WIN_EXPORT void finalize_embedding(nntrainer::InitLayerContext &context);
   WIN_EXPORT void finalize_lmhead(nntrainer::InitLayerContext &context);
   WIN_EXPORT void

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -512,10 +512,10 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   input = build_inference_inputs();
 
   ///@note contains possible bug
-  // std::vector<ml::train::TensorDim> input_dims;
-  // ml::train::TensorDim input_dim(1, 1, input_len, DIM);
-  // input_dims.push_back(input_dim);
-  // model->resetInputDimension(input_dims);
+  std::vector<ml::train::TensorDim> input_dims;
+  ml::train::TensorDim input_dim(1, 1, 1, input_len);
+  input_dims.push_back(input_dim);
+  model->resetInputDimension(input_dims);
 
   auto start_prefill = std::chrono::high_resolution_clock::now();
 

--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -511,10 +511,8 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
   };
   input = build_inference_inputs();
 
-  ///@note contains possible bug
-  std::vector<ml::train::TensorDim> input_dims;
-  ml::train::TensorDim input_dim(1, 1, 1, input_len);
-  input_dims.push_back(input_dim);
+  std::vector<ml::train::TensorDim> input_dims = model->getInputDimension();
+  input_dims[0] = ml::train::TensorDim(1, 1, 1, input_len);
   model->resetInputDimension(input_dims);
 
   auto start_prefill = std::chrono::high_resolution_clock::now();

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -501,4 +501,26 @@ void CachedSlimMoELayer::exportTo(
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
+std::array<std::vector<nntrainer::TensorDim>, 3>
+CachedSlimMoELayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
+  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  std::vector<nntrainer::TensorDim> output_dims(1);
+  output_dims[SINGLE_INOUT_IDX] = in_dim;
+  return {output_dims, {}, {}};
+}
+
+std::vector<nntrainer::TensorDim>
+CachedSlimMoELayer::updateTensorsByInputDimensions(
+  nntrainer::InitLayerContext &init_context,
+  nntrainer::RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -61,6 +61,9 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
   NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
     << "MoE layer only supports single input";
 
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+
   auto &weight_regularizer =
     std::get<nntrainer::props::WeightRegularizer>(*layer_impl_props);
   auto &weight_regularizer_constant =
@@ -71,18 +74,11 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
     std::get<nntrainer::props::WeightDecay>(*layer_impl_props);
 
   // 2. Set output dimensions (same as input)
-  const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
-  const bool is_nchw = context.getFormat() == nntrainer::Tformat::NCHW;
-  std::vector<nntrainer::TensorDim> output_dims(1);
-  output_dims[SINGLE_INOUT_IDX] = in_dim;
   context.setOutputDimensions(output_dims);
 
   // 3. Get MoE properties
   num_experts = std::get<props::NumExperts>(moe_props).get();
   topk = std::get<props::NumExpertsPerToken>(moe_props).get();
-  const unsigned int intermediate_size =
-    std::get<nntrainer::props::Unit>(moe_props).get();
-  const unsigned int hidden_size = in_dim.width(); // Feature dimension
 
   // activation function
   if (std::get<props::MoEActivation>(moe_props).empty()) {
@@ -98,15 +94,8 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
   }
 
   // 4. Initialie gate layer (router)
-  nntrainer::TensorDim gate_dim(
-    1, is_nchw ? 1 : num_experts, is_nchw ? hidden_size : 1,
-    is_nchw ? num_experts : hidden_size,
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     nntrainer::TensorDim::DataType::FP32),
-    is_nchw ? 0b0011 : 0b0101);
-
   gate_idx = context.requestWeight(
-    gate_dim, weight_initializer, weight_regularizer,
+    weight_dims[0], weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "gate", true);
 
   // 5. Initializer expert weights
@@ -114,51 +103,35 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
   expert_up_proj_indices.reserve(num_experts);
   expert_down_proj_indices.reserve(num_experts);
 
-  nntrainer::TensorDim expert_gate_dim(
-    1, is_nchw ? 1 : intermediate_size, is_nchw ? hidden_size : 1,
-    is_nchw ? intermediate_size : hidden_size,
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
-
-  nntrainer::TensorDim expert_down_dim(
-    1, is_nchw ? 1 : hidden_size, is_nchw ? intermediate_size : 1,
-    is_nchw ? hidden_size : intermediate_size,
-    nntrainer::TensorDim::TensorType(context.getFormat(),
-                                     context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
-
   for (unsigned int i = 0; i < num_experts; ++i) {
     // Up projection
     expert_up_proj_indices.push_back(context.requestWeight(
-      expert_gate_dim, // Same dimensions as gate projection
-      weight_initializer, weight_regularizer, weight_regularizer_constant,
-      weight_decay, "expert_up_" + std::to_string(i), false, true));
+      weight_dims[1 + 3 * i], weight_initializer, weight_regularizer,
+      weight_regularizer_constant, weight_decay,
+      "expert_up_" + std::to_string(i), false, true));
 
     // Gate projection
     expert_gate_proj_indices.push_back(context.requestWeight(
-      expert_gate_dim, weight_initializer, weight_regularizer,
+      weight_dims[2 + 3 * i], weight_initializer, weight_regularizer,
       weight_regularizer_constant, weight_decay,
       "expert_gate_" + std::to_string(i), false, true));
 
     // Down projection
     expert_down_proj_indices.push_back(context.requestWeight(
-      expert_down_dim, weight_initializer, weight_regularizer,
+      weight_dims[3 + 3 * i], weight_initializer, weight_regularizer,
       weight_regularizer_constant, weight_decay,
       "expert_down_" + std::to_string(i), false, true));
     need_load.push_back(true);
   }
 
   // 6. Request intermediate tensors
-  const unsigned batch_size = in_dim.batch();
-  const unsigned seq_len = in_dim.height();
-  const unsigned total_tokens = batch_size * seq_len;
+  router_logits_idx = context.requestTensor(
+    tensor_dims[0], "router_logits", nntrainer::Initializer::NONE, false,
+    nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 
-  // Router logits :  [batch * seq, num_experts]
-  router_logits_idx =
-    context.requestTensor({total_tokens, 1, 1, num_experts}, "router_logits",
-                          nntrainer::Initializer::NONE, false,
-                          nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
+  expert_mask_idx = context.requestTensor(
+    tensor_dims[1], "expert_mask", nntrainer::Initializer::ZEROS, false,
+    nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 }
 
 void CachedSlimMoELayer::forwarding(nntrainer::RunLayerContext &context,
@@ -504,9 +477,62 @@ void CachedSlimMoELayer::exportTo(
 std::array<std::vector<nntrainer::TensorDim>, 3>
 CachedSlimMoELayer::getLayerDimensions(nntrainer::InitLayerContext &context) {
   const auto &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+  const bool is_nchw = context.getFormat() == nntrainer::Tformat::NCHW;
+  const unsigned batch_size = in_dim.batch();
+  const unsigned seq_len = in_dim.height();
+  const unsigned total_tokens = batch_size * seq_len;
+
   std::vector<nntrainer::TensorDim> output_dims(1);
   output_dims[SINGLE_INOUT_IDX] = in_dim;
-  return {output_dims, {}, {}};
+
+  // Num experts, topk, intermediate size, hidden size
+  unsigned int num_experts = std::get<props::NumExperts>(moe_props).get();
+  unsigned int topk = std::get<props::NumExpertsPerToken>(moe_props).get();
+  const unsigned int intermediate_size =
+    std::get<nntrainer::props::Unit>(moe_props).get();
+  const unsigned int hidden_size = in_dim.width(); // Feature dimension
+
+  // 1. Gather Weight Dimensions (Gate + Experts)
+  std::vector<nntrainer::TensorDim> weight_dims;
+
+  // Gate Weight
+  nntrainer::TensorDim gate_dim(
+    1, is_nchw ? 1 : num_experts, is_nchw ? hidden_size : 1,
+    is_nchw ? num_experts : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     nntrainer::TensorDim::DataType::FP32),
+    is_nchw ? 0b0011 : 0b0101);
+  weight_dims.push_back(gate_dim);
+
+  // Expert Weights (Up, Gate, Down for each expert)
+  nntrainer::TensorDim expert_gate_dim(
+    1, is_nchw ? 1 : intermediate_size, is_nchw ? hidden_size : 1,
+    is_nchw ? intermediate_size : hidden_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  nntrainer::TensorDim expert_down_dim(
+    1, is_nchw ? 1 : hidden_size, is_nchw ? intermediate_size : 1,
+    is_nchw ? hidden_size : intermediate_size,
+    nntrainer::TensorDim::TensorType(context.getFormat(),
+                                     context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+
+  for (unsigned int i = 0; i < num_experts; ++i) {
+    weight_dims.push_back(
+      expert_gate_dim); // Up projection (using same gate dim shape)
+    weight_dims.push_back(expert_gate_dim); // Gate projection
+    weight_dims.push_back(expert_down_dim); // Down projection
+  }
+
+  // 2. Gather Temporary Tensor Dimensions
+  std::vector<nntrainer::TensorDim> tensor_dims(2);
+  tensor_dims[0] = nntrainer::TensorDim({total_tokens, 1, 1, num_experts});
+  tensor_dims[1] = nntrainer::TensorDim({num_experts, 1, topk, total_tokens});
+
+  return std::array<std::vector<nntrainer::TensorDim>, 3>{
+    output_dims, weight_dims, tensor_dims};
 }
 
 std::vector<nntrainer::TensorDim>
@@ -519,6 +545,9 @@ CachedSlimMoELayer::updateTensorsByInputDimensions(
   run_context.updateInput(SINGLE_INOUT_IDX,
                           init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
   run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  run_context.updateTensor(router_logits_idx, tensor_dims[0]);
+  run_context.updateTensor(expert_mask_idx, tensor_dims[1]);
 
   return output_dims;
 }

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -128,10 +128,6 @@ void CachedSlimMoELayer::finalize(nntrainer::InitLayerContext &context) {
   router_logits_idx = context.requestTensor(
     tensor_dims[0], "router_logits", nntrainer::Initializer::NONE, false,
     nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
-
-  expert_mask_idx = context.requestTensor(
-    tensor_dims[1], "expert_mask", nntrainer::Initializer::ZEROS, false,
-    nntrainer::TensorLifespan::FORWARD_FUNC_LIFESPAN);
 }
 
 void CachedSlimMoELayer::forwarding(nntrainer::RunLayerContext &context,
@@ -547,7 +543,6 @@ CachedSlimMoELayer::updateTensorsByInputDimensions(
   run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
 
   run_context.updateTensor(router_logits_idx, tensor_dims[0]);
-  run_context.updateTensor(expert_mask_idx, tensor_dims[1]);
 
   return output_dims;
 }

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -501,18 +501,4 @@ void CachedSlimMoELayer::exportTo(
   exporter.saveResult(moe_props, method, this); // Save MoE specific properties
 }
 
-void CachedSlimMoELayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  ml::train::TensorDim input_dim = context.getInput(SINGLE_INOUT_IDX).getDim();
-  ml::train::TensorDim output_dim =
-    context.getOutput(SINGLE_INOUT_IDX).getDim();
-
-  input_dim.height(input_dimensions[0].height());
-  output_dim.height(input_dimensions[0].height());
-
-  context.updateInput(SINGLE_INOUT_IDX, input_dim);
-  context.updateOutput(SINGLE_INOUT_IDX, output_dim);
-}
-
 } // namespace causallm

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -116,9 +116,6 @@ public:
    */
   bool supportBackwarding() const override { return false; }
 
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
   static constexpr const char *type =
     "moe_cached_slim"; /**< type of the layer */
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -119,7 +119,6 @@ public:
   void updateTensorsByInputDimensions(
     nntrainer::RunLayerContext &context,
     std::vector<nntrainer::TensorDim> input_dimensions) override;
-
   static constexpr const char *type =
     "moe_cached_slim"; /**< type of the layer */
 

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -74,11 +74,10 @@ public:
    * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
    */
   std::array<std::vector<nntrainer::TensorDim>, 3>
-  getLayerDimensions(nntrainer::InitLayerContext &context);
+  getLayerDimensions(nntrainer::InitLayerContext &context) override;
 
   /**
-   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext &context,
-   * RunLayerContext &run_context)
+   * @copydoc Layer::updateTensorsByInputDimensions(...)
    */
   std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
     nntrainer::InitLayerContext &init_context,

--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.h
@@ -71,6 +71,20 @@ public:
   void finalize(nntrainer::InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<nntrainer::TensorDim>, 3>
+  getLayerDimensions(nntrainer::InitLayerContext &context);
+
+  /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext &context,
+   * RunLayerContext &run_context)
+   */
+  std::vector<nntrainer::TensorDim> updateTensorsByInputDimensions(
+    nntrainer::InitLayerContext &init_context,
+    nntrainer::RunLayerContext &run_context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(nntrainer::RunLayerContext &context, bool training) override;

--- a/api/ccapi/include/model.h
+++ b/api/ccapi/include/model.h
@@ -409,19 +409,15 @@ public:
                         unsigned int to, bool output_hidden_state = false) = 0;
 
   /**
-   * @brief     reset input dimensions of a model
-   * @param[in] dims input dimensions
-   * @note Similar to reinitialize, the resetInputDimension API is used for
-   * modifying input dimensions after model initialization. The reinitialize
-   * function should be the officially called API when changing input
-   * dimensions, as it properly recalculates weights, tensors, and outputs for
-   * each layer. On the other hand, resetInputDimension is a specialized API
-   * created to modify only specific dimensions (specifically height values)
-   * within input/output dimensions. Since this API uniformly adjusts the height
-   * across all model layers, developers must verify that every layer in their
-   * model architecture can safely accommodate such height modifications.
+   * @brief     Reset input dimensions of a model
+   * @param[in] model_input_dims input dimensions
+   * @note resetInputDimension recalculates ans sets the dimensions of the
+   * outputs and the tensors according to the given input for each layer.
+   * However it must be guaranteed that the weight dimensions remain unchanged.
+   * If not, it will raise an error.
    */
-  virtual void resetInputDimension(std::vector<ml::train::TensorDim> dims) = 0;
+  virtual void
+  resetInputDimension(std::vector<ml::train::TensorDim> model_input_dims) = 0;
 
   /**
    * @brief     Summarize the model

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -330,15 +330,54 @@ void NetworkGraph::setBatchSize(unsigned int batch_size) {
     label_dims_[idx] = tensor_manager->getTensor(label_list[idx])->getDim();
 }
 
-void NetworkGraph::resetInputDimension(std::vector<TensorDim> dims) {
+void NetworkGraph::resetInputDimension(
+  std::vector<TensorDim> model_input_dims) {
   auto allocated = tensor_manager->isAllocated();
 
   if (allocated)
     deallocateTensors();
 
-  for (auto iter = cbegin(); iter != cend(); iter++) {
-    if ((*iter)->isFinalized()) {
-      (*iter)->updateTensorsByInputDimensions(dims);
+  std::unordered_map<std::string, std::vector<TensorDim>> input_map;
+
+  auto is_input_node = [](const LayerNode *node) -> bool {
+    return node->getInputConnections().empty();
+  };
+
+  size_t cnt = 0;
+
+  for (unsigned int idx = 0; idx < graph.size() - 1; ++idx) {
+    auto const &lnode = getSortedLayerNode(idx);
+    std::vector<TensorDim> input_dims = {};
+    if (!is_input_node(lnode.get())) {
+      input_dims = input_map.at(getSortedLayerNode(idx)->getName());
+    } else {
+      input_dims = {model_input_dims[cnt++]};
+    }
+
+    auto output_dims = lnode->updateTensorsByInputDimensions(input_dims);
+
+    for (auto i = 0u, num_node = lnode->getNumOutputConnections(); i < num_node;
+         ++i) {
+      auto conn = lnode->getOutputConnection(i);
+      if (!conn) {
+        ml_logi("out connection not defined for  %s, %u",
+                lnode->getName().c_str(), i);
+        continue;
+      }
+
+      auto sink_node = getLayerNode(conn->getName());
+      [[maybe_unused]] auto [it, b] =
+        input_map.try_emplace({sink_node->getName(), {}});
+
+      NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
+                      lnode->getName(),
+                    std::invalid_argument)
+        << "node pair does not match between " << lnode->getName() << ' '
+        << sink_node->getName();
+
+      auto &sink_tensors = it->second;
+      sink_tensors.resize(sink_node->getNumInputConnections());
+      sink_tensors[conn->getIndex()] = output_dims[i];
     }
   }
 

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -195,13 +195,16 @@ int NetworkGraph::addLossLayer(const std::string &loss_type_) {
 void NetworkGraph::setOutputConnections() {
   for (auto layer_iter = cbegin(); layer_iter != cend(); layer_iter++) {
     const auto &node = *layer_iter;
-    for (auto i = 0u, num_inode = node->getNumInputConnections(); i < num_inode;
-         ++i) {
+    for (unsigned int i = 0; i < node->getNumInputConnections(); ++i) {
       const auto &name = node->getInputConnectionName(i);
       const auto &idx = node->getInputConnectionIndex(i);
 
       auto node_setting_output = getLayerNode(name);
-      node_setting_output->setOutputConnection(idx, node->getName(), i);
+      if (node_setting_output) {
+        node_setting_output->setOutputConnection(idx, node->getName(), i);
+      } else {
+        ml_logi("node_setting_output not found for connection %s", name.c_str());
+      }
     }
   }
 }
@@ -354,7 +357,7 @@ void NetworkGraph::resetInputDimension(
         input_dims = it->second;
       }
     } else {
-      input_dims = {model_input_dims[cnt++]};
+      input_dims.push_back(model_input_dims[cnt++]);
     }
 
     auto output_dims = lnode->updateTensorsByInputDimensions(input_dims);
@@ -370,7 +373,7 @@ void NetworkGraph::resetInputDimension(
 
       auto sink_node = getLayerNode(conn->getName());
       [[maybe_unused]] auto [it, b] =
-        input_map.try_emplace({sink_node->getName(), {}});
+        input_map.try_emplace(sink_node->getName());
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
                       lnode->getName(),
@@ -1268,7 +1271,7 @@ int NetworkGraph::initialize(ExecutionMode mode,
 
       auto sink_node = getLayerNode(conn->getName());
       [[maybe_unused]] auto [it, b] =
-        input_map.try_emplace({sink_node->getName(), {}});
+        input_map.try_emplace(sink_node->getName());
 
       NNTR_THROW_IF(sink_node->getInputConnectionName(conn->getIndex()) !=
                       lnode->getName(),

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -349,7 +349,10 @@ void NetworkGraph::resetInputDimension(
     auto const &lnode = getSortedLayerNode(idx);
     std::vector<TensorDim> input_dims = {};
     if (!is_input_node(lnode.get())) {
-      input_dims = input_map.at(getSortedLayerNode(idx)->getName());
+      auto it = input_map.find(lnode->getName());
+      if (it != input_map.end()) {
+        input_dims = it->second;
+      }
     } else {
       input_dims = {model_input_dims[cnt++]};
     }

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -203,7 +203,8 @@ void NetworkGraph::setOutputConnections() {
       if (node_setting_output) {
         node_setting_output->setOutputConnection(idx, node->getName(), i);
       } else {
-        ml_logi("node_setting_output not found for connection %s", name.c_str());
+        ml_logi("node_setting_output not found for connection %s",
+                name.c_str());
       }
     }
   }

--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -345,7 +345,7 @@ void NetworkGraph::resetInputDimension(
 
   size_t cnt = 0;
 
-  for (unsigned int idx = 0; idx < graph.size() - 1; ++idx) {
+  for (unsigned int idx = 0; idx < graph.size(); ++idx) {
     auto const &lnode = getSortedLayerNode(idx);
     std::vector<TensorDim> input_dims = {};
     if (!is_input_node(lnode.get())) {

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -35,6 +35,7 @@ class Connection;
  * @brief   NeuralNetwork Graph Class which manage layers
  */
 class NetworkGraph {
+  friend class NeuralNetwork;
 public:
   /**
    * @brief     Constructor of NeuralNetwork Graph Class

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -201,19 +201,14 @@ public:
   void setBatchSize(unsigned int batch_size);
 
   /**
-   * @brief     reset input dimensions of a model
-   * @param[in] dims input dimensions
-   * @note Similar to reinitialize, the resetInputDimension API is used for
-   * modifying input dimensions after model initialization. The reinitialize
-   * function should be the officially called API when changing input
-   * dimensions, as it properly recalculates weights, tensors, and outputs for
-   * each layer. On the other hand, resetInputDimension is a specialized API
-   * created to modify only specific dimensions (specifically height values)
-   * within input/output dimensions. Since this API uniformly adjusts the height
-   * across all model layers, developers must verify that every layer in their
-   * model architecture can safely accommodate such height modifications.
+   * @brief     Reset input dimensions of a model
+   * @param[in] model_input_dims input dimensions
+   * @note resetInputDimension recalculates ans sets the dimensions of the
+   * outputs and the tensors according to the given input for each layer.
+   * However it must be guaranteed that the weight dimensions remain unchanged.
+   * If not, it will raise an error.
    */
-  void resetInputDimension(std::vector<TensorDim> dims);
+  void resetInputDimension(std::vector<TensorDim> model_input_dims);
 
   /**
    * @brief try apply gradient if possible

--- a/nntrainer/graph/network_graph.h
+++ b/nntrainer/graph/network_graph.h
@@ -36,6 +36,7 @@ class Connection;
  */
 class NetworkGraph {
   friend class NeuralNetwork;
+
 public:
   /**
    * @brief     Constructor of NeuralNetwork Graph Class

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -24,9 +24,12 @@ namespace nntrainer {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void AdditionLayer::finalize(InitLayerContext &context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+  context.setOutputDimensions(output_dims);
+
   if (!std::get<props::SkipPrefill>(add_props).empty())
     skip_prefill = std::get<props::SkipPrefill>(add_props).get();
-  context.setOutputDimensions({context.getInputDimensions()[0]});
 }
 
 void AdditionLayer::forwarding(RunLayerContext &context, bool training) {

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -112,4 +112,21 @@ void AdditionLayer::updateTensorsByInputDimensions(
   context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
+std::array<std::vector<TensorDim>, 3>
+AdditionLayer::getLayerDimensions(InitLayerContext &context) {
+  std::vector<TensorDim> output_dims(1);
+  output_dims[SINGLE_INOUT_IDX] =
+    context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  NNTR_THROW_IF(std::any_of(context.getInputDimensions().cbegin(),
+                            context.getInputDimensions().cend(),
+                            [&output_dims](const TensorDim &dim) {
+                              return output_dims[SINGLE_INOUT_IDX] != dim;
+                            }),
+                std::invalid_argument)
+    << "All of input dimensions of addition layer SHOULD BE identical";
+
+  return {output_dims, {}, {}};
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/addition_layer.cpp
+++ b/nntrainer/layers/addition_layer.cpp
@@ -32,6 +32,20 @@ void AdditionLayer::finalize(InitLayerContext &context) {
     skip_prefill = std::get<props::SkipPrefill>(add_props).get();
 }
 
+std::vector<TensorDim>
+AdditionLayer::updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                              RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  for (size_t i = 0; i < run_context.getNumInputs(); ++i) {
+    run_context.updateInput(i, init_context.getInputDimensions()[i]);
+  }
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void AdditionLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
 
@@ -104,15 +118,6 @@ void AdditionLayer::setProperty(const std::vector<std::string> &values) {
                       std::to_string(values.size());
     throw exception::not_supported(msg);
   }
-}
-
-void AdditionLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  for (size_t i = 0; i < context.getNumInputs(); ++i) {
-    context.updateInput(i, input_dimensions[0]);
-  }
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
 std::array<std::vector<TensorDim>, 3>

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -54,6 +54,14 @@ public:
   void finalize(InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  std::vector<TensorDim>
+  updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                 RunLayerContext &context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(RunLayerContext &context, bool training) override;

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -100,10 +100,6 @@ public:
    */
   const std::string getType() const override { return AdditionLayer::type; };
 
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
-
   std::tuple<props::Print, props::SkipPrefill>
     add_props; /**< fc layer properties : unit - number of output neurons */
   bool skip_prefill = false;

--- a/nntrainer/layers/addition_layer.h
+++ b/nntrainer/layers/addition_layer.h
@@ -101,6 +101,13 @@ public:
   bool skip_prefill = false;
 
   static constexpr const char *type = "addition";
+
+private:
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<TensorDim>, 3>
+  getLayerDimensions(InitLayerContext &context) override;
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -408,4 +408,98 @@ void FullyConnectedLayer::calcGradient(RunLayerContext &context) {
   }
 }
 
+std::array<std::vector<TensorDim>, 3>
+FullyConnectedLayer::getLayerDimensions(InitLayerContext &context) {
+  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
+    << "Fully connected layer takes only one input";
+
+  auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
+  const auto &unit = std::get<props::Unit>(fc_props).get();
+  const auto &lora_rank = (std::get<props::LoraRank>(fc_props).empty())
+                            ? 0
+                            : std::get<props::LoraRank>(fc_props).get();
+
+  /// @todo fc actaully supports multidimensions. EffDimFlag shouldn't be fixed
+  /// like this.
+  context.setEffDimFlagInputDimension(0, 0b1001);
+  context.setDynDimFlagInputDimension(0, 0b1000);
+
+  bool is_nchw = (context.getFormat() == Tformat::NCHW);
+  auto const &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  std::vector<TensorDim> output_dims;
+  std::vector<TensorDim> weight_dims;
+  std::vector<TensorDim> tensor_dims;
+
+  TensorDim output_dim = in_dim;
+  is_nchw ? output_dim.width(unit) : output_dim.channel(unit);
+  output_dim.setTensorType(
+    {context.getFormat(), context.getActivationDataType()});
+  output_dims.push_back(output_dim);
+
+  /** set weight specifications */
+  // @todo : This NCHW format setting is just temporal, it needs to be set by
+  // global configuration
+
+  /** Weight Dimension : (1, 1, in_dim.width(), unit)*/
+  TensorDim weight_dim(
+    1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
+    is_nchw ? unit : in_dim.channel(),
+    TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+    is_nchw ? 0b0011 : 0b0101);
+  weight_dims.push_back(weight_dim);
+
+  if (disable_bias.empty() || disable_bias.get() == false) {
+    /** Bias Dimension : (1, 1, 1, unit) */
+    /// @note bias is directly added to activation
+    /// since we have no dequantizer for add operation,
+    /// we have to set its data type as same as activation.
+    /// This should be updated when the dequantizer is supported.
+    TensorDim bias_dim(1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
+                       TensorDim::TensorType(context.getFormat(),
+                                             context.getActivationDataType()),
+                       is_nchw ? 0b0001 : 0b0100);
+    weight_dims.push_back(bias_dim);
+  }
+
+  if (lora_rank) {
+    /** loraA Dimension : (1, 1, in_dim.width, lora_rank) */
+    TensorDim loraA_dim(
+      1, is_nchw ? 1 : lora_rank, is_nchw ? in_dim.width() : 1,
+      is_nchw ? lora_rank : in_dim.channel(),
+      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      is_nchw ? 0b0011 : 0b0101);
+    weight_dims.push_back(loraA_dim);
+
+    /** loraB Dimension : (1, 1, lora_rank, unit) */
+    TensorDim loraB_dim(
+      1, is_nchw ? 1 : unit, is_nchw ? lora_rank : 1,
+      is_nchw ? unit : lora_rank,
+      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
+      is_nchw ? 0b0011 : 0b0101);
+    weight_dims.push_back(loraB_dim);
+
+    /** loraTmp Dimension : (B, 1, in_dim.height(), lora_rank) */
+    TensorDim loraTmp_dim(
+      in_dim.batch(), is_nchw ? 1 : lora_rank, is_nchw ? in_dim.height() : 1,
+      is_nchw ? lora_rank : in_dim.width(),
+      TensorDim::TensorType(context.getFormat(),
+                            context.getActivationDataType()),
+      is_nchw ? 0b1011 : 0b1101);
+    tensor_dims.push_back(loraTmp_dim);
+
+    /** loraTmp Dimension : (B, 1, in_dim.height(), unit) */
+    TensorDim loraOut_dim(
+      in_dim.batch(), is_nchw ? 1 : unit, is_nchw ? in_dim.height() : 1,
+      is_nchw ? unit : in_dim.width(),
+      TensorDim::TensorType(context.getFormat(),
+                            context.getActivationDataType()),
+      is_nchw ? 0b1011 : 0b1101);
+    tensor_dims.push_back(loraOut_dim);
+  }
+
+  return std::array<std::vector<TensorDim>, 3>{output_dims, weight_dims,
+                                               tensor_dims};
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -131,6 +131,18 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   }
 }
 
+std::vector<TensorDim> FullyConnectedLayer::updateTensorsByInputDimensions(
+  InitLayerContext &init_context, RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
+}
+
 void FullyConnectedLayer::exportTo(
   Exporter &exporter, const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -140,6 +140,14 @@ std::vector<TensorDim> FullyConnectedLayer::updateTensorsByInputDimensions(
                           init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
   run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
 
+  const auto &lora_rank = (std::get<props::LoraRank>(fc_props).empty())
+                            ? 0
+                            : std::get<props::LoraRank>(fc_props).get();
+  if (lora_rank) {
+    run_context.updateTensor(lora_idx[LORAParams::loraTmp], tensor_dims[0]);
+    run_context.updateTensor(lora_idx[LORAParams::loraOut], tensor_dims[1]);
+  }
+
   return output_dims;
 }
 

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -60,7 +60,6 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   auto &bias_initializer = std::get<props::BiasInitializer>(*layer_impl_props);
   auto &disable_bias = std::get<props::DisableBias>(*layer_impl_props);
 
-  const auto &unit = std::get<props::Unit>(fc_props).get();
   const auto &lora_rank = (std::get<props::LoraRank>(fc_props).empty())
                             ? 0
                             : std::get<props::LoraRank>(fc_props).get();
@@ -70,61 +69,26 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
   if (!std::get<props::SkipPrefill>(*layer_impl_props).empty())
     skip_prefill = std::get<props::SkipPrefill>(*layer_impl_props).get();
 
-  NNTR_THROW_IF(context.getNumInputs() != 1, std::invalid_argument)
-    << "Fully connected layer takes only one input";
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
 
-  std::vector<TensorDim> output_dims(1);
-
-  /// @todo fc actaully supports multidimensions. EffDimFlag shouldn't be fixed
-  /// like this.
-  context.setEffDimFlagInputDimension(0, 0b1001);
-  context.setDynDimFlagInputDimension(0, 0b1000);
-
-  bool is_nchw = (context.getFormat() == Tformat::NCHW);
   /** set output dimensions */
-  auto const &in_dim = context.getInputDimensions()[0];
-  output_dims[0] = in_dim;
-  is_nchw ? output_dims[0].width(unit) : output_dims[0].channel(unit);
-
-  output_dims[0].setTensorType(
-    {context.getFormat(), context.getActivationDataType()});
-
   context.setOutputDimensions(output_dims);
 
-  /** set weight specifications */
-  // @todo : This NCHW format setting is just temporal, it needs to be set by
-  // global configuration
-
-  /** Bias Dimension : (1, 1, 1, unit) */
-  /// @note Bias is un-quantized and added directly to the activation. Its
-  /// storage dtype must match how it is laid out on disk:
-  ///  - float weight (FP16/FP32): bias is stored in the activation dtype, so
-  ///    request it as such (no cast needed at the add site).
-  ///  - quantized weight (Q4_0/Q6_K/QINT*/...): bias is stored FP32 on disk;
-  ///    requesting it as the (possibly FP16) activation dtype would reinterpret
-  ///    the FP32 bytes and corrupt it. Request FP32 and cast to the activation
-  ///    dtype at the add site below.
-  const auto weight_dtype = context.getWeightDataType();
-  const bool weight_is_float = (weight_dtype == TensorDim::DataType::FP32 ||
-                                weight_dtype == TensorDim::DataType::FP16);
-  const auto bias_dtype = weight_is_float ? context.getActivationDataType()
-                                          : TensorDim::DataType::FP32;
-  TensorDim bias_dim(1, is_nchw ? 1 : unit, 1, is_nchw ? unit : 1,
-                     TensorDim::TensorType(context.getFormat(), bias_dtype),
-                     is_nchw ? 0b0001 : 0b0100);
-
-  /** Weight Dimension : (1, 1, in_dim.width(), unit)*/
-  TensorDim weight_dim(
-    1, is_nchw ? 1 : unit, is_nchw ? in_dim.width() : 1,
-    is_nchw ? unit : in_dim.channel(),
-    TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
-    is_nchw ? 0b0011 : 0b0101);
-
+  TensorDim weight_dim = weight_dims[FCParams::weight];
   weight_idx[FCParams::weight] = context.requestWeight(
     weight_dim, weight_initializer, weight_regularizer,
     weight_regularizer_constant, weight_decay, "weight", true);
 
   if (disable_bias.empty() || disable_bias.get() == false) {
+    TensorDim bias_dim = weight_dims[FCParams::bias];
+    const auto weight_dtype = context.getWeightDataType();
+    const bool weight_is_float = (weight_dtype == TensorDim::DataType::FP32 ||
+                                  weight_dtype == TensorDim::DataType::FP16);
+    const auto bias_dtype = weight_is_float ? context.getActivationDataType()
+                                            : TensorDim::DataType::FP32;
+    bias_dim.setDataType(bias_dtype);
+
     weight_idx[FCParams::bias] =
       context.requestWeight(bias_dim, bias_initializer, WeightRegularizer::NONE,
                             1.0f, bias_decay, "bias", true);
@@ -132,49 +96,22 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
 
   /** create weights for LoRA */
   if (lora_rank) {
-
-    /** loraA Dimension : (1, 1, in_dim.width, lora_rank) */
-    TensorDim loraA_dim(
-      1, is_nchw ? 1 : lora_rank, is_nchw ? in_dim.width() : 1,
-      is_nchw ? lora_rank : in_dim.channel(),
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
-      is_nchw ? 0b0011 : 0b0101);
-
-    /** loraB Dimension : (1, 1, lora_rank, unit) */
-    TensorDim loraB_dim(
-      1, is_nchw ? 1 : unit, is_nchw ? lora_rank : 1,
-      is_nchw ? unit : lora_rank,
-      TensorDim::TensorType(context.getFormat(), context.getWeightDataType()),
-      is_nchw ? 0b0011 : 0b0101);
-
-    /** loraTmp Dimension : (B, 1, in_dim.height(), lora_rank) */
-    TensorDim loraTmp_dim(
-      in_dim.batch(), is_nchw ? 1 : lora_rank, is_nchw ? in_dim.height() : 1,
-      is_nchw ? lora_rank : in_dim.width(),
-      TensorDim::TensorType(context.getFormat(),
-                            context.getActivationDataType()),
-      is_nchw ? 0b1011 : 0b1101);
-
-    /** loraTmp Dimension : (B, 1, in_dim.height(), unit) */
-    TensorDim loraOut_dim(
-      in_dim.batch(), is_nchw ? 1 : unit, is_nchw ? in_dim.height() : 1,
-      is_nchw ? unit : in_dim.width(),
-      TensorDim::TensorType(context.getFormat(),
-                            context.getActivationDataType()),
-      is_nchw ? 0b1011 : 0b1101);
-
+    TensorDim loraA_dim = weight_dims[weight_dims.size() - 2];
     lora_idx[LORAParams::loraA] = context.requestWeight(
       loraA_dim, Initializer::ZEROS, weight_regularizer,
       weight_regularizer_constant, weight_decay, "loraA", true);
 
+    TensorDim loraB_dim = weight_dims[weight_dims.size() - 1];
     lora_idx[LORAParams::loraB] = context.requestWeight(
       loraB_dim, Initializer::LECUN_NORMAL, weight_regularizer,
       weight_regularizer_constant, weight_decay, "loraB", true);
 
+    TensorDim loraTmp_dim = tensor_dims[0];
     lora_idx[LORAParams::loraTmp] =
       context.requestTensor(loraTmp_dim, "hidden_tmp_lora", Initializer::NONE,
                             true, TensorLifespan::FORWARD_GRAD_LIFESPAN);
 
+    TensorDim loraOut_dim = tensor_dims[1];
     lora_idx[LORAParams::loraOut] =
       context.requestTensor(loraOut_dim, "hidden_lora", Initializer::NONE, true,
                             TensorLifespan::FORWARD_FUNC_LIFESPAN);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -54,6 +54,14 @@ public:
   void finalize(InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  std::vector<TensorDim>
+  updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                 RunLayerContext &context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(RunLayerContext &context, bool training) override;

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -128,6 +128,12 @@ private:
   std::array<unsigned int, 4> lora_idx;   /**< indices of the lora weights */
   std::unique_ptr<nntrainer::Quantizer> quantizer;
   bool skip_prefill = false;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<TensorDim>, 3>
+  getLayerDimensions(InitLayerContext &context) override;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -84,14 +84,10 @@ void InputLayer::exportTo(Exporter &exporter,
 }
 
 void InputLayer::finalize(InitLayerContext &context) {
-
-  std::vector<TensorDim> output_dims = context.getInputDimensions();
-  // Preserve the declared input dtype — the previous behaviour of silently
-  // promoting FP32 inputs to the model's activation dtype clobbers integer-
-  // valued inputs (e.g. embedding token IDs) when the model runs at FP16.
-  // Models that want a dtype change should declare it on the input layer
-  // (input_dtype=FP16) instead of relying on an implicit promotion here.
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
   context.setOutputDimensions(output_dims);
+
   is_inplace = output_dims == context.getInputDimensions();
 }
 
@@ -104,13 +100,7 @@ void InputLayer::updateTensorsByInputDimensions(
 
 std::array<std::vector<TensorDim>, 3>
 InputLayer::getLayerDimensions(InitLayerContext &context) {
-  TensorDim::DataType output_dtype = context.getActivationDataType();
-
   std::vector<TensorDim> output_dims = context.getInputDimensions();
-  for (auto &d : output_dims) {
-    d.setDataType(output_dtype);
-  }
-
   return {output_dims, {}, {}};
 }
 

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -91,11 +91,17 @@ void InputLayer::finalize(InitLayerContext &context) {
   is_inplace = output_dims == context.getInputDimensions();
 }
 
-void InputLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-  context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
+std::vector<TensorDim>
+InputLayer::updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                           RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  run_context.updateOutput(SINGLE_INOUT_IDX, output_dims[SINGLE_INOUT_IDX]);
+
+  return output_dims;
 }
 
 std::array<std::vector<TensorDim>, 3>

--- a/nntrainer/layers/input_layer.cpp
+++ b/nntrainer/layers/input_layer.cpp
@@ -102,4 +102,16 @@ void InputLayer::updateTensorsByInputDimensions(
   context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
+std::array<std::vector<TensorDim>, 3>
+InputLayer::getLayerDimensions(InitLayerContext &context) {
+  TensorDim::DataType output_dtype = context.getActivationDataType();
+
+  std::vector<TensorDim> output_dims = context.getInputDimensions();
+  for (auto &d : output_dims) {
+    d.setDataType(output_dtype);
+  }
+
+  return {output_dims, {}, {}};
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -113,6 +113,12 @@ public:
 
 private:
   std::tuple<props::Normalization, props::Standardization> input_props;
+
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<TensorDim>, 3>
+  getLayerDimensions(InitLayerContext &context) override;
 };
 } // namespace nntrainer
 

--- a/nntrainer/layers/input_layer.h
+++ b/nntrainer/layers/input_layer.h
@@ -65,6 +65,14 @@ public:
   void finalize(InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  std::vector<TensorDim>
+  updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                 RunLayerContext &context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(RunLayerContext &context, bool training) override;
@@ -104,10 +112,6 @@ public:
    * @copydoc Layer::setProperty(const std::vector<std::string> &values)
    */
   void setProperty(const std::vector<std::string> &values) override;
-
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   static constexpr const char *type = "input";
 

--- a/nntrainer/layers/layer_context.h
+++ b/nntrainer/layers/layer_context.h
@@ -425,6 +425,8 @@ public:
    */
   bool isMixedTraining() { return istrequal(tensor_type[1], "FP32"); }
 
+  void setInputDimension(std::vector<TensorDim> dim) { input_dim = dim; }
+
 private:
   std::vector<TensorDim> input_dim; /**< Input dimensions for the layer */
   bool is_inplace;           /**< if the layer is expected to run in-place */

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -176,6 +176,20 @@ public:
   virtual const std::string getType() const = 0;
 
   /**
+   * @brief     get output, weight and tensor dimensions of layer
+   * @param     context Context of the layer
+   *
+   * @details   Input dimensions will be provided set in the context. This
+   * function must set output dimensions in the given context. Further, context
+   * can be finalze weights for the layer, and any extra tensor required
+   * for the operation of the layer.
+   */
+  virtual std::array<std::vector<TensorDim>, 3>
+  getLayerDimensions(InitLayerContext &context) {
+    return {std::move(context.getInputDimensions()), {}, {}};
+  };
+
+  /**
    * @brief     Finalize creating the layer
    * @param     context Context of the layer
    *

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -302,14 +302,14 @@ public:
 
   /**
    * @brief Update the tensor dimensions of layer by input dimensions
-   * @param     context Context of the layer
-   * @param     input_dimensions input dimensions of layer
+   * @param     init_context InitLayerContext of the layer
+   * @param     run_context RunLayerContext of the layer
    * @details Update the dimensions of inputs, outputs, weights and tensors
    * based on the input dimensions
    */
-  virtual void
-  updateTensorsByInputDimensions(RunLayerContext &context,
-                                 std::vector<TensorDim> input_dimensions) {
+  virtual std::vector<TensorDim>
+  updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                 RunLayerContext &run_context) {
     throw std::invalid_argument("updateTensorsByInputDimensions() is currently "
                                 "not supported for layer type " +
                                 getType());

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -668,9 +668,7 @@ InitLayerContext LayerNode::finalize(const std::vector<TensorDim> &input_dims,
 
   layer->finalize(context);
 
-#ifdef ENABLE_TEST
   init_context = std::make_unique<InitLayerContext>(context);
-#endif // ENABLE_TEST
 
 #ifdef PROFILE
   auto profile_name = [this](const char *suffix) {
@@ -891,12 +889,15 @@ void LayerNode::setBatch(unsigned int batch) {
   getLayer()->setBatch(*run_context, batch);
 }
 
-void LayerNode::updateTensorsByInputDimensions(
+std::vector<TensorDim> LayerNode::updateTensorsByInputDimensions(
   std::vector<TensorDim> input_dimensions) {
   NNTR_THROW_IF(!run_context, std::invalid_argument)
     << " update tensors not supported before initialization";
 
-  getLayer()->updateTensorsByInputDimensions(*run_context, input_dimensions);
+  init_context->setInputDimension(input_dimensions);
+
+  return getLayer()->updateTensorsByInputDimensions(*init_context,
+                                                    *run_context);
 }
 
 /**

--- a/nntrainer/layers/layer_node.cpp
+++ b/nntrainer/layers/layer_node.cpp
@@ -896,8 +896,23 @@ std::vector<TensorDim> LayerNode::updateTensorsByInputDimensions(
 
   init_context->setInputDimension(input_dimensions);
 
-  return getLayer()->updateTensorsByInputDimensions(*init_context,
-                                                    *run_context);
+  auto output_dims =
+    getLayer()->updateTensorsByInputDimensions(*init_context, *run_context);
+
+  // Defensive weight dimension check to prevent dynamic weight resizing at
+  // runtime
+  auto weight_dims = std::get<1>(getLayer()->getLayerDimensions(*init_context));
+  for (unsigned int i = 0; i < weight_dims.size(); ++i) {
+    NNTR_THROW_IF(run_context->getWeight(i).getDim() != weight_dims[i],
+                  std::invalid_argument)
+      << "The input to be changed triggers a change in the previously "
+         "allocated weight dimensions for layer "
+      << getName() << " at index " << i
+      << ". Original: " << run_context->getWeight(i).getDim()
+      << ", New: " << weight_dims[i];
+  }
+
+  return output_dims;
 }
 
 /**

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -357,7 +357,8 @@ public:
    * @details Update the dimensions of inputs, outputs, weights, tensors based
    * on the input dimensions
    */
-  void updateTensorsByInputDimensions(std::vector<TensorDim> input_dimensions);
+  std::vector<TensorDim>
+  updateTensorsByInputDimensions(std::vector<TensorDim> input_dimensions);
 
   /**
    * @brief   If the current layer can support in-place
@@ -1044,14 +1045,12 @@ private:
   ml::train::LayerComputeEngine compute_engine =
     ml::train::LayerComputeEngine::CPU;
 
-#ifdef ENABLE_TEST
   /**
    * @brief   Init context which is stored for debugging issue
    *
    * @note init context is stored only for testing purpose
    */
   std::unique_ptr<InitLayerContext> init_context;
-#endif // ENABLE_TEST
 
   std::unique_ptr<RunLayerContext>
     run_context; /**< context required for running/execution of the layer. This

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -23,11 +23,9 @@ namespace nntrainer {
 static constexpr size_t SINGLE_INOUT_IDX = 0;
 
 void MultiOutLayer::finalize(InitLayerContext &context) {
-  std::vector<TensorDim> out_dims(context.getNumRequestedOutputs());
-  const TensorDim &in_dim = context.getInputDimensions()[0];
-
-  std::fill(out_dims.begin(), out_dims.end(), in_dim);
-  context.setOutputDimensions(out_dims);
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(context);
+  context.setOutputDimensions(output_dims);
 }
 
 void MultiOutLayer::forwarding(RunLayerContext &context, bool training) {

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -98,4 +98,14 @@ void MultiOutLayer::updateTensorsByInputDimensions(
   }
 }
 
+std::array<std::vector<TensorDim>, 3>
+MultiOutLayer::getLayerDimensions(InitLayerContext &context) {
+  std::vector<TensorDim> out_dims(context.getNumRequestedOutputs());
+  const TensorDim &in_dim = context.getInputDimensions()[SINGLE_INOUT_IDX];
+
+  std::fill(out_dims.begin(), out_dims.end(), in_dim);
+
+  return {out_dims, {}, {}};
+}
+
 } /* namespace nntrainer */

--- a/nntrainer/layers/multiout_layer.cpp
+++ b/nntrainer/layers/multiout_layer.cpp
@@ -28,6 +28,21 @@ void MultiOutLayer::finalize(InitLayerContext &context) {
   context.setOutputDimensions(output_dims);
 }
 
+std::vector<TensorDim>
+MultiOutLayer::updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                              RunLayerContext &run_context) {
+  [[maybe_unused]] auto [output_dims, weight_dims, tensor_dims] =
+    getLayerDimensions(init_context);
+
+  run_context.updateInput(SINGLE_INOUT_IDX,
+                          init_context.getInputDimensions()[SINGLE_INOUT_IDX]);
+  for (size_t i = 0; i < run_context.getNumOutputs(); ++i) {
+    run_context.updateOutput(i, output_dims[i]);
+  }
+
+  return output_dims;
+}
+
 void MultiOutLayer::forwarding(RunLayerContext &context, bool training) {
   if (!context.getInPlace()) {
     const Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
@@ -83,16 +98,6 @@ void MultiOutLayer::setProperty(const std::vector<std::string> &values) {
     std::string msg = "[MultioutLayer] Unknown Layer Properties count " +
                       std::to_string(values.size());
     throw exception::not_supported(msg);
-  }
-}
-
-void MultiOutLayer::updateTensorsByInputDimensions(
-  nntrainer::RunLayerContext &context,
-  std::vector<nntrainer::TensorDim> input_dimensions) {
-  context.updateInput(SINGLE_INOUT_IDX, input_dimensions[0]);
-
-  for (size_t i = 0; i < context.getNumOutputs(); ++i) {
-    context.updateOutput(i, input_dimensions[0]);
   }
 }
 

--- a/nntrainer/layers/multiout_layer.h
+++ b/nntrainer/layers/multiout_layer.h
@@ -104,6 +104,13 @@ public:
     std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   static constexpr const char *type = "multiout";
+
+private:
+  /**
+   * @copydoc Layer::getLayerDimensions(InitLayerContext &context)
+   */
+  std::array<std::vector<TensorDim>, 3>
+  getLayerDimensions(InitLayerContext &context) override;
 };
 
 } // namespace nntrainer

--- a/nntrainer/layers/multiout_layer.h
+++ b/nntrainer/layers/multiout_layer.h
@@ -52,6 +52,14 @@ public:
   void finalize(InitLayerContext &context) override;
 
   /**
+   * @copydoc Layer::updateTensorsByInputDimensions(InitLayerContext
+   * &init_context, RunLayerContext &context)
+   */
+  std::vector<TensorDim>
+  updateTensorsByInputDimensions(InitLayerContext &init_context,
+                                 RunLayerContext &context) override;
+
+  /**
    * @copydoc Layer::forwarding(RunLayerContext &context, bool training)
    */
   void forwarding(RunLayerContext &context, bool training) override;
@@ -98,10 +106,6 @@ public:
    * @copydoc Layer::getType()
    */
   const std::string getType() const override { return MultiOutLayer::type; };
-
-  void updateTensorsByInputDimensions(
-    nntrainer::RunLayerContext &context,
-    std::vector<nntrainer::TensorDim> input_dimensions) override;
 
   static constexpr const char *type = "multiout";
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -77,6 +77,16 @@ namespace nntrainer {
 namespace {
 
 Tensor mapExternalTensor(float *buf, const TensorDim &dim) {
+  if (dim.getDataLen() == 0) {
+    throw std::invalid_argument(
+      "[mapExternalTensor] empty tensor dim is not allowed: dim = [" +
+      std::to_string(dim.batch()) + ", " +
+      std::to_string(dim.channel()) + ", " +
+      std::to_string(dim.height()) + ", " +
+      std::to_string(dim.width()) + "]"
+    );
+  }
+
   const unsigned int bytes = static_cast<unsigned int>(
     static_cast<size_t>(dim.getDataLen()) * dim.getDataTypeSize());
 

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -80,11 +80,9 @@ Tensor mapExternalTensor(float *buf, const TensorDim &dim) {
   if (dim.getDataLen() == 0) {
     throw std::invalid_argument(
       "[mapExternalTensor] empty tensor dim is not allowed: dim = [" +
-      std::to_string(dim.batch()) + ", " +
-      std::to_string(dim.channel()) + ", " +
-      std::to_string(dim.height()) + ", " +
-      std::to_string(dim.width()) + "]"
-    );
+      std::to_string(dim.batch()) + ", " + std::to_string(dim.channel()) +
+      ", " + std::to_string(dim.height()) + ", " + std::to_string(dim.width()) +
+      "]");
   }
 
   const unsigned int bytes = static_cast<unsigned int>(

--- a/nntrainer/models/neuralnet.cpp
+++ b/nntrainer/models/neuralnet.cpp
@@ -1634,8 +1634,11 @@ std::vector<float *> NeuralNetwork::incremental_inference(
   return output;
 }
 
-void NeuralNetwork::resetInputDimension(std::vector<TensorDim> dims) {
-  model_graph.resetInputDimension(dims);
+void NeuralNetwork::resetInputDimension(
+  std::vector<TensorDim> model_input_dims) {
+  if (initialized) {
+    model_graph.resetInputDimension(model_input_dims);
+  }
 }
 
 int NeuralNetwork::setDataset(const DatasetModeType &mode,

--- a/nntrainer/models/neuralnet.h
+++ b/nntrainer/models/neuralnet.h
@@ -423,19 +423,14 @@ public:
                         bool output_hidden_state = false) override;
 
   /**
-   * @brief     reset input dimensions of a model
-   * @param[in] dims input dimensions
-   * @note Similar to reinitialize, the resetInputDimension API is used for
-   * modifying input dimensions after model initialization. The reinitialize
-   * function should be the officially called API when changing input
-   * dimensions, as it properly recalculates weights, tensors, and outputs for
-   * each layer. On the other hand, resetInputDimension is a specialized API
-   * created to modify only specific dimensions (specifically height values)
-   * within input/output dimensions. Since this API uniformly adjusts the height
-   * across all model layers, developers must verify that every layer in their
-   * model architecture can safely accommodate such height modifications.
+   * @brief     Reset input dimensions of a model
+   * @param[in] model_input_dims input dimensions
+   * @note resetInputDimension recalculates ans sets the dimensions of the
+   * outputs and the tensors according to the given input for each layer.
+   * However it must be guaranteed that the weight dimensions remain unchanged.
+   * If not, it will raise an error.
    */
-  void resetInputDimension(std::vector<TensorDim> dims) override;
+  void resetInputDimension(std::vector<TensorDim> model_input_dims) override;
 
   /**
    * @brief     Run NeuralNetwork train with callback function by user

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -159,7 +159,7 @@ Tensor::Tensor(std::string name_, Tformat fm, Tdatatype d_type) {
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type is not "
+      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d_type) + ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }
@@ -215,7 +215,7 @@ Tensor::Tensor(const TensorDim &d, bool alloc_now, Initializer init,
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type is not "
+      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d.getDataType()) + ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }
@@ -266,7 +266,7 @@ Tensor::Tensor(const TensorDim &d, const void *buf, QScheme qscheme) {
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type is not "
+      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d.getDataType()) + ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }
@@ -331,6 +331,14 @@ Tensor::Tensor(const std::unique_ptr<TensorBase> &rhs) {
 #else
     throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
+  } else if (rhs->getDataType() == Tdatatype::Q4_K) {
+    itensor_ = std::make_unique<Q4_K_Tensor>(*rhs.get());
+  } else if (rhs->getDataType() == Tdatatype::Q6_K) {
+    itensor_ = std::make_unique<Q6_K_Tensor>(*rhs.get());
+  } else if (rhs->getDataType() == Tdatatype::Q4_0) {
+    itensor_ = std::make_unique<Q4_0_Tensor>(*rhs.get());
+  } else if (rhs->getDataType() == Tdatatype::QS4CX) {
+    itensor_ = std::make_unique<QS4CX_Tensor>(*rhs.get());
   } else if (rhs->getDataType() == Tdatatype::UINT4) {
     itensor_ = std::make_unique<Uint4QTensor>(*rhs.get());
   } else if (rhs->getDataType() == Tdatatype::UINT8) {

--- a/nntrainer/tensor/tensor.cpp
+++ b/nntrainer/tensor/tensor.cpp
@@ -159,7 +159,9 @@ Tensor::Tensor(std::string name_, Tformat fm, Tdatatype d_type) {
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d_type) + ") is not "
+      "Error: Tensor cannot be constructed because the given d_type (" +
+      std::to_string((int)d_type) +
+      ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }
@@ -215,7 +217,9 @@ Tensor::Tensor(const TensorDim &d, bool alloc_now, Initializer init,
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d.getDataType()) + ") is not "
+      "Error: Tensor cannot be constructed because the given d_type (" +
+      std::to_string((int)d.getDataType()) +
+      ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }
@@ -266,7 +270,9 @@ Tensor::Tensor(const TensorDim &d, const void *buf, QScheme qscheme) {
 #endif
   } else {
     throw std::invalid_argument(
-      "Error: Tensor cannot be constructed because the given d_type (" + std::to_string((int)d.getDataType()) + ") is not "
+      "Error: Tensor cannot be constructed because the given d_type (" +
+      std::to_string((int)d.getDataType()) +
+      ") is not "
       "compatible with itensor. The supported d_types are: FP32, FP16 "
       "(if built with ENABLE_FP16).");
   }

--- a/test/unittest/models/causallm_test_utils.cpp
+++ b/test/unittest/models/causallm_test_utils.cpp
@@ -497,7 +497,17 @@ FixtureConfigs loadFixtureConfigs(const std::filesystem::path &dir) {
 bool runQuantize(const std::string &quantize_bin,
                  const std::filesystem::path &fp32_dir,
                  const std::filesystem::path &out_dir) {
-  std::string cmd = quantize_bin + " " + fp32_dir.string() + " -o " +
+  std::string cmd = "";
+#ifdef _WIN32
+  if (const char *path = std::getenv("PATH")) {
+    cmd += "set PATH=" + std::string(path) + " && ";
+  }
+#else
+  if (const char *ld_path = std::getenv("LD_LIBRARY_PATH")) {
+    cmd += "LD_LIBRARY_PATH=" + std::string(ld_path) + " ";
+  }
+#endif
+  cmd += quantize_bin + " " + fp32_dir.string() + " -o " +
                     out_dir.string() + " --fc_dtype Q4_0 2>&1";
   int ret = std::system(cmd.c_str());
   return ret == 0;

--- a/test/unittest/models/causallm_test_utils.cpp
+++ b/test/unittest/models/causallm_test_utils.cpp
@@ -498,17 +498,13 @@ bool runQuantize(const std::string &quantize_bin,
                  const std::filesystem::path &fp32_dir,
                  const std::filesystem::path &out_dir) {
   std::string cmd = "";
-#ifdef _WIN32
-  if (const char *path = std::getenv("PATH")) {
-    cmd += "set PATH=" + std::string(path) + " && ";
-  }
-#else
+#ifndef _WIN32
   if (const char *ld_path = std::getenv("LD_LIBRARY_PATH")) {
     cmd += "LD_LIBRARY_PATH=" + std::string(ld_path) + " ";
   }
 #endif
-  cmd += quantize_bin + " " + fp32_dir.string() + " -o " +
-                    out_dir.string() + " --fc_dtype Q4_0 2>&1";
+  cmd += quantize_bin + " " + fp32_dir.string() + " -o " + out_dir.string() +
+         " --fc_dtype Q4_0 2>&1";
   int ret = std::system(cmd.c_str());
   return ret == 0;
 }

--- a/test/unittest/models/causallm_test_utils.h
+++ b/test/unittest/models/causallm_test_utils.h
@@ -224,6 +224,11 @@ public:
   void initializeModel() override { this->initialize(); }
 
   /**
+   * @brief Get the underlying NNTrainer Model pointer
+   */
+  ml::train::Model *getModel() { return this->model.get(); }
+
+  /**
    * @brief Save model weights
    */
   void saveWeight(const std::string &path) override { this->save_weight(path); }

--- a/test/unittest/models/unittest_causallm_qwen3.cpp
+++ b/test/unittest/models/unittest_causallm_qwen3.cpp
@@ -16,6 +16,7 @@
 
 #include <layer.h>
 #include <layer_context.h>
+#include <layer_node.h>
 #include <qwen3_causallm.h>
 #include <qwen3_embedding.h>
 
@@ -433,6 +434,91 @@ TEST_P(CausalLMTinyModelTest, WeightRoundTripProducesSameLogits) {
 TEST_P(CausalLMTinyModelTest, PromptProducesExpectedLogits) {
   const auto files = makeFiles();
   causallm_test::expectPromptProducesExpectedLogits(GetParam(), files);
+}
+
+/**
+ * @brief Test that resetInputDimension dynamically resizes the Qwen3 model
+ * successfully
+ */
+TEST_P(CausalLMTinyModelTest,
+       ResetInputDimensionResizesQwen3ModelSuccessfully) {
+  const auto files = makeFiles();
+  auto config =
+    causallm_test::makeTinyCausalLMConfig(GetParam(), files.tokenizer_path);
+  auto model_runner =
+    GetParam().create_model(config.model, config.generation, config.nntrainer);
+
+  model_runner->initializeModel();
+
+  auto qwen_model = dynamic_cast<TinyQwen3CausalLM *>(model_runner.get());
+  ASSERT_NE(qwen_model, nullptr);
+
+  auto nn_model = qwen_model->getModel();
+  ASSERT_NE(nn_model, nullptr);
+
+  std::vector<ml::train::TensorDim> input_dims = nn_model->getInputDimension();
+  ASSERT_FALSE(input_dims.empty());
+
+  // 1. Capture and verify the original input sequence length before resizing
+  unsigned int original_width = input_dims[0].width();
+
+  // Dynamically compute a new sequence length that is guaranteed to be
+  // different from original_width
+  unsigned int new_width = (original_width == 4u) ? 8u : 4u;
+
+  // Dynamic resizing: Change sequence length (width) to new_width
+  input_dims[0].width(new_width);
+
+  EXPECT_NO_THROW(nn_model->resetInputDimension(input_dims));
+
+  // 2. Deterministic Verification: Retrieve and verify the model's updated
+  // input dimension
+  std::vector<ml::train::TensorDim> updated_input_dims =
+    nn_model->getInputDimension();
+  ASSERT_FALSE(updated_input_dims.empty());
+
+  // Verify that the input sequence length has successfully resized and is
+  // different from original
+  EXPECT_EQ(updated_input_dims[0].width(), new_width);
+  EXPECT_NE(updated_input_dims[0].width(), original_width);
+
+  // 3. Deep Structural Verification: Extract intermediate layers to verify
+  // propagation In transformer models, the sequence length shifts from 'width'
+  // in the input to 'height' in subsequent layers.
+
+  std::vector<std::string> layers_to_check = {
+    "embedding0",            // Embedding layer
+    "layer0_attention_norm", // RMS Norm layer
+    "layer0_wq",             // Fully Connected layer
+    "layer0_q_norm",         // Reshaped RMS Norm layer
+    "layer0_attention",      // Multi-Head Attention Core layer
+    "layer0_attention_out",  // Fully Connected layer (Output projection)
+    "layer0_decoder_add",    // Addition layer
+    "layer0_ffn_norm",       // RMS Norm layer
+    "output_norm"            // Terminal RMS Norm layer before Logits
+  };
+
+  for (const auto &layer_name : layers_to_check) {
+    std::shared_ptr<ml::train::Layer> layer;
+    int status = nn_model->getLayer(layer_name.c_str(), &layer);
+    EXPECT_EQ(status, ML_ERROR_NONE)
+      << "Failed to extract layer: " << layer_name;
+    ASSERT_NE(layer, nullptr) << "Layer pointer is null for: " << layer_name;
+
+    // Forcefully downcast the API wrapper to the core LayerNode to access
+    // internal tensor dimensions
+    auto layer_node = std::static_pointer_cast<nntrainer::LayerNode>(layer);
+    ASSERT_NE(layer_node, nullptr)
+      << "Failed to downcast to LayerNode for: " << layer_name;
+
+    auto out_dims = layer_node->getOutputDimensions();
+    ASSERT_FALSE(out_dims.empty())
+      << "Output dimensions are empty for layer: " << layer_name;
+
+    EXPECT_EQ(out_dims[0].height(), new_width)
+      << "Height mismatch detected at layer: " << layer_name << ". Expected "
+      << new_width << " but got " << out_dims[0].height();
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Dependency of the PR

- None (Directly rebased on top of the latest upstream/main branch f97c2e26)

## Commits to be reviewed in this PR


<details><summary>001d175f</summary><br />

**[layer] added getLayerDimensions**

- Implemented getLayerDimensions. It will be used for finalize and
  updateTensorsByInputDimensions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>77686f23</summary><br />

**[layer] exploit getLayerDimensions in layer finalize**

- Modified layer finalize to exploit getLayerDimensions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>9194d936</summary><br />

**[graph] update resetInputDimension**

- resetInputDimensions has been updated from applying the model's input dimension directly
  to adapting the actual input dimension for each layer.
- Update the updateTensorsByInputDimensions function to return output dimensions to be used
  by the following layer.
- Update the updateTensorsByInputDimensions function to exploit getLayerDimensions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>bb8c6a3a</summary><br />

**[neuralnet] remove reInitialize**

- Remove reInitialize, reFinalize, reFinalizeContext.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>0eb4074d</summary><br />

**[layer] update custom layer updateTensorsByInputDimensions signatures**

- Update the updateTensorsByInputDimensions method overrides in custom CausalLM layers and
  AdditionLayer to match the newly refactored (InitLayerContext &, RunLayerContext &) core
  interface.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>09914627</summary><br />

**[layer] fix mha_core use_external_cache segfault**

- Wrap cache_key and cache_value tensor updates in updateTensorsByInputDimensions and
  setBatch inside an if (!use_external_cache) check to prevent segmentation faults when using
  external KV cache.
- Add friend class NeuralNetwork to NetworkGraph to allow the model class to access input
  names list.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>c64a9334</summary><br />

**[tensor] add quantized types support and mapExternalTensor validation**

- Add missing quantized data types Q4_K, Q6_K, Q4_0, and QS4CX to the Tensor constructor
  wrapping a unique_ptr<TensorBase> to prevent runtime incompatible data type fatal errors.
- Add a runtime defensive check in mapExternalTensor to throw a descriptive exception when
  an empty tensor dimension is encountered, preventing subsequent silent segfaults.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>79b15f0f</summary><br />

**[causallm] fix resetInputDimension call to prevent out-of-bounds error**

- Retrieve the full input dimensions list from the model first, and then update only the
  first dimension with the prompt length. This ensures the passed dimensions list has the
  exact size of all inputs expected by NetworkGraph::resetInputDimension, preventing
  out-of-bounds memory accesses and invalid dimensions.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>


### Summary

- **Introduce getLayerDimensions Interface**: Implements `getLayerDimensions` in the Layer
  interface enabling layers to dynamically trace and compute their own specific output
  dimensions rather than forcing global model input dims across all layers.
- **Overhaul resetInputDimension Logic**: Refactors the `resetInputDimension` sequence to
  safely adapt the computed layer dimensions incrementally across the NetworkGraph,
  eliminating out-of-bounds (OOB) memory corruption and vector access faults.
- **Quantized Types and KV Cache Stability**: Adds full quantized data types (`Q4_K`,
  `Q6_K`, `Q4_0`, `QS4CX`) to the main Tensor interface, wraps external KV cache operations
  inside defensive null-checks in `MHACoreLayer` to prevent segmentation faults, and drops
  deprecated `reInitialize` legacy methods.

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>