### PR TITLE
[HTP] Bring up an HVX/HMX CDSP skel: vector add, u8i4 HMX matmul, f32 softmax

### DIFF
--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_dma_ring.c
+ * @date   06 Aug 2026
+ * @brief  Minimal dmlink user-DMA ring for cross-matmul weight prefetch
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Ported from the doc13 §3a measurement bench's ring_push2d/ring_drain,
+ * itself lifted from llama.cpp ggml-hexagon's dma-queue.{c,h}. Behaviour is
+ * unchanged; only the names are de-abbreviated and the file stands alone so
+ * both the u8i4 and (later) u8i8 matmul modules can share one ring.
+ */
+
+#include "hexkl_dma_ring.h"
+
+#include <hexagon_protos.h>
+#include <hexagon_types.h>
+#include <hmx_hexagon_protos.h>
+#include <string.h>
+
+/** @brief One 2D DMA descriptor. Hardware-defined layout; do not reorder. */
+typedef struct __attribute__((aligned(128))) hexkl_dma_desc2d_s {
+  void *next;
+  uint32_t dst_stride : 24;
+  uint32_t desc_size : 2;
+  uint32_t dst_comp : 1;
+  uint32_t src_comp : 1;
+  uint32_t dst_bypass : 1;
+  uint32_t src_bypass : 1;
+  uint32_t order : 1;
+  uint32_t done : 1;
+  void *src;
+  void *dst;
+  uint32_t desc_type : 8;
+  uint32_t reserved0 : 24;
+  uint32_t row_size : 24;
+  uint32_t nrows_lo : 8;
+  uint32_t nrows_hi : 8;
+  uint32_t src_stride : 24;
+  uint32_t offset : 24;
+  uint32_t reserved1 : 8;
+} hexkl_dma_desc2d;
+
+static inline void hexkl_dma_link(void *cur, void *next) {
+  asm volatile(" release(%0):at" : : "r"(next));
+  asm volatile(" dmlink(%0, %1)" : : "r"(cur), "r"(next));
+}
+
+static inline void hexkl_dma_start(void *p) {
+  asm volatile(" release(%0):at" : : "r"(p));
+  asm volatile(" dmstart(%0)" : : "r"(p));
+}
+
+/** @brief Power of two, comfortably above the pushes any one call issues,
+ *         so a call's transfers never wrap into ones still in flight. */
+#define HEXKL_DMA_RING_N 256u
+
+static hexkl_dma_desc2d g_ring[HEXKL_DMA_RING_N] __attribute__((aligned(128)));
+static uint32_t g_push, g_pop;
+static hexkl_dma_desc2d *g_tail;
+static int g_started;
+
+static void hexkl_dma_ring_wait_idx(uint32_t i) {
+  long guard = 0;
+  while (!g_ring[i].done && guard++ < 50000000L) {
+    unsigned r = 0;
+    asm volatile(" %0 = dmpoll" : "=r"(r) : : "memory");
+    (void)r;
+  }
+}
+
+void hexkl_dma_ring_reset(void) {
+  memset(g_ring, 0, sizeof(g_ring));
+  g_push = 0;
+  g_pop = 0;
+  g_tail = &g_ring[HEXKL_DMA_RING_N - 1];
+  g_started = 0;
+}
+
+void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
+                          uint32_t src_stride, uint32_t row_size,
+                          uint32_t nrows, int src_vtcm, int dst_vtcm) {
+  if (((g_push + 1) & (HEXKL_DMA_RING_N - 1)) == g_pop) {
+    // Ring full: the oldest transfer must have already finished by the time
+    // we have wrapped this far around, so reclaiming it is a formality, not
+    // a stall -- but wait for `done` explicitly rather than assume it.
+    hexkl_dma_ring_wait_idx(g_pop);
+    g_pop = (g_pop + 1) & (HEXKL_DMA_RING_N - 1);
+  }
+  hexkl_dma_desc2d *d = &g_ring[g_push];
+  d->next = 0;
+  d->desc_size = 1;
+  d->desc_type = 9;
+  d->src_comp = 0;
+  d->dst_comp = 0;
+  d->src_bypass = src_vtcm ? 1 : 0;
+  d->dst_bypass = dst_vtcm ? 1 : 0;
+  d->order = 0;
+  d->done = 0;
+  d->reserved0 = 0;
+  d->reserved1 = 0;
+  d->offset = 0;
+  d->src = (void *)src;
+  d->dst = dst;
+  d->src_stride = src_stride;
+  d->dst_stride = dst_stride;
+  d->row_size = row_size;
+  d->nrows_lo = nrows & 0xffu;
+  d->nrows_hi = (nrows >> 8) & 0xffu;
+  Q6_dccleaninva_A((void *)d); // push the descriptor to memory for the DMA engine
+  if (!g_started) {
+    hexkl_dma_start(d);
+    g_started = 1;
+  } else {
+    hexkl_dma_link(g_tail, d);
+  }
+  g_tail = d;
+  g_push = (g_push + 1) & (HEXKL_DMA_RING_N - 1);
+}
+
+void hexkl_dma_ring_drain(void) {
+  while (g_pop != g_push) {
+    hexkl_dma_ring_wait_idx(g_pop);
+    g_pop = (g_pop + 1) & (HEXKL_DMA_RING_N - 1);
+  }
+  g_started = 0; // engine idle after drain -- the next push must dmstart
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_dma_ring.h
+ * @date   06 Aug 2026
+ * @brief  Minimal dmlink user-DMA ring for cross-matmul weight prefetch
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HEXKL_DMA_RING_H__
+#define __NNTRAINER_HEXKL_DMA_RING_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Resets the ring to empty.
+ *
+ * Call once per logical group of transfers (here: once per mm_u8i4_layer
+ * call), not once per transfer -- hexkl_dma_ring_push2d's own wraparound
+ * handling is what keeps a long-running ring correct across many pushes.
+ */
+void hexkl_dma_ring_reset(void);
+
+/**
+ * @brief Queues one 2D transfer; starts the DMA engine if idle, otherwise
+ *        chains onto the in-flight descriptor via dmlink so many transfers
+ *        run on the single DMA engine without a second dmstart.
+ *
+ * @param src_vtcm  nonzero if @a src is in VTCM (bypasses L2)
+ * @param dst_vtcm  nonzero if @a dst is in VTCM (bypasses L2)
+ */
+void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
+                          uint32_t src_stride, uint32_t row_size,
+                          uint32_t nrows, int src_vtcm, int dst_vtcm);
+
+/** @brief Blocks until every queued transfer has completed. */
+void hexkl_dma_ring_drain(void);
+
+#endif /* __NNTRAINER_HEXKL_DMA_RING_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hexkl_mm_u8i4.c
+ * @date   03 Aug 2026
+ * @brief  VTCM layout and HMX orchestration for the A8W4 matmul
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <AEEStdErr.h>
+
+#include "hexkl_micro.h"
+
+#include "hexkl_mm_u8i4.h"
+
+#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Bytes in one packed i4 weight tile (32x32 values). */
+#define WEIGHT_TILE_BYTES 512u
+/** @brief Bytes in one int32 accumulator tile (64x32 values). */
+#define ACC_TILE_BYTES 8192u
+
+int hexkl_mm_u8i4_plan(uint8_t *vtcm_base, uint32_t vtcm_size, uint32_t m_pad,
+                       uint32_t k, uint32_t n, hexkl_mm_u8i4_layout *out) {
+  if (!vtcm_base || !out || k == 0 || n == 0 || m_pad == 0) {
+    return AEE_EBADPARM;
+  }
+  if ((k % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0 ||
+      (n % HEXKL_HMX_INT8_BLOCK_N_COL) != 0 ||
+      (m_pad % HEXKL_HMX_INT8_BLOCK_N_ROW) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+
+  out->vtcm_base = vtcm_base;
+  out->vtcm_size = vtcm_size;
+
+  out->w_base = 0u;
+  out->w_size = n_ktiles * n_ntiles * WEIGHT_TILE_BYTES;
+
+  // Activation tiles must sit on HEXKL_HMX_ACTIVATION_ALIGNMENT, and each
+  // tile is exactly that many bytes, so aligning the base is enough.
+  out->act_base = ROUND_UP_U32(out->w_size, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  out->act_size = n_rblocks * n_ktiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+
+  out->result_off = out->act_base + out->act_size;
+
+  // Put the config region at the top of the arena, rounded down to its
+  // alignment so the rounding can never eat into the result region.
+  if (vtcm_size < hexkl_micro_hmx_config_size()) {
+    return AEE_ENOMEMORY;
+  }
+  out->config_off = (vtcm_size - hexkl_micro_hmx_config_size()) &
+                    ~(HEXKL_HMX_CONFIG_ALIGNMENT - 1u);
+
+  if (out->result_off + ACC_TILE_BYTES > out->config_off) {
+    return AEE_ENOMEMORY;
+  }
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_bake_weights(const hexkl_mm_u8i4_layout *L,
+                               const int8_t *w_i4_rm, uint32_t k, uint32_t n) {
+  if (!L || !w_i4_rm) {
+    return AEE_EBADPARM;
+  }
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+
+  for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+    for (uint32_t nt = 0; nt < n_ntiles; ++nt) {
+      const uint32_t off = L->w_base + (kt * n_ntiles + nt) * WEIGHT_TILE_BYTES;
+      int res =
+        hexkl_micro_hmx_rm_to_wh_i4(L->vtcm_base, off, w_i4_rm, kt, nt, n);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_run(const hexkl_mm_u8i4_layout *L, uint32_t m_pad, uint32_t k,
+                      uint32_t n, int32_t *acc_i32) {
+  if (!L || !acc_i32) {
+    return AEE_EBADPARM;
+  }
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+
+  for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
+    for (uint32_t nt = 0; nt < n_ntiles; ++nt) {
+      hexkl_micro_hmx_acc_clear_int32();
+
+      for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+        const uint32_t act_off =
+          L->act_base + (rb * n_ktiles + kt) * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+        const uint32_t w_off =
+          L->w_base + (kt * n_ntiles + nt) * WEIGHT_TILE_BYTES;
+        int res = hexkl_micro_hmx_mm_u8i4(L->vtcm_base, act_off, w_off);
+        if (res != AEE_SUCCESS) {
+          return res;
+        }
+      }
+
+      int res = hexkl_micro_hmx_acc_read_int32(L->vtcm_base, L->config_off,
+                                               L->result_off);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+      // Going through copy_32b_to_submatrix keeps us off the accumulator's
+      // shuffled layout, which HexKL does not document.
+      res = hexkl_micro_hmx_copy_32b_to_submatrix(L->vtcm_base, L->result_off,
+                                                  acc_i32, rb, nt, m_pad, n);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+  return AEE_SUCCESS;
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hexkl_mm_u8i4.h
+ * @date   03 Aug 2026
+ * @brief  VTCM layout and HMX orchestration for the A8W4 matmul
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HEXKL_MM_U8I4_H__
+#define __NNTRAINER_HEXKL_MM_U8I4_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Where each region lives inside the VTCM arena.
+ *
+ * Byte offsets from @a vtcm_base, not pointers, because that is what the
+ * HexKL micro API takes.
+ */
+typedef struct {
+  uint8_t *vtcm_base;  /**< base of the VTCM arena from hexkl_micro_hw_init */
+  uint32_t vtcm_size;  /**< total arena size in bytes */
+  uint32_t w_base;     /**< all baked weight tiles, (K/32)*(N/32)*512 bytes */
+  uint32_t w_size;     /**< byte span of the weight region */
+  uint32_t act_base;   /**< activation AH tiles, m_pad*K bytes, 2048-aligned */
+  uint32_t act_size;   /**< byte span of the activation region */
+  uint32_t result_off; /**< 8192-byte accumulator readout, 2048-aligned */
+  uint32_t config_off; /**< HMX config region, 256-aligned */
+} hexkl_mm_u8i4_layout;
+
+/**
+ * @brief Computes the VTCM partitioning and checks it against the arena.
+ *
+ * Pure arithmetic apart from reading hexkl_micro_hmx_config_size(), so it
+ * is the one piece of this file that could be unit tested on the host.
+ *
+ * @return AEE_SUCCESS, AEE_EBADPARM on a shape violation, or
+ *         AEE_ENOMEMORY when the partitioning does not fit.
+ */
+int hexkl_mm_u8i4_plan(uint8_t *vtcm_base, uint32_t vtcm_size, uint32_t m_pad,
+                       uint32_t k, uint32_t n, hexkl_mm_u8i4_layout *out);
+
+/**
+ * @brief Converts every weight tile to WH layout once, into VTCM.
+ *
+ * HexKL's example calls rm_to_wh_i4 from the innermost matmul loop, which
+ * serializes the layout conversion against the multiply. Hoisting it here
+ * means the matmul reads the tiles in place with no copy at all.
+ *
+ * @param[in] w_i4_rm weights as int4 values in int8 containers, range
+ *                    [-8, 7], K rows by N columns, row-major
+ */
+int hexkl_mm_u8i4_bake_weights(const hexkl_mm_u8i4_layout *L,
+                               const int8_t *w_i4_rm, uint32_t k, uint32_t n);
+
+/**
+ * @brief Runs the HMX matmul over the baked weights and staged activation.
+ *
+ * Requires hexkl_micro_hmx_setup_acc_read_int32() to have been called for
+ * L->config_off, the HMX lock to be held, and the activation to already be
+ * in AH layout at L->act_base.
+ *
+ * @param[out] acc_i32 m_pad by n int32 accumulators, row-major, in DDR
+ */
+int hexkl_mm_u8i4_run(const hexkl_mm_u8i4_layout *L, uint32_t m_pad, uint32_t k,
+                      uint32_t n, int32_t *acc_i32);
+
+#endif /* __NNTRAINER_HEXKL_MM_U8I4_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i4_dma.c
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i4 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "hexkl_mm_u8i4_dma.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <AEEStdErr.h>
+
+#include "hexkl_dma_ring.h"
+#include "hexkl_micro.h"
+#include "hvx_dequant_i32.h"
+#include "hvx_quant_u8.h"
+
+#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Bytes in one packed i4 weight tile (32x32 values). Matches
+ *         hexkl_mm_u8i4.c's local definition -- both are file-scoped, so
+ *         this is not a redefinition, just the same constant kept in sync
+ *         by inspection. If HexKL ever exposes it from hexkl_micro.h, both
+ *         files should switch to that instead of this comment. */
+#define WEIGHT_TILE_BYTES_U8I4 512u
+/** @brief Bytes in one int32 accumulator tile (64x32 values). */
+#define ACC_TILE_BYTES 8192u
+/** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
+ *         this size have a documented hardware bug (doc13 §3a, §5). */
+#define MAX_DMA_ROW_BYTES 262144u
+
+static uint32_t dma_row_size_dividing(uint32_t total_bytes) {
+  uint32_t rs = MAX_DMA_ROW_BYTES;
+  while (rs > 1 && (total_bytes % rs) != 0) {
+    rs >>= 1;
+  }
+  return rs;
+}
+
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
+                               uint8_t *vtcm_base, uint32_t vtcm_size,
+                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
+                               const float *w_scale, const int32_t *colsum_w,
+                               const float *bias, uint32_t *out_handle) {
+  if (!tbl || !vtcm_base || !w_i4_rm || !w_scale || !colsum_w || !bias ||
+      !out_handle || K == 0 || N == 0) {
+    return AEE_EBADPARM;
+  }
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0 ||
+      (N % HEXKL_HMX_INT8_BLOCK_N_COL) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  uint32_t slot = HEXKL_MM_U8I4_MAX_WEIGHTS;
+  for (uint32_t i = 0; i < HEXKL_MM_U8I4_MAX_WEIGHTS; ++i) {
+    if (!tbl->slots[i].in_use) {
+      slot = i;
+      break;
+    }
+  }
+  if (slot == HEXKL_MM_U8I4_MAX_WEIGHTS) {
+    return AEE_ENOMEMORY;
+  }
+
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_tiles = N / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t wh_bytes = k_tiles * n_tiles * WEIGHT_TILE_BYTES_U8I4;
+  if (wh_bytes > vtcm_size) {
+    return AEE_ENOMEMORY; // weight alone does not fit the VTCM scratch arena
+  }
+
+  // Bake every tile into VTCM (borrowed as scratch -- caller holds the HMX
+  // lock and has no other VTCM use in flight), then copy the baked bytes
+  // out to DSP heap memory where they stay resident across calls. A plain
+  // copy, not the DMA ring: registration happens once per weight at model
+  // load, off the per-token hot path, so its cost is not what this file
+  // exists to optimise.
+  for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+    for (uint32_t nt = 0; nt < n_tiles; ++nt) {
+      const uint32_t off = (kt * n_tiles + nt) * WEIGHT_TILE_BYTES_U8I4;
+      int res =
+        hexkl_micro_hmx_rm_to_wh_i4(vtcm_base, off, w_i4_rm, kt, nt, N);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+
+  hexkl_weight_u8i4 *h = &tbl->slots[slot];
+  h->wh_bytes = (uint8_t *)malloc(wh_bytes);
+  h->w_scale = (float *)malloc(sizeof(float) * N);
+  h->colsum_w = (int32_t *)malloc(sizeof(int32_t) * N);
+  h->bias = (float *)malloc(sizeof(float) * N);
+  if (!h->wh_bytes || !h->w_scale || !h->colsum_w || !h->bias) {
+    free(h->wh_bytes);
+    free(h->w_scale);
+    free(h->colsum_w);
+    free(h->bias);
+    memset(h, 0, sizeof(*h));
+    return AEE_ENOMEMORY;
+  }
+  memcpy(h->wh_bytes, vtcm_base, wh_bytes);
+  memcpy(h->w_scale, w_scale, sizeof(float) * N);
+  memcpy(h->colsum_w, colsum_w, sizeof(int32_t) * N);
+  memcpy(h->bias, bias, sizeof(float) * N);
+  h->K = K;
+  h->N = N;
+  h->in_use = 1;
+
+  *out_handle = slot;
+  return AEE_SUCCESS;
+}
+
+int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle) {
+  if (!tbl || handle >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
+      !tbl->slots[handle].in_use) {
+    return AEE_EBADPARM;
+  }
+  hexkl_weight_u8i4 *h = &tbl->slots[handle];
+  free(h->wh_bytes);
+  free(h->w_scale);
+  free(h->colsum_w);
+  free(h->bias);
+  memset(h, 0, sizeof(*h));
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off,
+                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat) {
+  if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
+      !out_cat || M == 0 || K == 0) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t m_pad = ROUND_UP_U32(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  // Validate every handle up front -- K must match, and this is also where
+  // the widest weight (for the double-buffer size) and the total output
+  // width (for out_cat bounds) come from.
+  uint32_t n_tiles_max = 0, n_max = 0;
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    if (handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS || !tbl->slots[handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    const hexkl_weight_u8i4 *h = &tbl->slots[handles[i]];
+    if (h->K != K) {
+      return AEE_EBADPARM;
+    }
+    const uint32_t nt = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    if (nt > n_tiles_max) {
+      n_tiles_max = nt;
+    }
+    if (h->N > n_max) {
+      n_max = h->N;
+    }
+  }
+
+  // VTCM layout: activation (all row-bands, shared across every handle) |
+  // weight double-buffer (sized for the widest handle) | one result tile.
+  const uint32_t act_bytes = n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+  const uint32_t act_off = 0;
+  const uint32_t wb_max = k_tiles * n_tiles_max * WEIGHT_TILE_BYTES_U8I4;
+  const uint32_t wbuf[2] = {
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT),
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT) + wb_max,
+  };
+  const uint32_t result_off =
+    ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  if (result_off + ACC_TILE_BYTES > config_off) {
+    return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
+  }
+  if (result_off + ACC_TILE_BYTES > vtcm_size) {
+    return AEE_ENOMEMORY;
+  }
+
+  // K1/K2: quantize the shared activation once, straight into its AH tiles
+  // in VTCM -- no separate layout pass, matching hvx_quant_pack_u8_ah's
+  // contract.
+  float *act_scale = (float *)malloc(sizeof(float) * m_pad);
+  int32_t *act_zp = (int32_t *)malloc(sizeof(int32_t) * m_pad);
+  int32_t *acc_scratch = (int32_t *)malloc(sizeof(int32_t) * (size_t)m_pad * n_max);
+  if (!act_scale || !act_zp || !acc_scratch) {
+    free(act_scale);
+    free(act_zp);
+    free(acc_scratch);
+    return AEE_ENOMEMORY;
+  }
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
+  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                      vtcm_base + act_off);
+
+  int rc = AEE_SUCCESS;
+  size_t out_off = 0;
+  hexkl_dma_ring_reset();
+
+  // Load handle 0's weight before the loop starts -- there is nothing to
+  // prefetch it behind yet, so this one transfer is blocking.
+  {
+    const hexkl_weight_u8i4 *h0 = &tbl->slots[handles[0]];
+    const uint32_t nt0 = h0->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wb0 = k_tiles * nt0 * WEIGHT_TILE_BYTES_U8I4;
+    const uint32_t rs0 = dma_row_size_dividing(wb0);
+    hexkl_dma_ring_push2d(vtcm_base + wbuf[0], h0->wh_bytes, rs0, rs0, rs0,
+                         wb0 / rs0, /*src_vtcm=*/0, /*dst_vtcm=*/1);
+    hexkl_dma_ring_drain();
+  }
+
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    const hexkl_weight_u8i4 *h = &tbl->slots[handles[i]];
+    const uint32_t nt_n = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wcur = wbuf[i & 1u];
+
+    if (i + 1 < n_handles) {
+      // Cross-matmul prefetch (doc13 §3a): while handle i computes below,
+      // stream handle i+1's weight into the OTHER buffer in the
+      // background. One transfer, chunked under the >512KB-row DMA bug's
+      // threshold, not one per tile.
+      const hexkl_weight_u8i4 *hn = &tbl->slots[handles[i + 1]];
+      const uint32_t nt_next = hn->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+      const uint32_t wb_next = k_tiles * nt_next * WEIGHT_TILE_BYTES_U8I4;
+      const uint32_t rs = dma_row_size_dividing(wb_next);
+      hexkl_dma_ring_push2d(vtcm_base + wbuf[(i + 1) & 1u], hn->wh_bytes, rs,
+                           rs, rs, wb_next / rs, /*src_vtcm=*/0,
+                           /*dst_vtcm=*/1);
+    }
+
+    for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
+      for (uint32_t nt = 0; nt < nt_n; ++nt) {
+        hexkl_micro_hmx_acc_clear_int32();
+        for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+          const uint32_t act_tile_off =
+            act_off + (rb * k_tiles + kt) * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+          const uint32_t w_tile_off =
+            wcur + (kt * nt_n + nt) * WEIGHT_TILE_BYTES_U8I4;
+          rc = hexkl_micro_hmx_mm_u8i4(vtcm_base, act_tile_off, w_tile_off);
+          if (rc != AEE_SUCCESS) {
+            goto out;
+          }
+        }
+        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, result_off);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+        rc = hexkl_micro_hmx_copy_32b_to_submatrix(
+          vtcm_base, result_off, acc_scratch, rb, nt, m_pad, h->N);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+      }
+    }
+
+    // Block until handle i+1's weight has fully landed before moving on to
+    // it -- matches the measured bench's "next weight fully in wnxt before
+    // matmul i+1" invariant. Dequant below does not touch the DMA engine,
+    // so a later pass could move it ahead of this drain to overlap with
+    // the prefetch; left as-is for correctness first.
+    hexkl_dma_ring_drain();
+
+    hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,
+                           h->colsum_w, h->w_scale, h->bias,
+                           out_cat + out_off);
+    out_off += (size_t)M * h->N;
+  }
+
+out:
+  free(act_scale);
+  free(act_zp);
+  free(acc_scratch);
+  return rc;
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i4_dma.h
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i4 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Turns hexkl_mm_u8i4's accuracy-harness building blocks (plan / bake /
+ * run, one matmul at a time, weight baked fresh every call) into the
+ * performance path doc15 §4/§8 item 3 describes: a weight is baked once
+ * and kept DSP-resident until released, and a "layer" of matmuls that share
+ * one activation (Q/K/V, or gate/up) runs back to back with the next
+ * weight prefetched into VTCM while the current one computes -- the
+ * cross-matmul win measured in doc13 §3a (1.7-2x over SDKL on V79).
+ */
+
+#ifndef __NNTRAINER_HEXKL_MM_U8I4_DMA_H__
+#define __NNTRAINER_HEXKL_MM_U8I4_DMA_H__
+
+#include <stdint.h>
+
+/** @brief Upper bound on weights resident at once. A 28-layer qwen3-sized
+ *         model registers 7 per layer (q,k,v,o,gate,up,down) = 196; this
+ *         leaves headroom without making the table itself large. */
+#define HEXKL_MM_U8I4_MAX_WEIGHTS 512
+
+/**
+ * @brief One registered weight: WH-baked bytes plus its dequant constants,
+ *        resident in DSP heap memory (not VTCM -- VTCM is compute
+ *        scratch) until hexkl_weight_u8i4_release.
+ */
+typedef struct {
+  int in_use;
+  uint8_t *wh_bytes; /**< k_tiles*n_tiles*512 bytes, WH layout */
+  float *w_scale;    /**< N entries */
+  int32_t *colsum_w; /**< N entries */
+  float *bias;       /**< N entries */
+  uint32_t K, N;
+} hexkl_weight_u8i4;
+
+typedef struct {
+  hexkl_weight_u8i4 slots[HEXKL_MM_U8I4_MAX_WEIGHTS];
+} hexkl_weight_u8i4_table;
+
+/**
+ * @brief Bakes a K x N int4 weight (int4 values in int8 containers,
+ *        row-major) to WH layout and keeps the result resident until
+ *        hexkl_weight_u8i4_release.
+ *
+ * Borrows the caller's VTCM arena as scratch for the bake -- the caller
+ * must hold the HMX lock, and no other VTCM use may be in flight for the
+ * duration of this call.
+ *
+ * @param[out] out_handle  index into @a tbl; pass back to
+ *                         hexkl_mm_u8i4_layer_run / hexkl_weight_u8i4_release
+ * @return AEE_SUCCESS, AEE_EBADPARM on a shape violation, AEE_ENOMEMORY if
+ *         the table is full or a host allocation fails, or a HexKL error
+ *         code from the bake itself.
+ */
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
+                               uint8_t *vtcm_base, uint32_t vtcm_size,
+                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
+                               const float *w_scale, const int32_t *colsum_w,
+                               const float *bias, uint32_t *out_handle);
+
+/** @brief Frees a registered weight's resident bytes. */
+int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle);
+
+/**
+ * @brief Runs matmuls against several registered weights that share one
+ *        quantized activation, double-buffering each weight into VTCM and
+ *        prefetching the next handle's weight while the current one
+ *        computes.
+ *
+ * Every handle must have been registered with K == @a K; this is checked,
+ * not assumed. Output is dequantized f32, one contiguous M x handle[i].N
+ * block per handle in call order (not interleaved row-by-row).
+ *
+ * @param config_off  session-constant HMX config region offset (from
+ *                     hexkl_mm_u8i4_plan; the same for every M/K/N because
+ *                     it depends only on vtcm_size). The caller must have
+ *                     called hexkl_micro_hmx_setup_acc_read_int32 for it
+ *                     once already -- this function does not repeat that
+ *                     because it is session-scoped, not call-scoped.
+ * @param[out] out_cat  sum(handles[i].N) * M f32 entries
+ */
+int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off,
+                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat);
+
+#endif /* __NNTRAINER_HEXKL_MM_U8I4_DMA_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_convert.h
+ * @date   03 Aug 2026
+ * @brief  int32 <-> f32 vector conversion for HVX, which has no such
+ *         instruction
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_CONVERT_H__
+#define __NNTRAINER_HVX_CONVERT_H__
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+/**
+ * @brief Bit pattern of 1.5 * 2^23 (12582912.0f).
+ *
+ * HVX has no numeric conversion between int32 and f32. Q6_Vw_equals_Vsf
+ * and Q6_Vsf_equals_Vw are bit reinterpretations, and the vcvt family
+ * only covers hf<->h/uh/b/ub and sf<->hf/bf. The magic-number identity
+ * below is the way across.
+ *
+ * Adding an integer x to the bit pattern of 1.5 * 2^23 lands x in the low
+ * mantissa bits, because that float's exponent puts the mantissa's least
+ * significant bit at value 1. Subtracting the same constant as a float
+ * then leaves exactly (float)x.
+ *
+ * Valid for |x| <= 2^22 = 4194304. Our accumulators are bounded by
+ * 255 * 8 * K, which is 2088960 at K=1024, so the margin is about 2x.
+ * Nothing here is safe for larger K without revisiting this bound.
+ */
+#define HVX_CONVERT_MAGIC_BITS 0x4B400000u
+
+/**
+ * @brief Converts int32 lanes to f32 lanes. Exact for |x| <= 2^22.
+ *
+ * HVX_Vector is type-agnostic: passing it directly to an f32 intrinsic
+ * reinterprets the bits without conversion. Q6_Vsf_equals_Vw /
+ * Q6_Vw_equals_Vsf look like reinterpret but are in fact NUMERIC
+ * conversions (V79 HVX Programmer's Reference Manual: "Convert IEEE
+ * floating point to integer... round to zero"), which would destroy the
+ * magic-number identity.
+ */
+static inline HVX_Vector hvx_w_to_sf(HVX_Vector v) {
+  const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);
+  const HVX_Vector bits = Q6_Vw_vadd_VwVw(v, magic);
+  return Q6_Vsf_vsub_VsfVsf(bits, magic);
+}
+
+/**
+ * @brief Converts f32 lanes to int32 lanes, rounding to nearest even.
+ *
+ * The rounding comes from the float add, so it is round-to-nearest-even.
+ * Host references that compare against this must use nearbyint, not round.
+ * Valid for results in |x| <= 2^22.
+ *
+ * Same reinterpret note as hvx_w_to_sf: the cross-type handoff is implicit.
+ */
+static inline HVX_Vector hvx_sf_to_w_rne(HVX_Vector v) {
+  const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);
+  const HVX_Vector biased = Q6_Vsf_vadd_VsfVsf(v, magic);
+  return Q6_Vw_vsub_VwVw(biased, magic);
+}
+
+/**
+ * @brief Broadcasts a float to every lane.
+ *
+ * Q6_V_vsplat_R takes a word, so the float's bits have to get there
+ * somehow. memcpy is the way that does not punt on strict aliasing --
+ * casting through int* is what -Wstrict-aliasing objects to, and this
+ * build uses -Wall -Werror. The compiler folds the memcpy away.
+ */
+static inline HVX_Vector hvx_splat_sf(float f) {
+  int bits;
+  __builtin_memcpy(&bits, &f, sizeof(bits));
+  return Q6_V_vsplat_R(bits);
+}
+
+#endif /* __NNTRAINER_HVX_CONVERT_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_dequant_i32.c
+ * @date   03 Aug 2026
+ * @brief  int32 accumulator to f32 dequantization for the A8W4 path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <stddef.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+#include "hvx_dequant_i32.h"
+
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 or int32 lanes per HVX vector. */
+#define LANES (VLEN / 4u)
+
+void hvx_dequant_i32_to_f32(const int32_t *acc, uint32_t m_valid,
+                            uint32_t m_pad, uint32_t n, const float *act_scale,
+                            const int32_t *act_zp, const int32_t *colsum_w,
+                            const float *w_scale, const float *bias,
+                            float *out) {
+  (void)m_pad;
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const int32_t *arow = acc + (size_t)m * n;
+    float *orow = out + (size_t)m * n;
+    const float s = act_scale[m];
+    const int32_t z = act_zp[m];
+
+    const uint32_t n_vec = n / LANES;
+    const HVX_Vector vs = hvx_splat_sf(s);
+    const HVX_Vector vzf = Q6_Vsf_equals_Vw(Q6_V_vsplat_R(z));
+
+    const HVX_UVector *vacc = (const HVX_UVector *)arow;
+    const HVX_UVector *vcs = (const HVX_UVector *)colsum_w;
+    const HVX_UVector *vws = (const HVX_UVector *)w_scale;
+    const HVX_UVector *vb = (const HVX_UVector *)bias;
+    HVX_UVector *vout = (HVX_UVector *)orow;
+
+    for (uint32_t v = 0; v < n_vec; ++v) {
+      const HVX_Vector af = Q6_Vsf_equals_Vw(vacc[v]);
+      const HVX_Vector csf = Q6_Vsf_equals_Vw(vcs[v]);
+      const HVX_Vector corrected =
+        Q6_Vsf_vsub_VsfVsf(af, Q6_Vsf_vmpy_VsfVsf(vzf, csf));
+      const HVX_Vector scaled =
+        Q6_Vsf_vmpy_VsfVsf(Q6_Vsf_vmpy_VsfVsf(corrected, vs), vws[v]);
+      vout[v] = Q6_Vsf_vadd_VsfVsf(scaled, vb[v]);
+    }
+
+    for (uint32_t j = n_vec * LANES; j < n; ++j) {
+      const int32_t corrected = arow[j] - z * colsum_w[j];
+      orow[j] = (float)corrected * s * w_scale[j] + bias[j];
+    }
+  }
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_dequant_i32.h
+ * @date   03 Aug 2026
+ * @brief  int32 accumulator to f32 dequantization for the A8W4 path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_DEQUANT_I32_H__
+#define __NNTRAINER_HVX_DEQUANT_I32_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Turns HMX int32 accumulators back into f32 (K3).
+ *
+ * out[m][n] = (acc[m][n] - act_zp[m]*colsum_w[n]) * act_scale[m]
+ *             * w_scale[n] + bias[n]
+ *
+ * The zp*colsum term corrects for HMX taking unsigned activations: with
+ * x = s*(u - zp), the dot product expands to s*d*(sum u*q_w - zp*sum q_w),
+ * and sum q_w over the reduction depends only on the weights, so it is a
+ * precomputed table rather than runtime work.
+ *
+ * HexKL micro exposes no bias, scale or zero-point registers, which is why
+ * this pass exists at all.
+ *
+ * @param[in]  acc      m_pad by n int32, row-major
+ * @param[in]  m_valid  rows to emit; padded rows are skipped because their
+ *                      quantization parameters are synthetic
+ * @param[in]  colsum_w per-channel sum of the int4 weights, n entries
+ * @param[in]  w_scale  per-channel dequantization multiplier, n entries
+ * @param[out] out      m_valid by n f32, row-major
+ */
+void hvx_dequant_i32_to_f32(const int32_t *acc, uint32_t m_valid,
+                            uint32_t m_pad, uint32_t n, const float *act_scale,
+                            const int32_t *act_zp, const int32_t *colsum_w,
+                            const float *w_scale, const float *bias,
+                            float *out);
+
+#endif /* __NNTRAINER_HVX_DEQUANT_I32_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_exp_f32.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_exp_f32.h
@@ -53,20 +53,20 @@
  */
 static inline HVX_Vector hvx_exp_sf(HVX_Vector x) {
   const HVX_Vector log2e = hvx_splat_sf(1.44269504f); /* 1/ln(2) */
-  /* ln2_hi + ln2_lo == ln2, split so that k*ln2_hi is exact (see the
+  /** ln2_hi + ln2_lo == ln2, split so that k*ln2_hi is exact (see the
      range-reduction comment below for why one f32 constant is not enough
      and how this split fixes it). */
   const HVX_Vector ln2_hi = hvx_splat_sf(0.693359375f);
   const HVX_Vector ln2_lo = hvx_splat_sf(-2.12194440e-4f);
   const HVX_Vector zero = Q6_V_vzero();
 
-  /* Clamp the bottom. Without it a -1e30 input pushes x/ln2 past the
+  /** Clamp the bottom. Without it a -1e30 input pushes x/ln2 past the
      |v| <= 2^22 domain of hvx_sf_to_w_rne, k comes out as garbage, and the
      underflow guard below can be fooled into passing it through. -120
      underflows to zero anyway, so nothing representable is lost. */
   x = Q6_Vsf_vmax_VsfVsf(x, hvx_splat_sf(-120.0f));
 
-  /* k = round(x / ln2), kf = (float)k.
+  /** k = round(x / ln2), kf = (float)k.
      The two directions are asymmetric: Q6_Vw_equals_Vsf rounds toward
      zero, so f32 -> int32 goes through the magic-number identity in
      hvx_convert.h, while int32 -> f32 is a single numeric convert (the
@@ -74,7 +74,7 @@ static inline HVX_Vector hvx_exp_sf(HVX_Vector x) {
   const HVX_Vector k = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(x, log2e));
   const HVX_Vector kf = Q6_Vsf_equals_Vw(k);
 
-  /* r = x - kf*ln2, in [-ln2/2, ln2/2]. Computed in qf32 (dropping to Vsf
+  /** r = x - kf*ln2, in [-ln2/2, ln2/2]. Computed in qf32 (dropping to Vsf
      only once, at the end) because x and kf*ln2 are close in magnitude
      here, and a plain-Vsf multiply would round away precision before the
      subtraction's cancellation amplifies it.
@@ -91,7 +91,7 @@ static inline HVX_Vector hvx_exp_sf(HVX_Vector x) {
   const HVX_Vector r =
     Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_Vqf32Vqf32(r_hi_qf32, kf_ln2_lo_qf32));
 
-  /* p = 1 + r + r^2 * (1/2! + r*(1/3! + r*(1/4! + r*(1/5! + r*(1/6! +
+  /** p = 1 + r + r^2 * (1/2! + r*(1/3! + r*(1/4! + r*(1/5! + r*(1/6! +
    *     r/7!)))))
      Coefficients are written as 1/n! rather than hex bit patterns so the
      value's origin stays in the source; the compiler folds them.
@@ -129,11 +129,11 @@ static inline HVX_Vector hvx_exp_sf(HVX_Vector x) {
 
   const HVX_Vector p = Q6_Vsf_equals_Vqf32(p_qf32);
 
-  /* p is in [0.707, 1.414], so its exponent field is 126 or 127. Adding
+  /** p is in [0.707, 1.414], so its exponent field is 126 or 127. Adding
      k there multiplies by 2^k. */
   const HVX_Vector y = Q6_Vw_vaslacc_VwVwR(p, k, 23);
 
-  /* If k plus that exponent lands at zero or below, the true result is
+  /** If k plus that exponent lands at zero or below, the true result is
      subnormal or smaller and the bit add produced garbage, not a small
      number. Shift off the sign bit, pull the 8 exponent bits down. */
   const HVX_Vector p_exp = Q6_Vuw_vlsr_VuwR(Q6_Vw_vasl_VwR(p, 1), 24);

--- a/nntrainer/tensor/htp_backend/hvx/hvx_exp_f32.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_exp_f32.h
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_exp_f32.h
+ * @date   05 Aug 2026
+ * @brief  Vector exp() over f32 lanes for HVX
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_EXP_F32_H__
+#define __NNTRAINER_HVX_EXP_F32_H__
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+
+/**
+ * @brief exp(x) for every f32 lane.
+ *
+ * exp(x) = 2^k * exp(r) with k an integer and r near zero. 2^k is not
+ * computed; k is added to the exponent field, one instruction. So the
+ * polynomial only has to cover r.
+ *
+ * k comes from round-to-nearest, not floor. That halves r's range to
+ * [-ln2/2, ln2/2], which cuts the residue of a given degree by 2^(degree+1).
+ * It also means the reduction is hvx_sf_to_w_rne, which already exists --
+ * HVX has no floor instruction, so floor would need its own bit-twiddling
+ * helper.
+ *
+ * The polynomial is 7th order to keep the worst-case relative error under
+ * 1e-6 across the domain below. Both the range reduction (x - kf*ln2) and
+ * the polynomial's Horner recurrence are computed in the qf32
+ * extended-precision format rather than plain Vsf: on real HVX hardware,
+ * chained Vsf multiply-adds lose precision that qf32 retains, so every
+ * vmpy/vadd in both steps below routes through qf32 and only drops to Vsf
+ * once, at the very end.
+ *
+ * Domain:
+ *   x >= -87.3     relative error <= 1e-6.
+ *   x <~ -87.7     returns 0. The true value is subnormal there and this
+ *                  flushes it, which is what softmax wants: it feeds
+ *                  x - max, and a term that small cannot move a sum of 1.
+ *   x >  88.7      UNDEFINED, and not an infinity -- there is no overflow
+ *                  clamp. softmax feeds x - max <= 0, so a clamp would
+ *                  cost instructions on an unreachable path.
+ *   NaN / Inf      undefined.
+ *
+ * x == 0 returns exactly 1.0f.
+ */
+static inline HVX_Vector hvx_exp_sf(HVX_Vector x) {
+  const HVX_Vector log2e = hvx_splat_sf(1.44269504f); /* 1/ln(2) */
+  /* ln2_hi + ln2_lo == ln2, split so that k*ln2_hi is exact (see the
+     range-reduction comment below for why one f32 constant is not enough
+     and how this split fixes it). */
+  const HVX_Vector ln2_hi = hvx_splat_sf(0.693359375f);
+  const HVX_Vector ln2_lo = hvx_splat_sf(-2.12194440e-4f);
+  const HVX_Vector zero = Q6_V_vzero();
+
+  /* Clamp the bottom. Without it a -1e30 input pushes x/ln2 past the
+     |v| <= 2^22 domain of hvx_sf_to_w_rne, k comes out as garbage, and the
+     underflow guard below can be fooled into passing it through. -120
+     underflows to zero anyway, so nothing representable is lost. */
+  x = Q6_Vsf_vmax_VsfVsf(x, hvx_splat_sf(-120.0f));
+
+  /* k = round(x / ln2), kf = (float)k.
+     The two directions are asymmetric: Q6_Vw_equals_Vsf rounds toward
+     zero, so f32 -> int32 goes through the magic-number identity in
+     hvx_convert.h, while int32 -> f32 is a single numeric convert (the
+     same one hvx_dequant_i32.c uses). */
+  const HVX_Vector k = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(x, log2e));
+  const HVX_Vector kf = Q6_Vsf_equals_Vw(k);
+
+  /* r = x - kf*ln2, in [-ln2/2, ln2/2]. Computed in qf32 (dropping to Vsf
+     only once, at the end) because x and kf*ln2 are close in magnitude
+     here, and a plain-Vsf multiply would round away precision before the
+     subtraction's cancellation amplifies it.
+
+     ln2 itself is split into ln2_hi + ln2_lo (the Cephes/fdlibm/SLEEF/
+     glibc technique): a single f32 constant only carries ~24 mantissa
+     bits, too few once k*ln2 is computed for |k| up to ~170 over this
+     domain. ln2_hi's low mantissa bits are zero, so k*ln2_hi is exact in
+     f32; ln2_lo is the tiny remainder that recovers the rest. */
+  const HVX_Vector kf_ln2_hi_qf32 = Q6_Vqf32_vmpy_VsfVsf(kf, ln2_hi);
+  const HVX_Vector x_qf32 = Q6_Vqf32_vadd_VsfVsf(x, zero);
+  const HVX_Vector r_hi_qf32 = Q6_Vqf32_vsub_Vqf32Vqf32(x_qf32, kf_ln2_hi_qf32);
+  const HVX_Vector kf_ln2_lo_qf32 = Q6_Vqf32_vmpy_VsfVsf(kf, ln2_lo);
+  const HVX_Vector r =
+    Q6_Vsf_equals_Vqf32(Q6_Vqf32_vsub_Vqf32Vqf32(r_hi_qf32, kf_ln2_lo_qf32));
+
+  /* p = 1 + r + r^2 * (1/2! + r*(1/3! + r*(1/4! + r*(1/5! + r*(1/6! +
+   *     r/7!)))))
+     Coefficients are written as 1/n! rather than hex bit patterns so the
+     value's origin stays in the source; the compiler folds them.
+
+     This Horner recurrence runs in qf32, for the same reason the
+     reduction above does: chained plain-Vsf multiply/adds don't hold
+     full precision through real HVX hardware, so every vmpy and vadd
+     here is qf32. Q6_Vqf32_vadd_Vqf32Vsf's own output is already a valid
+     operand to Q6_Vqf32_vmpy_Vqf32Vqf32, so no extra renormalizing add is
+     needed between steps. r itself is lifted to qf32 once, up front, and
+     reused. p only comes back to Vsf at the very end, right before the
+     exponent injection below, which still operates on plain Vsf. */
+  const HVX_Vector r_qf32 = Q6_Vqf32_vadd_VsfVsf(r, zero);
+
+  HVX_Vector p_qf32 = Q6_Vqf32_vmpy_VsfVsf(hvx_splat_sf(1.0f / 5040.0f), r);
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vsf(p_qf32, hvx_splat_sf(1.0f / 720.0f));
+
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vsf(p_qf32, hvx_splat_sf(1.0f / 120.0f));
+
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vsf(p_qf32, hvx_splat_sf(1.0f / 24.0f));
+
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vsf(p_qf32, hvx_splat_sf(1.0f / 6.0f));
+
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vsf(p_qf32, hvx_splat_sf(0.5f));
+
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+  p_qf32 = Q6_Vqf32_vmpy_Vqf32Vqf32(p_qf32, r_qf32);
+
+  const HVX_Vector r_plus_1_qf32 = Q6_Vqf32_vadd_VsfVsf(r, hvx_splat_sf(1.0f));
+  p_qf32 = Q6_Vqf32_vadd_Vqf32Vqf32(p_qf32, r_plus_1_qf32);
+
+  const HVX_Vector p = Q6_Vsf_equals_Vqf32(p_qf32);
+
+  /* p is in [0.707, 1.414], so its exponent field is 126 or 127. Adding
+     k there multiplies by 2^k. */
+  const HVX_Vector y = Q6_Vw_vaslacc_VwVwR(p, k, 23);
+
+  /* If k plus that exponent lands at zero or below, the true result is
+     subnormal or smaller and the bit add produced garbage, not a small
+     number. Shift off the sign bit, pull the 8 exponent bits down. */
+  const HVX_Vector p_exp = Q6_Vuw_vlsr_VuwR(Q6_Vw_vasl_VwR(p, 1), 24);
+  const HVX_VectorPred underflow =
+    Q6_Q_vcmp_gt_VwVw(zero, Q6_Vw_vadd_VwVw(k, p_exp));
+
+  return Q6_V_vmux_QVV(underflow, zero, y);
+}
+
+#endif /* __NNTRAINER_HVX_EXP_F32_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -79,7 +79,7 @@ void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
       continue; /* leaves scale 1, zp 0 */
     }
     const float s = (rmax - rmin) / 255.0f;
-    /* nearbyintf, not roundf: the vectorized path rounds to nearest even
+    /** nearbyintf, not roundf: the vectorized path rounds to nearest even
        and the host reference is written to match. */
     int32_t z = (int32_t)nearbyintf(-rmin / s);
     if (z < 0) {

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_quant_u8.c
+ * @date   03 Aug 2026
+ * @brief  Per-row asymmetric uint8 dynamic activation quantization
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <math.h>
+#include <string.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+#include "hvx_quant_u8.h"
+
+/** @brief HMX activation tile geometry, mirrored from hexkl_micro.h. */
+#define TILE_ROW 64u
+#define TILE_INNER 32u
+#define ACT_TILE_BYTES 2048u
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 lanes per HVX vector. */
+#define FLANES (VLEN / 4u)
+
+void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
+                              uint32_t k, float *scale, int32_t *zp) {
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    scale[m] = 1.0f;
+    zp[m] = 0;
+  }
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float *row = x + (size_t)m * k;
+    const uint32_t n_vec = k / FLANES;
+    float min0 = row[0];
+    float max0 = row[0];
+
+    if (n_vec > 0) {
+      // FastRPC buffers carry no vector alignment guarantee, so the
+      // unaligned vector type is what keeps this from faulting.
+      const HVX_UVector *vrow = (const HVX_UVector *)row;
+      HVX_Vector vmin = vrow[0];
+      HVX_Vector vmax = vrow[0];
+      for (uint32_t i = 1; i < n_vec; ++i) {
+        vmin = Q6_Vsf_vmin_VsfVsf(vmin, vrow[i]);
+        vmax = Q6_Vsf_vmax_VsfVsf(vmax, vrow[i]);
+      }
+      // Fold 32 lanes down to 1 by rotating half the remaining width each
+      // step: 64, 32, 16, 8, 4 bytes.
+      for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
+        vmin = Q6_Vsf_vmin_VsfVsf(vmin, Q6_V_vror_VR(vmin, (int)rot));
+        vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_V_vror_VR(vmax, (int)rot));
+      }
+      float lane_min[FLANES];
+      float lane_max[FLANES];
+      *(HVX_UVector *)lane_min = vmin;
+      *(HVX_UVector *)lane_max = vmax;
+      min0 = lane_min[0];
+      max0 = lane_max[0];
+    }
+
+    for (uint32_t i = n_vec * FLANES; i < k; ++i) {
+      if (row[i] < min0) {
+        min0 = row[i];
+      }
+      if (row[i] > max0) {
+        max0 = row[i];
+      }
+    }
+    const float rmin = min0 < 0.0f ? min0 : 0.0f;
+    const float rmax = max0 > 0.0f ? max0 : 0.0f;
+    if (rmin == rmax) {
+      continue; /* leaves scale 1, zp 0 */
+    }
+    const float s = (rmax - rmin) / 255.0f;
+    /* nearbyintf, not roundf: the vectorized path rounds to nearest even
+       and the host reference is written to match. */
+    int32_t z = (int32_t)nearbyintf(-rmin / s);
+    if (z < 0) {
+      z = 0;
+    }
+    if (z > 255) {
+      z = 255;
+    }
+    scale[m] = s;
+    zp[m] = z;
+  }
+}
+
+void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                          uint32_t k, const float *scale, const int32_t *zp,
+                          uint8_t *out_ah) {
+  const uint32_t n_ktiles = k / TILE_INNER;
+
+  memset(out_ah, 0, (size_t)m_pad * k);
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float *row = x + (size_t)m * k;
+    const float inv_s = 1.0f / scale[m];
+    const int32_t z = zp[m];
+    const uint32_t rb = m / TILE_ROW;
+    const uint32_t r = m % TILE_ROW;
+
+    const HVX_Vector vinv = hvx_splat_sf(inv_s);
+    const HVX_Vector vz = Q6_V_vsplat_R(z);
+    const HVX_Vector vlo = Q6_V_vzero();
+    const HVX_Vector vhi = Q6_V_vsplat_R(255);
+
+    for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+      const HVX_UVector *vin = (const HVX_UVector *)(row + kt * TILE_INNER);
+      // 32 f32 lanes is exactly one vector, and TILE_INNER is 32.
+      HVX_Vector vq = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin[0], vinv));
+      vq = Q6_Vw_vadd_VwVw(vq, vz);
+      vq = Q6_Vw_vmax_VwVw(vq, vlo);
+      vq = Q6_Vw_vmin_VwVw(vq, vhi);
+
+      // Only the low 32 lanes carry data, so stage the vector and copy the
+      // 32 bytes we want. A packed store would need three quarters of the
+      // vector to be live.
+      int32_t lane[FLANES];
+      *(HVX_UVector *)lane = vq;
+      uint8_t *dst =
+        out_ah + (size_t)(rb * n_ktiles + kt) * ACT_TILE_BYTES + r * TILE_INNER;
+      for (uint32_t c = 0; c < TILE_INNER; ++c) {
+        dst[c] = (uint8_t)lane[c];
+      }
+    }
+  }
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_quant_u8.h
+ * @date   03 Aug 2026
+ * @brief  Per-row asymmetric uint8 dynamic activation quantization
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_QUANT_U8_H__
+#define __NNTRAINER_HVX_QUANT_U8_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Computes the per-row scale and zero point (K1).
+ *
+ * x[m][k] is recovered as scale[m] * (u[m][k] - zp[m]).
+ *
+ * Rows at or past @a m_valid are padding: they get scale 1 and zp 0 so a
+ * host reference can reproduce them without special cases.
+ *
+ * @param[in]  x        activation, m_valid rows by k columns, row-major f32
+ * @param[in]  m_valid  rows carrying real data
+ * @param[in]  m_pad    rows after padding up to a multiple of 64
+ * @param[out] scale    m_pad entries
+ * @param[out] zp       m_pad entries, each in [0, 255]
+ */
+void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
+                              uint32_t k, float *scale, int32_t *zp);
+
+/**
+ * @brief Quantizes to uint8 and writes AH tiles (K2).
+ *
+ * Writes directly in the layout the HMX activation port expects: 64x32
+ * tiles, flat row-major inside a tile, tiles in (row_block, inner_tile)
+ * order at a 2048-byte stride. No separate layout pass is needed for
+ * 8-bit activations.
+ *
+ * Rounding is round-to-nearest-even, matching hvx_sf_to_w_rne.
+ *
+ * @param[in]  out_ah  destination, m_pad * k bytes. Usually VTCM, and then
+ *                     it must be 2048-byte aligned.
+ */
+void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                          uint32_t k, const float *scale, const int32_t *zp,
+                          uint8_t *out_ah);
+
+#endif /* __NNTRAINER_HVX_QUANT_U8_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_softmax_f32.c
+ * @date   05 Aug 2026
+ * @brief  Row-wise f32 softmax on HVX
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+#include "hvx_exp_f32.h"
+#include "hvx_softmax_f32.h"
+
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 lanes per HVX vector. */
+#define LANES (VLEN / 4u)
+
+/**
+ * @brief Loads n < LANES floats into lanes 0..n-1, filling the rest with pad.
+ *
+ * Staging through an aligned stack buffer rather than reading a vector
+ * straight off the row end: that read would run up to 124 bytes past the
+ * buffer, which rpcmem's page granularity usually hides and occasionally
+ * does not. It also keeps whatever lives past the row out of the
+ * reductions. Same idiom as hvx_quant_u8.c.
+ */
+static inline HVX_Vector load_tail_sf(const float *p, uint32_t n, float pad) {
+  float buf[LANES] __attribute__((aligned(VLEN)));
+
+  for (uint32_t i = 0; i < LANES; ++i) {
+    buf[i] = pad;
+  }
+  memcpy(buf, p, (size_t)n * sizeof(float));
+  return *(const HVX_Vector *)buf;
+}
+
+/** @brief Stores lanes 0..n-1, leaving everything past them untouched. */
+static inline void store_tail_sf(float *p, uint32_t n, HVX_Vector v) {
+  float buf[LANES] __attribute__((aligned(VLEN)));
+
+  *(HVX_Vector *)buf = v;
+  memcpy(p, buf, (size_t)n * sizeof(float));
+}
+
+/**
+ * @brief Folds 32 lanes into one value, replicated across every lane.
+ *
+ * Rotate by half the remaining width each step: 64, 32, 16, 8, 4 bytes.
+ * Same shape as the reduction in hvx_quant_u8.c.
+ */
+static inline HVX_Vector reduce_max_sf(HVX_Vector v) {
+  for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
+    v = Q6_Vsf_vmax_VsfVsf(v, Q6_V_vror_VR(v, (int)rot));
+  }
+  return v;
+}
+
+/** @copydoc reduce_max_sf */
+static inline HVX_Vector reduce_sum_sf(HVX_Vector v) {
+  for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
+    v = Q6_Vsf_vadd_VsfVsf(v, Q6_V_vror_VR(v, (int)rot));
+  }
+  return v;
+}
+
+/** @brief Pulls lane 0 out as a scalar. */
+static inline float lane0_sf(HVX_Vector v) {
+  float x;
+  store_tail_sf(&x, 1u, v);
+  return x;
+}
+
+void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
+                          uint32_t m_last, uint32_t k, float scale) {
+  const uint32_t nvec = k / LANES;
+  const uint32_t nloe = k % LANES;
+  const HVX_Vector vscale = hvx_splat_sf(scale);
+
+  for (uint32_t m = m_first; m < m_last; ++m) {
+    const float *xr = x + (size_t)m * k;
+    float *yr = y + (size_t)m * k;
+
+    // FastRPC buffers carry no vector alignment guarantee, so the
+    // unaligned vector type is what keeps this from faulting.
+    const HVX_UVector *vx = (const HVX_UVector *)xr;
+    HVX_UVector *vy = (HVX_UVector *)yr;
+
+    /* Pass 1: max of x*scale. Scaling here instead of using
+       scale*max(x) is what keeps a negative scale correct -- a negative
+       scale flips which element is the maximum. */
+    HVX_Vector vmax = hvx_splat_sf(xr[0] * scale);
+    for (uint32_t v = 0; v < nvec; ++v) {
+      vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_Vsf_vmpy_VsfVsf(vx[v], vscale));
+    }
+    if (nloe) {
+      /* Pad with a real element of the row: it can never beat the max. */
+      const HVX_Vector t = load_tail_sf(xr + nvec * LANES, nloe, xr[0]);
+      vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_Vsf_vmpy_VsfVsf(t, vscale));
+    }
+    const HVX_Vector vm = reduce_max_sf(vmax);
+
+    /* Pass 2: y = exp(x*scale - max), summing as we go. The exp results
+       go straight to y, so no scratch buffer is needed; pass 3 scales
+       them in place. Reading vx[v] before writing vy[v] at the same index
+       is what makes y == x safe.
+
+       The sum accumulates in qf32 for the extra mantissa headroom: there
+       are k/32 accumulation steps and the output tolerance is 1e-6.
+       Adding two zeros is how a canonical qf32 zero is obtained. */
+    HVX_Vector acc = Q6_Vqf32_vadd_VsfVsf(Q6_V_vzero(), Q6_V_vzero());
+    for (uint32_t v = 0; v < nvec; ++v) {
+      const HVX_Vector e =
+        hvx_exp_sf(Q6_Vsf_vsub_VsfVsf(Q6_Vsf_vmpy_VsfVsf(vx[v], vscale), vm));
+      vy[v] = e;
+      acc = Q6_Vqf32_vadd_Vqf32Vsf(acc, e);
+    }
+    if (nloe) {
+      const HVX_Vector t = load_tail_sf(xr + nvec * LANES, nloe, 0.0f);
+      HVX_Vector e =
+        hvx_exp_sf(Q6_Vsf_vsub_VsfVsf(Q6_Vsf_vmpy_VsfVsf(t, vscale), vm));
+      /* The pad lanes hold exp(0*scale - max), not zero, so they have to
+         be masked off before they reach the sum. Padding the input cannot
+         fix this: no input value maps to an exact zero after exp. */
+      e = Q6_V_vmux_QVV(Q6_Q_vsetq2_R((int)(nloe * 4u)), e, Q6_V_vzero());
+      store_tail_sf(yr + nvec * LANES, nloe, e);
+      acc = Q6_Vqf32_vadd_Vqf32Vsf(acc, e);
+    }
+    const float sum = lane0_sf(reduce_sum_sf(Q6_Vsf_equals_Vqf32(acc)));
+
+    /* Pass 3: normalize in place. sum is one scalar replicated across the
+       vector, so a scalar reciprocal is both exact and cheaper than a
+       vector Newton iteration. sum is at least 1 in exact arithmetic --
+       the maximum element contributes exp(0) -- so the guard is only
+       there for a row of NaNs. */
+    const HVX_Vector vr = hvx_splat_sf(sum > 0.0f ? 1.0f / sum : 1.0f);
+    for (uint32_t v = 0; v < nvec; ++v) {
+      vy[v] = Q6_Vsf_vmpy_VsfVsf(vy[v], vr);
+    }
+
+    if (nloe) {
+      const HVX_Vector t = load_tail_sf(yr + nvec * LANES, nloe, 0.0f);
+      store_tail_sf(yr + nvec * LANES, nloe, Q6_Vsf_vmpy_VsfVsf(t, vr));
+    }
+  }
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
@@ -95,7 +95,7 @@ void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
     const HVX_UVector *vx = (const HVX_UVector *)xr;
     HVX_UVector *vy = (HVX_UVector *)yr;
 
-    /* Pass 1: max of x*scale. Scaling here instead of using
+    /** Pass 1: max of x*scale. Scaling here instead of using
        scale*max(x) is what keeps a negative scale correct -- a negative
        scale flips which element is the maximum. */
     HVX_Vector vmax = hvx_splat_sf(xr[0] * scale);
@@ -109,7 +109,7 @@ void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
     }
     const HVX_Vector vm = reduce_max_sf(vmax);
 
-    /* Pass 2: y = exp(x*scale - max), summing as we go. The exp results
+    /** Pass 2: y = exp(x*scale - max), summing as we go. The exp results
        go straight to y, so no scratch buffer is needed; pass 3 scales
        them in place. Reading vx[v] before writing vy[v] at the same index
        is what makes y == x safe.
@@ -128,7 +128,7 @@ void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
       const HVX_Vector t = load_tail_sf(xr + nvec * LANES, nloe, 0.0f);
       HVX_Vector e =
         hvx_exp_sf(Q6_Vsf_vsub_VsfVsf(Q6_Vsf_vmpy_VsfVsf(t, vscale), vm));
-      /* The pad lanes hold exp(0*scale - max), not zero, so they have to
+      /** The pad lanes hold exp(0*scale - max), not zero, so they have to
          be masked off before they reach the sum. Padding the input cannot
          fix this: no input value maps to an exact zero after exp. */
       e = Q6_V_vmux_QVV(Q6_Q_vsetq2_R((int)(nloe * 4u)), e, Q6_V_vzero());
@@ -137,7 +137,7 @@ void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
     }
     const float sum = lane0_sf(reduce_sum_sf(Q6_Vsf_equals_Vqf32(acc)));
 
-    /* Pass 3: normalize in place. sum is one scalar replicated across the
+    /** Pass 3: normalize in place. sum is one scalar replicated across the
        vector, so a scalar reciprocal is both exact and cheaper than a
        vector Newton iteration. sum is at least 1 in exact arithmetic --
        the maximum element contributes exp(0) -- so the guard is only

--- a/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.c
@@ -23,7 +23,7 @@
 /** @brief HVX vector width in bytes (128B mode). */
 #define VLEN 128u
 /** @brief f32 lanes per HVX vector. */
-#define LANES (VLEN / 4u)
+#define LANES (VLEN / sizeof(float))
 
 /**
  * @brief Loads n < LANES floats into lanes 0..n-1, filling the rest with pad.

--- a/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_softmax_f32.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_softmax_f32.h
+ * @date   05 Aug 2026
+ * @brief  Row-wise f32 softmax on HVX
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_SOFTMAX_F32_H__
+#define __NNTRAINER_HVX_SOFTMAX_F32_H__
+
+#include <stdint.h>
+
+/**
+ * @brief y[m][*] = softmax(x[m][*] * scale) for rows [m_first, m_last).
+ *
+ * Rows are dense with stride @a k and are independent of each other, so
+ * this knows nothing about threads: calling it with (0, m) is the whole
+ * matrix, and a worker pool can hand each thread its own row range. The
+ * range shape mirrors hvx_dequant_i32_to_f32.
+ *
+ * @a y may alias @a x.
+ *
+ * @param[in]  x        m_last*k floats, row-major. No alignment requirement
+ * @param[out] y        same shape as @a x; may be the same pointer
+ * @param[in]  m_first  first row to process
+ * @param[in]  m_last   one past the last row
+ * @param[in]  k        row length, at least 1
+ * @param[in]  scale    folded into x before the softmax
+ */
+void hvx_softmax_rows_f32(const float *x, float *y, uint32_t m_first,
+                          uint32_t m_last, uint32_t k, float scale);
+
+#endif /* __NNTRAINER_HVX_SOFTMAX_F32_H__ */

--- a/test/htp/.gitignore
+++ b/test/htp/.gitignore
@@ -1,0 +1,2 @@
+generated/
+build/

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -41,6 +41,7 @@ mkdir -p generated build
 
 SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -4,7 +4,10 @@
 # Generates the FastRPC stub/skel from nntr_hvx.idl and builds the DSP skel.
 #
 # Prerequisite: source $HEXAGON_SDK_ROOT/setup_sdk_env.source
+#   The SDK must be 6.1.1.0 or newer: HexKL ships libhexkl_micro.a for v79
+#   only from lib/6.1.1.0 up. 6.4.0.1 is the verified combination.
 # Override the target with: HEX_ARCH=v75 ./build.sh
+# Override HexKL with:      HEXKL_ROOT=/path/to/hexkl_addon ./build.sh
 
 set -eu
 
@@ -12,7 +15,21 @@ set -eu
 : "${DEFAULT_HEXAGON_TOOLS_ROOT:?source setup_sdk_env.source first}"
 
 HEX_ARCH="${HEX_ARCH:-v79}"
+HEXKL_ROOT="${HEXKL_ROOT:-$HOME/Downloads/hexkl_addon}"
+HEXKL_SDK_VER="${HEXKL_SDK_VER:-6.4.0.1}"
+HEXKL_TOOLS_VARIANT="${HEXKL_TOOLS_VARIANT:-toolv19}"
+HEXKL_LIB="$HEXKL_ROOT/lib/$HEXKL_SDK_VER/hexagon_${HEXKL_TOOLS_VARIANT}_${HEX_ARCH}/libhexkl_micro.a"
+
+if [ ! -f "$HEXKL_LIB" ]; then
+    echo "Error: HexKL static library not found:" >&2
+    echo "  $HEXKL_LIB" >&2
+    echo "HexKL provides v79 only for lib/6.1.1.0 and newer." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BACKEND="$REPO_ROOT/nntrainer/tensor/htp_backend"
 cd "$SCRIPT_DIR"
 
 mkdir -p generated build
@@ -22,16 +39,23 @@ mkdir -p generated build
     -I "$HEXAGON_SDK_ROOT/incs/stddef" \
     -mdll -o generated nntr_hvx.idl
 
+SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \
     -Wall -Werror \
     -I generated \
+    -I "$HEXKL_ROOT/include" \
+    -I "$BACKEND/hvx" \
+    -I "$BACKEND/hmx" \
     -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/qurt" \
     -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/posix" \
     -isystem "$HEXAGON_SDK_ROOT/incs" \
     -isystem "$HEXAGON_SDK_ROOT/incs/stddef" \
     -isystem "$HEXAGON_SDK_ROOT/ipc/fastrpc/incs" \
-    hvx_add_f32.c generated/nntr_hvx_skel.c \
+    $SRCS \
+    "$HEXKL_LIB" \
     -o build/libnntr_hvx_skel.so
 
-echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH)"
+echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH, hexkl $HEXKL_SDK_VER)"

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates the FastRPC stub/skel from nntr_hvx.idl and builds the DSP skel.
+#
+# Prerequisite: source $HEXAGON_SDK_ROOT/setup_sdk_env.source
+# Override the target with: HEX_ARCH=v75 ./build.sh
+
+set -eu
+
+: "${HEXAGON_SDK_ROOT:?source setup_sdk_env.source first}"
+: "${DEFAULT_HEXAGON_TOOLS_ROOT:?source setup_sdk_env.source first}"
+
+HEX_ARCH="${HEX_ARCH:-v79}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+mkdir -p generated build
+
+"$HEXAGON_SDK_ROOT/ipc/fastrpc/qaic/Ubuntu/qaic" \
+    -I "$HEXAGON_SDK_ROOT/incs" \
+    -I "$HEXAGON_SDK_ROOT/incs/stddef" \
+    -mdll -o generated nntr_hvx.idl
+
+"$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
+    -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \
+    -Wall -Werror \
+    -I generated \
+    -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/qurt" \
+    -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/posix" \
+    -isystem "$HEXAGON_SDK_ROOT/incs" \
+    -isystem "$HEXAGON_SDK_ROOT/incs/stddef" \
+    -isystem "$HEXAGON_SDK_ROOT/ipc/fastrpc/incs" \
+    hvx_add_f32.c generated/nntr_hvx_skel.c \
+    -o build/libnntr_hvx_skel.so
+
+echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH)"

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -39,7 +39,7 @@ mkdir -p generated build
     -I "$HEXAGON_SDK_ROOT/incs/stddef" \
     -mdll -o generated nntr_hvx.idl
 
-SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
+SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c nntr_hvx_softmax.c generated/nntr_hvx_skel.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -40,7 +40,8 @@ mkdir -p generated build
     -mdll -o generated nntr_hvx.idl
 
 SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c nntr_hvx_softmax.c generated/nntr_hvx_skel.c"
-SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c $BACKEND/hmx/hexkl_mm_u8i4_dma.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_dma_ring.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_softmax_f32.c"
 

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -42,6 +42,7 @@ mkdir -p generated build
 SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c nntr_hvx_softmax.c generated/nntr_hvx_skel.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
+SRCS="$SRCS $BACKEND/hvx/hvx_softmax_f32.c"
 
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
- * @file   hvx_add_f32.c
- * @brief  DSP-side implementation of the nntr_hvx FastRPC interface.
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
  *
- * Built into libnntr_hvx_skel.so and loaded into the CDSP unsigned PD.
+ * @file   hvx_add_f32.c
+ * @date   03 Aug 2026
+ * @brief  DSP-side implementation of the nntr_hvx FastRPC interface
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <stdlib.h>
@@ -51,8 +55,8 @@ int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
     return AEE_EUNSUPPORTED;
   }
 
-  /* FastRPC buffers carry no vector alignment guarantee, so the unaligned
-     vector type is what keeps this from faulting on a misaligned input. */
+  // FastRPC buffers carry no vector alignment guarantee, so the unaligned
+  // vector type is what keeps this from faulting on a misaligned input.
   const HVX_UVector *va = (const HVX_UVector *)a;
   const HVX_UVector *vb = (const HVX_UVector *)b;
   HVX_UVector *vc = (HVX_UVector *)c;
@@ -62,8 +66,8 @@ int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
     vc[i] = Q6_Vsf_vadd_VsfVsf(va[i], vb[i]);
   }
 
-  /* ponytail: scalar tail; a masked vector store would fold it in, add
-     that only if the tail shows up in a profile. */
+  // ponytail: scalar tail; a masked vector store would fold it in, add
+  // that only if the tail shows up in a profile.
   for (int i = n_vec * LANES; i < aLen; ++i) {
     c[i] = a[i] + b[i];
   }

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   hvx_add_f32.c
+ * @brief  DSP-side implementation of the nntr_hvx FastRPC interface.
+ *
+ * Built into libnntr_hvx_skel.so and loaded into the CDSP unsigned PD.
+ */
+
+#include <stdlib.h>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
+  (void)uri;
+  /* No per-session state; a unique non-NULL handle is all FastRPC needs. */
+  void *ctx = malloc(1);
+  if (!ctx) {
+    return AEE_ENOMEMORY;
+  }
+  *handle = (remote_handle64)ctx;
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_close(remote_handle64 handle) {
+  free((void *)handle);
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
+                     const float *b, int bLen, float *c, int cLen) {
+  (void)handle;
+  (void)a;
+  (void)b;
+  (void)c;
+
+  if (aLen != bLen || aLen != cLen) {
+    return AEE_EBADPARM;
+  }
+
+  /* Not implemented yet -- Task 3 replaces this with the HVX kernel.
+     Reaching this return proves the FastRPC path is up. */
+  return AEE_EUNSUPPORTED;
+}

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -11,7 +11,16 @@
 #include <AEEStdErr.h>
 #include <remote.h>
 
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+#include <qurt.h>
+
 #include "nntr_hvx.h"
+
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128
+/** @brief float lanes per HVX vector. */
+#define LANES ((int)(VLEN / sizeof(float)))
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
   (void)uri;
@@ -32,15 +41,32 @@ int nntr_hvx_close(remote_handle64 handle) {
 int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
                      const float *b, int bLen, float *c, int cLen) {
   (void)handle;
-  (void)a;
-  (void)b;
-  (void)c;
 
   if (aLen != bLen || aLen != cLen) {
     return AEE_EBADPARM;
   }
 
-  /* Not implemented yet -- Task 3 replaces this with the HVX kernel.
-     Reaching this return proves the FastRPC path is up. */
-  return AEE_EUNSUPPORTED;
+  /* Bits 15:8 hold the number of 128-byte HVX contexts. */
+  if (((qurt_hvx_get_units() >> 8) & 0xFF) == 0) {
+    return AEE_EUNSUPPORTED;
+  }
+
+  /* FastRPC buffers carry no vector alignment guarantee, so the unaligned
+     vector type is what keeps this from faulting on a misaligned input. */
+  const HVX_UVector *va = (const HVX_UVector *)a;
+  const HVX_UVector *vb = (const HVX_UVector *)b;
+  HVX_UVector *vc = (HVX_UVector *)c;
+
+  const int n_vec = aLen / LANES;
+  for (int i = 0; i < n_vec; ++i) {
+    vc[i] = Q6_Vsf_vadd_VsfVsf(va[i], vb[i]);
+  }
+
+  /* ponytail: scalar tail; a masked vector store would fold it in, add
+     that only if the tail shows up in a profile. */
+  for (int i = n_vec * LANES; i < aLen; ++i) {
+    c[i] = a[i] + b[i];
+  }
+
+  return AEE_SUCCESS;
 }

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -11,15 +11,19 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <AEEStdErr.h>
+#include <HAP_farf.h>
 #include <remote.h>
 
 #include <hexagon_types.h>
 #include <hvx_hexagon_protos.h>
 #include <qurt.h>
 
+#include "hexkl_micro.h"
 #include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
 
 /** @brief HVX vector width in bytes (128B mode). */
 #define VLEN 128
@@ -28,18 +32,72 @@
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
   (void)uri;
-  /* No per-session state; a unique non-NULL handle is all FastRPC needs. */
-  void *ctx = malloc(1);
-  if (!ctx) {
+
+  nntr_hvx_session *s = (nntr_hvx_session *)calloc(1, sizeof(nntr_hvx_session));
+  if (!s) {
     return AEE_ENOMEMORY;
   }
-  *handle = (remote_handle64)ctx;
+
+  // hw_init and the HMX lock happen once here, for the session's whole
+  // lifetime, instead of per call (doc15 §3/§4) -- every other entry point
+  // in this skel reaches vtcm_base/vtcm_size/config_off through the
+  // session rather than re-acquiring either.
+  uint32_t hmx_fp16_rate = 0;
+  int res = hexkl_micro_hw_init(&s->vtcm_base, &s->vtcm_size, &hmx_fp16_rate);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: hexkl_micro_hw_init failed: 0x%08x", res);
+    free(s);
+    return res;
+  }
+  // config_off depends only on vtcm_size (see hexkl_mm_u8i4_plan), so it is
+  // computed once here rather than at every mm_u8i4_layer call.
+  const uint32_t config_size = hexkl_micro_hmx_config_size();
+  if (s->vtcm_size < config_size) {
+    free(s);
+    return AEE_ENOMEMORY;
+  }
+  s->config_off =
+    (s->vtcm_size - config_size) & ~(HEXKL_HMX_CONFIG_ALIGNMENT - 1u);
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: hexkl_micro_hmx_lock failed: 0x%08x", res);
+    free(s);
+    return res;
+  }
+  s->hmx_locked = 1;
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(s->vtcm_base, s->config_off);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: setup_acc_read_int32 failed: 0x%08x", res);
+    hexkl_micro_hmx_unlock();
+    free(s);
+    return res;
+  }
+
+  *handle = (remote_handle64)s;
   return AEE_SUCCESS;
 }
 
 int nntr_hvx_close(remote_handle64 handle) {
-  free((void *)handle);
-  return AEE_SUCCESS;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_SUCCESS;
+  }
+  for (uint32_t i = 0; i < HEXKL_MM_U8I4_MAX_WEIGHTS; ++i) {
+    if (s->weights.slots[i].in_use) {
+      hexkl_weight_u8i4_release(&s->weights, i);
+    }
+  }
+  int res = AEE_SUCCESS;
+  if (s->hmx_locked) {
+    res = hexkl_micro_hmx_unlock();
+    if (res != AEE_SUCCESS) {
+      FARF(ERROR, "nntr_hvx_close: hexkl_micro_hmx_unlock failed: 0x%08x", res);
+    }
+  }
+  free(s);
+  return res;
 }
 
 int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -28,8 +28,8 @@
 /** @brief HVX vector width in bytes (128B mode). */
 #define VLEN 128u
 /** @brief f32 lanes per HVX vector. */
-/* Kept as an int-casted expression (not the unsigned LANES form used
-   elsewhere) because n_vec/i in this file's loops are int. */
+/** Kept as an int-casted expression (not the unsigned LANES form used
+    elsewhere) because n_vec/i in this file's loops are int. */
 #define LANES ((int)(VLEN / sizeof(float)))
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
@@ -40,7 +40,7 @@ int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
     return AEE_ENOMEMORY;
   }
 
-  /* Bits 15:8 hold the number of 128-byte HVX contexts. Checked once for
+  /** Bits 15:8 hold the number of 128-byte HVX contexts. Checked once for
      the session: every entry in this skel uses HVX and the unit count does
      not change while a session is open. */
   if (((qurt_hvx_get_units() >> 8) & 0xFF) == 0) {

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -26,8 +26,10 @@
 #include "nntr_hvx_session.h"
 
 /** @brief HVX vector width in bytes (128B mode). */
-#define VLEN 128
-/** @brief float lanes per HVX vector. */
+#define VLEN 128u
+/** @brief f32 lanes per HVX vector. */
+/* Kept as an int-casted expression (not the unsigned LANES form used
+   elsewhere) because n_vec/i in this file's loops are int. */
 #define LANES ((int)(VLEN / sizeof(float)))
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -38,6 +38,14 @@ int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
     return AEE_ENOMEMORY;
   }
 
+  /* Bits 15:8 hold the number of 128-byte HVX contexts. Checked once for
+     the session: every entry in this skel uses HVX and the unit count does
+     not change while a session is open. */
+  if (((qurt_hvx_get_units() >> 8) & 0xFF) == 0) {
+    free(s);
+    return AEE_EUNSUPPORTED;
+  }
+
   // hw_init and the HMX lock happen once here, for the session's whole
   // lifetime, instead of per call (doc15 §3/§4) -- every other entry point
   // in this skel reaches vtcm_base/vtcm_size/config_off through the
@@ -106,11 +114,6 @@ int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,
 
   if (aLen != bLen || aLen != cLen) {
     return AEE_EBADPARM;
-  }
-
-  /* Bits 15:8 hold the number of 128-byte HVX contexts. */
-  if (((qurt_hvx_get_units() >> 8) & 0xFF) == 0) {
-    return AEE_EUNSUPPORTED;
   }
 
   // FastRPC buffers carry no vector alignment guarantee, so the unaligned

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -31,6 +31,7 @@ interface nntr_hvx : remote_handle64 {
    // 엔트리는 tail을 다루지 않는다).
    AEEResult exp_f32(in sequence<float> x, rout sequence<float> y);
 
-   AEEResult softmax_f32(in uint32 M, in uint32 K, in float scale,
-                         in sequence<float> x, rout sequence<float> y);
+   AEEResult softmax_f32(in uint32 M, in uint32 K, in uint32 m_first,
+                         in float scale, in sequence<float> x,
+                         rout sequence<float> y);
 };

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -24,4 +24,13 @@ interface nntr_hvx : remote_handle64 {
                               rout sequence<int32> act_zp,
                               rout sequence<int32> acc_i32,
                               rout sequence<float> out_f32);
+
+   // HVX softmax 검증용. exp을 따로 뚫는 이유: softmax 출력만 보면 exp의
+   // 상대오차가 sum 정규화로 상쇄되어 드러나지 않는다.
+   // xLen은 32의 배수여야 한다 (hvx_exp_sf는 벡터 단위 연산이고, 이
+   // 엔트리는 tail을 다루지 않는다).
+   AEEResult exp_f32(in sequence<float> x, rout sequence<float> y);
+
+   AEEResult softmax_f32(in uint32 M, in uint32 K, in float scale,
+                         in sequence<float> x, rout sequence<float> y);
 };

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -11,14 +11,6 @@ interface nntr_hvx : remote_handle64 {
    AEEResult add_f32(in sequence<float> a, in sequence<float> b,
                      rout sequence<float> c);
 
-   // Accuracy harness: activation already quantized on the host, so this
-   // isolates the weight bake, the WH layout and the HMX matmul.
-   AEEResult mm_u8i4_from_u8(in uint32 M, in uint32 K, in uint32 N,
-                             in sequence<uint8> act_u8_ah,
-                             in sequence<int8> w_i4_rm,
-                             rout sequence<int32> acc_i32,
-                             rout sequence<uint8> w_wh_dump);
-
    // Accuracy harness: the whole flow, quantization and dequantization on
    // the DSP. Intermediate buffers come back so each stage is checkable.
    AEEResult mm_u8i4_from_f32(in uint32 M, in uint32 K, in uint32 N,

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -1,0 +1,13 @@
+//============================================================================
+// SPDX-License-Identifier: Apache-2.0
+//
+// FastRPC interface for HVX kernel device bring-up.
+//============================================================================
+
+#include "AEEStdDef.idl"
+#include "remote.idl"
+
+interface nntr_hvx : remote_handle64 {
+   AEEResult add_f32(in sequence<float> a, in sequence<float> b,
+                     rout sequence<float> c);
+};

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -25,10 +25,11 @@ interface nntr_hvx : remote_handle64 {
                               rout sequence<int32> acc_i32,
                               rout sequence<float> out_f32);
 
-   // HVX softmax 검증용. exp을 따로 뚫는 이유: softmax 출력만 보면 exp의
-   // 상대오차가 sum 정규화로 상쇄되어 드러나지 않는다.
-   // xLen은 32의 배수여야 한다 (hvx_exp_sf는 벡터 단위 연산이고, 이
-   // 엔트리는 tail을 다루지 않는다).
+   // For HVX softmax verification. exp is broken out as its own entry
+   // because looking at softmax output alone hides exp's relative error --
+   // sum normalization cancels it out. xLen must be a multiple of 32 --
+   // hvx_exp_sf operates in whole vectors and this entry does not handle a
+   // tail.
    AEEResult exp_f32(in sequence<float> x, rout sequence<float> y);
 
    AEEResult softmax_f32(in uint32 M, in uint32 K, in uint32 m_first,

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -10,4 +10,26 @@
 interface nntr_hvx : remote_handle64 {
    AEEResult add_f32(in sequence<float> a, in sequence<float> b,
                      rout sequence<float> c);
+
+   // Accuracy harness: activation already quantized on the host, so this
+   // isolates the weight bake, the WH layout and the HMX matmul.
+   AEEResult mm_u8i4_from_u8(in uint32 M, in uint32 K, in uint32 N,
+                             in sequence<uint8> act_u8_ah,
+                             in sequence<int8> w_i4_rm,
+                             rout sequence<int32> acc_i32,
+                             rout sequence<uint8> w_wh_dump);
+
+   // Accuracy harness: the whole flow, quantization and dequantization on
+   // the DSP. Intermediate buffers come back so each stage is checkable.
+   AEEResult mm_u8i4_from_f32(in uint32 M, in uint32 K, in uint32 N,
+                              in sequence<float> act_f32,
+                              in sequence<int8> w_i4_rm,
+                              in sequence<float> w_scale,
+                              in sequence<int32> colsum_w,
+                              in sequence<float> bias,
+                              rout sequence<uint8> act_u8_ah,
+                              rout sequence<float> act_scale,
+                              rout sequence<int32> act_zp,
+                              rout sequence<int32> acc_i32,
+                              rout sequence<float> out_f32);
 };

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -34,4 +34,32 @@ interface nntr_hvx : remote_handle64 {
    AEEResult softmax_f32(in uint32 M, in uint32 K, in uint32 m_first,
                          in float scale, in sequence<float> x,
                          rout sequence<float> y);
+
+   // --- Performance path (doc15 §8 item 3) ---
+   //
+   // Bakes a K x N int4 weight (int4 values in int8 containers, row-major)
+   // to WH layout once and keeps it DSP-resident, along with its dequant
+   // constants, until weight_release_u8i4. hw_init and the HMX lock happen
+   // once in nntr_hvx_open, not per call -- see nntr_hvx_session.h.
+   AEEResult weight_register_u8i4(in uint32 K, in uint32 N,
+                                  in sequence<int8> w_i4_rm,
+                                  in sequence<float> w_scale,
+                                  in sequence<int32> colsum_w,
+                                  in sequence<float> bias,
+                                  rout uint32 w_handle);
+
+   AEEResult weight_release_u8i4(in uint32 w_handle);
+
+   // Runs matmuls against several registered weights that share ONE
+   // quantized activation -- e.g. a Q/K/V or gate/up projection set. Every
+   // handle must have been registered with the same K. Quantizes act_f32
+   // once, double-buffers each handle's weight into VTCM with the next
+   // handle prefetched while the current one computes (doc13 §3a
+   // cross-matmul prefetch: 1.7-2x over SDKL on V79), and returns
+   // dequantized f32 -- one contiguous M x handle[i].N block per handle in
+   // call order.
+   AEEResult mm_u8i4_layer(in uint32 M, in uint32 K,
+                           in sequence<uint32> w_handles,
+                           in sequence<float> act_f32,
+                           rout sequence<float> out_cat);
 };

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -22,8 +22,8 @@
 #include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
 
-/** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
-#define ROUND_UP(v, a) (((v) + ((a)-1)) & ~((a)-1))
+/** @brief Rounds @a v up to a multiple of @a a. */
+#define ROUND_UP(v, a) ((((v) + ((a)-1)) / (a)) * (a))
 
 /**
  * @brief Brings up HMX and reports the VTCM budget.

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   nntr_hvx_mm_u8i4.c
+ * @date   03 Aug 2026
+ * @brief  FastRPC entry points for the HMX u8i4 accuracy harness
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <string.h>
+
+#include <AEEStdErr.h>
+#include <HAP_farf.h>
+#include <remote.h>
+
+#include "hexkl_micro.h"
+#include "hexkl_mm_u8i4.h"
+#include "nntr_hvx.h"
+
+/** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
+#define ROUND_UP(v, a) (((v) + ((a)-1)) & ~((a)-1))
+
+/**
+ * @brief Brings up HMX and reports the VTCM budget.
+ *
+ * Split out because both entry points need the same preamble, and because
+ * the VTCM size it reports is itself a measurement we do not have yet.
+ */
+static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
+  uint32_t hmx_fp16_rate = 0;
+  int res = hexkl_micro_hw_init(vtcm_base, vtcm_size, &hmx_fp16_rate);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hw_init failed: 0x%08x", res);
+    return res;
+  }
+  FARF(ALWAYS, "vtcm_base=%p vtcm_size=%u config_size=%u hmx_fp16_rate=%u",
+       (void *)*vtcm_base, (unsigned)*vtcm_size,
+       (unsigned)hexkl_micro_hmx_config_size(), (unsigned)hmx_fp16_rate);
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_mm_u8i4_from_u8(remote_handle64 handle, uint32 M, uint32 K,
+                             uint32 N, const uint8 *act_u8_ah, int act_u8_ahLen,
+                             const int8 *w_i4_rm, int w_i4_rmLen,
+                             int32 *acc_i32, int acc_i32Len, uint8 *w_wh_dump,
+                             int w_wh_dumpLen) {
+  (void)handle;
+
+  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+
+  if ((uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)w_i4_rmLen != K * N ||
+      (uint32_t)acc_i32Len != m_pad * N) {
+    FARF(ERROR, "bad lengths: act=%d w=%d acc=%d (M=%u K=%u N=%u m_pad=%u)",
+         act_u8_ahLen, w_i4_rmLen, acc_i32Len, (unsigned)M, (unsigned)K,
+         (unsigned)N, (unsigned)m_pad);
+    return AEE_EBADPARM;
+  }
+
+  uint8_t *vtcm_base = NULL;
+  uint32_t vtcm_size = 0;
+  int res = hmx_bringup(&vtcm_base, &vtcm_size);
+  if (res != AEE_SUCCESS) {
+    return res;
+  }
+
+  hexkl_mm_u8i4_layout L;
+  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "plan failed: 0x%08x (need w=%u act=%u, vtcm=%u)", res,
+         (unsigned)L.w_size, (unsigned)L.act_size, (unsigned)vtcm_size);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
+  }
+  if (res == AEE_SUCCESS) {
+    // Activation arrives already in AH layout, so a flat copy places it.
+    memcpy(vtcm_base + L.act_base, act_u8_ah, (size_t)m_pad * K);
+    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
+  }
+  if (res == AEE_SUCCESS && w_wh_dumpLen > 0) {
+    const uint32_t n_copy =
+      (uint32_t)w_wh_dumpLen < L.w_size ? (uint32_t)w_wh_dumpLen : L.w_size;
+    memcpy(w_wh_dump, vtcm_base + L.w_base, n_copy);
+  }
+
+  int res2 = hexkl_micro_hmx_unlock();
+  if (res2 != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
+    if (res == AEE_SUCCESS) {
+      res = res2;
+    }
+  }
+  return res;
+}
+
+int nntr_hvx_mm_u8i4_from_f32(
+  remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
+  int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,
+  int w_scaleLen, const int32 *colsum_w, int colsum_wLen, const float *bias,
+  int biasLen, uint8 *act_u8_ah, int act_u8_ahLen, float *act_scale,
+  int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
+  int acc_i32Len, float *out_f32, int out_f32Len) {
+  (void)handle;
+  (void)M;
+  (void)K;
+  (void)N;
+  (void)act_f32;
+  (void)act_f32Len;
+  (void)w_i4_rm;
+  (void)w_i4_rmLen;
+  (void)w_scale;
+  (void)w_scaleLen;
+  (void)colsum_w;
+  (void)colsum_wLen;
+  (void)bias;
+  (void)biasLen;
+  (void)act_u8_ah;
+  (void)act_u8_ahLen;
+  (void)act_scale;
+  (void)act_scaleLen;
+  (void)act_zp;
+  (void)act_zpLen;
+  (void)acc_i32;
+  (void)acc_i32Len;
+  (void)out_f32;
+  (void)out_f32Len;
+  return AEE_EUNSUPPORTED;
+}

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -18,6 +18,8 @@
 
 #include "hexkl_micro.h"
 #include "hexkl_mm_u8i4.h"
+#include "hvx_dequant_i32.h"
+#include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
 
 /** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
@@ -113,28 +115,64 @@ int nntr_hvx_mm_u8i4_from_f32(
   int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
   int acc_i32Len, float *out_f32, int out_f32Len) {
   (void)handle;
-  (void)M;
-  (void)K;
-  (void)N;
-  (void)act_f32;
-  (void)act_f32Len;
-  (void)w_i4_rm;
-  (void)w_i4_rmLen;
-  (void)w_scale;
-  (void)w_scaleLen;
-  (void)colsum_w;
-  (void)colsum_wLen;
-  (void)bias;
-  (void)biasLen;
-  (void)act_u8_ah;
-  (void)act_u8_ahLen;
-  (void)act_scale;
-  (void)act_scaleLen;
-  (void)act_zp;
-  (void)act_zpLen;
-  (void)acc_i32;
-  (void)acc_i32Len;
-  (void)out_f32;
-  (void)out_f32Len;
-  return AEE_EUNSUPPORTED;
+
+  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+
+  if ((uint32_t)act_f32Len != M * K || (uint32_t)w_i4_rmLen != K * N ||
+      (uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)act_scaleLen != m_pad ||
+      (uint32_t)act_zpLen != m_pad || (uint32_t)acc_i32Len != m_pad * N ||
+      (uint32_t)w_scaleLen != N || (uint32_t)colsum_wLen != N ||
+      (uint32_t)biasLen != N || (uint32_t)out_f32Len != M * N) {
+    FARF(ERROR, "bad lengths (M=%u K=%u N=%u m_pad=%u)", (unsigned)M,
+         (unsigned)K, (unsigned)N, (unsigned)m_pad);
+    return AEE_EBADPARM;
+  }
+
+  uint8_t *vtcm_base = NULL;
+  uint32_t vtcm_size = 0;
+  int res = hmx_bringup(&vtcm_base, &vtcm_size);
+  if (res != AEE_SUCCESS) {
+    return res;
+  }
+
+  hexkl_mm_u8i4_layout L;
+  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "plan failed: 0x%08x", res);
+    return res;
+  }
+
+  // K1 then K2, writing the AH tiles straight into VTCM.
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
+  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                       vtcm_base + L.act_base);
+  memcpy(act_u8_ah, vtcm_base + L.act_base, (size_t)m_pad * K);
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
+  }
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
+  }
+
+  if (res == AEE_SUCCESS) {
+    hvx_dequant_i32_to_f32(acc_i32, M, m_pad, N, act_scale, act_zp, colsum_w,
+                           w_scale, bias, out_f32);
+  }
+
+  int res2 = hexkl_micro_hmx_unlock();
+  if (res2 != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
+    if (res == AEE_SUCCESS) {
+      res = res2;
+    }
+  }
+  return res;
 }

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -44,69 +44,6 @@ static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
   return AEE_SUCCESS;
 }
 
-int nntr_hvx_mm_u8i4_from_u8(remote_handle64 handle, uint32 M, uint32 K,
-                             uint32 N, const uint8 *act_u8_ah, int act_u8_ahLen,
-                             const int8 *w_i4_rm, int w_i4_rmLen,
-                             int32 *acc_i32, int acc_i32Len, uint8 *w_wh_dump,
-                             int w_wh_dumpLen) {
-  (void)handle;
-
-  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
-
-  if ((uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)w_i4_rmLen != K * N ||
-      (uint32_t)acc_i32Len != m_pad * N) {
-    FARF(ERROR, "bad lengths: act=%d w=%d acc=%d (M=%u K=%u N=%u m_pad=%u)",
-         act_u8_ahLen, w_i4_rmLen, acc_i32Len, (unsigned)M, (unsigned)K,
-         (unsigned)N, (unsigned)m_pad);
-    return AEE_EBADPARM;
-  }
-
-  uint8_t *vtcm_base = NULL;
-  uint32_t vtcm_size = 0;
-  int res = hmx_bringup(&vtcm_base, &vtcm_size);
-  if (res != AEE_SUCCESS) {
-    return res;
-  }
-
-  hexkl_mm_u8i4_layout L;
-  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "plan failed: 0x%08x (need w=%u act=%u, vtcm=%u)", res,
-         (unsigned)L.w_size, (unsigned)L.act_size, (unsigned)vtcm_size);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_lock();
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
-  if (res == AEE_SUCCESS) {
-    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
-  }
-  if (res == AEE_SUCCESS) {
-    // Activation arrives already in AH layout, so a flat copy places it.
-    memcpy(vtcm_base + L.act_base, act_u8_ah, (size_t)m_pad * K);
-    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
-  }
-  if (res == AEE_SUCCESS && w_wh_dumpLen > 0) {
-    const uint32_t n_copy =
-      (uint32_t)w_wh_dumpLen < L.w_size ? (uint32_t)w_wh_dumpLen : L.w_size;
-    memcpy(w_wh_dump, vtcm_base + L.w_base, n_copy);
-  }
-
-  int res2 = hexkl_micro_hmx_unlock();
-  if (res2 != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
-    if (res == AEE_SUCCESS) {
-      res = res2;
-    }
-  }
-  return res;
-}
-
 int nntr_hvx_mm_u8i4_from_f32(
   remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
   int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -18,32 +18,26 @@
 
 #include "hexkl_micro.h"
 #include "hexkl_mm_u8i4.h"
+#include "hexkl_mm_u8i4_dma.h"
 #include "hvx_dequant_i32.h"
 #include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
 
 /** @brief Rounds @a v up to a multiple of @a a. */
 #define ROUND_UP(v, a) ((((v) + ((a)-1)) / (a)) * (a))
 
 /**
- * @brief Brings up HMX and reports the VTCM budget.
+ * @brief Accuracy harness: the whole flow, quantization and dequantization
+ *        on the DSP, with every intermediate buffer returned so each stage
+ *        is checkable. Used by unittest_hvx_mm_u8i4's fixed shapes.
  *
- * Split out because both entry points need the same preamble, and because
- * the VTCM size it reports is itself a measurement we do not have yet.
+ * hw_init and the HMX lock are session-scoped (nntr_hvx_open), not per
+ * call, since doc15 §8 item 3 turned this from a call that stood alone into
+ * one of several entry points sharing one session. The weight is still
+ * baked fresh every call -- that is the point of this harness, checking the
+ * bake -- unlike the resident-weight path in mm_u8i4_layer below.
  */
-static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
-  uint32_t hmx_fp16_rate = 0;
-  int res = hexkl_micro_hw_init(vtcm_base, vtcm_size, &hmx_fp16_rate);
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hw_init failed: 0x%08x", res);
-    return res;
-  }
-  FARF(ALWAYS, "vtcm_base=%p vtcm_size=%u config_size=%u hmx_fp16_rate=%u",
-       (void *)*vtcm_base, (unsigned)*vtcm_size,
-       (unsigned)hexkl_micro_hmx_config_size(), (unsigned)hmx_fp16_rate);
-  return AEE_SUCCESS;
-}
-
 int nntr_hvx_mm_u8i4_from_f32(
   remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
   int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,
@@ -51,7 +45,10 @@ int nntr_hvx_mm_u8i4_from_f32(
   int biasLen, uint8 *act_u8_ah, int act_u8_ahLen, float *act_scale,
   int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
   int acc_i32Len, float *out_f32, int out_f32Len) {
-  (void)handle;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
 
   const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
 
@@ -65,15 +62,8 @@ int nntr_hvx_mm_u8i4_from_f32(
     return AEE_EBADPARM;
   }
 
-  uint8_t *vtcm_base = NULL;
-  uint32_t vtcm_size = 0;
-  int res = hmx_bringup(&vtcm_base, &vtcm_size);
-  if (res != AEE_SUCCESS) {
-    return res;
-  }
-
   hexkl_mm_u8i4_layout L;
-  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  int res = hexkl_mm_u8i4_plan(s->vtcm_base, s->vtcm_size, m_pad, K, N, &L);
   if (res != AEE_SUCCESS) {
     FARF(ERROR, "plan failed: 0x%08x", res);
     return res;
@@ -82,19 +72,13 @@ int nntr_hvx_mm_u8i4_from_f32(
   // K1 then K2, writing the AH tiles straight into VTCM.
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
   hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                       vtcm_base + L.act_base);
-  memcpy(act_u8_ah, vtcm_base + L.act_base, (size_t)m_pad * K);
+                       s->vtcm_base + L.act_base);
+  memcpy(act_u8_ah, s->vtcm_base + L.act_base, (size_t)m_pad * K);
 
-  res = hexkl_micro_hmx_lock();
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
-  if (res == AEE_SUCCESS) {
-    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
-  }
+  // setup_acc_read_int32 already ran once in nntr_hvx_open for
+  // s->config_off, which hexkl_mm_u8i4_plan recomputes identically here
+  // (it is a pure function of vtcm_size) -- no need to call it again.
+  res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
   if (res == AEE_SUCCESS) {
     res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
   }
@@ -103,13 +87,75 @@ int nntr_hvx_mm_u8i4_from_f32(
     hvx_dequant_i32_to_f32(acc_i32, M, m_pad, N, act_scale, act_zp, colsum_w,
                            w_scale, bias, out_f32);
   }
-
-  int res2 = hexkl_micro_hmx_unlock();
-  if (res2 != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
-    if (res == AEE_SUCCESS) {
-      res = res2;
-    }
-  }
   return res;
+}
+
+/**
+ * @brief Bakes a K x N int4 weight once and keeps it resident until
+ *        weight_release_u8i4 -- see hexkl_mm_u8i4_dma.h.
+ */
+int nntr_hvx_weight_register_u8i4(remote_handle64 handle, uint32 K, uint32 N,
+                                  const int8 *w_i4_rm, int w_i4_rmLen,
+                                  const float *w_scale, int w_scaleLen,
+                                  const int32 *colsum_w, int colsum_wLen,
+                                  const float *bias, int biasLen,
+                                  uint32 *w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)w_i4_rmLen != K * N || (uint32_t)w_scaleLen != N ||
+      (uint32_t)colsum_wLen != N || (uint32_t)biasLen != N) {
+    FARF(ERROR, "weight_register_u8i4: bad lengths (K=%u N=%u)", (unsigned)K,
+         (unsigned)N);
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i4_register(&s->weights, s->vtcm_base, s->vtcm_size,
+                                    K, N, w_i4_rm, w_scale, colsum_w, bias,
+                                    w_handle);
+}
+
+int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i4_release(&s->weights, w_handle);
+}
+
+/**
+ * @brief Runs a layer's worth of matmuls (Q/K/V, or gate/up) against one
+ *        shared activation -- see hexkl_mm_u8i4_dma.h. This is the entry
+ *        point PR③'s ComputeOps seam will call; nntr_hvx_mm_u8i4_from_f32
+ *        above stays the accuracy harness.
+ */
+int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
+                           const uint32 *w_handles, int w_handlesLen,
+                           const float *act_f32, int act_f32Len,
+                           float *out_cat, int out_catLen) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s || w_handlesLen <= 0) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)act_f32Len != M * K) {
+    FARF(ERROR, "mm_u8i4_layer: bad act_f32Len (M=%u K=%u)", (unsigned)M,
+         (unsigned)K);
+    return AEE_EBADPARM;
+  }
+  uint32_t n_total = 0;
+  for (int i = 0; i < w_handlesLen; ++i) {
+    if (w_handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
+        !s->weights.slots[w_handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    n_total += s->weights.slots[w_handles[i]].N;
+  }
+  if ((uint32_t)out_catLen != M * n_total) {
+    FARF(ERROR, "mm_u8i4_layer: bad out_catLen (M=%u n_total=%u)",
+         (unsigned)M, (unsigned)n_total);
+    return AEE_EBADPARM;
+  }
+  return hexkl_mm_u8i4_layer_run(&s->weights, s->vtcm_base, s->vtcm_size,
+                                 s->config_off, M, K, w_handles,
+                                 (uint32_t)w_handlesLen, act_f32, out_cat);
 }

--- a/test/htp/nntr_hvx_session.h
+++ b/test/htp/nntr_hvx_session.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   nntr_hvx_session.h
+ * @date   06 Aug 2026
+ * @brief  Per-session HMX/VTCM state and the u8i4 weight registry
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTR_HVX_SESSION_H__
+#define __NNTR_HVX_SESSION_H__
+
+#include <stdint.h>
+
+#include "hexkl_mm_u8i4_dma.h"
+
+/**
+ * @brief State held for the lifetime of one nntr_hvx_open()/close() pair.
+ *
+ * hw_init and the HMX lock happen once in open() rather than per call (doc15
+ * §3/§4): every FastRPC entry point in this file reaches its VTCM arena and
+ * weight table through the session instead of re-acquiring either. This
+ * assumes one open session at a time -- hexkl_micro_hw_init is a singleton
+ * DSP resource, so a second concurrent open would contend for the same VTCM
+ * arena and HMX lock. nntrainer opens exactly one HTP session per process,
+ * so that is not a real constraint today; it would need addressing before
+ * this skel served more than one client process at once.
+ */
+typedef struct {
+  uint8_t *vtcm_base;
+  uint32_t vtcm_size;
+  uint32_t config_off; /**< session-constant: depends only on vtcm_size */
+  int hmx_locked;      /**< close() only unlocks/finalizes what open() set up */
+  hexkl_weight_u8i4_table weights;
+} nntr_hvx_session;
+
+#endif /* __NNTR_HVX_SESSION_H__ */

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -11,6 +11,7 @@
  */
 
 #include <AEEStdErr.h>
+#include <HAP_farf.h>
 #include <remote.h>
 
 #include <hexagon_types.h>
@@ -18,6 +19,7 @@
 #include <qurt.h>
 
 #include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
 
 #include "hvx_exp_f32.h"
 #include "hvx_softmax_f32.h"
@@ -33,9 +35,17 @@ static int have_hvx(void) {
 
 int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
                      int yLen) {
-  (void)handle;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
 
-  if (xLen != yLen || xLen <= 0 || (unsigned)xLen % LANES != 0u) {
+  if (xLen != yLen) {
+    FARF(ERROR, "exp_f32: bad lengths (xLen=%d yLen=%d)", xLen, yLen);
+    return AEE_EBADPARM;
+  }
+  if (xLen <= 0 || (unsigned)xLen % LANES != 0u) {
+    FARF(ERROR, "exp_f32: xLen not a multiple of %u (xLen=%d)", LANES, xLen);
     return AEE_EBADPARM;
   }
   if (!have_hvx()) {
@@ -57,12 +67,19 @@ int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
 int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
                          uint32 m_first, float scale, const float *x, int xLen,
                          float *y, int yLen) {
-  (void)handle;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
 
   if (M == 0u || K == 0u || m_first > M) {
+    FARF(ERROR, "softmax_f32: bad shape (M=%u K=%u m_first=%u)", (unsigned)M,
+         (unsigned)K, (unsigned)m_first);
     return AEE_EBADPARM;
   }
   if ((uint32)xLen != M * K || xLen != yLen) {
+    FARF(ERROR, "softmax_f32: bad lengths (M=%u K=%u xLen=%d yLen=%d)",
+         (unsigned)M, (unsigned)K, xLen, yLen);
     return AEE_EBADPARM;
   }
   if (!have_hvx()) {

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -55,11 +55,11 @@ int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
 }
 
 int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
-                         float scale, const float *x, int xLen, float *y,
-                         int yLen) {
+                         uint32 m_first, float scale, const float *x, int xLen,
+                         float *y, int yLen) {
   (void)handle;
 
-  if (M == 0u || K == 0u) {
+  if (M == 0u || K == 0u || m_first > M) {
     return AEE_EBADPARM;
   }
   if ((uint32)xLen != M * K || xLen != yLen) {
@@ -69,6 +69,6 @@ int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
     return AEE_EUNSUPPORTED;
   }
 
-  hvx_softmax_rows_f32(x, y, 0u, M, K, scale);
+  hvx_softmax_rows_f32(x, y, m_first, M, K, scale);
   return AEE_SUCCESS;
 }

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -21,6 +21,8 @@
 
 #include "nntr_hvx.h"
 
+#include "hvx_exp_f32.h"
+
 /** @brief f32 lanes per HVX vector in 128B mode. */
 #define LANES 32u
 
@@ -33,7 +35,6 @@ static int have_hvx(void) {
 int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
                      int yLen) {
   (void)handle;
-  (void)x;
 
   if (xLen != yLen || xLen <= 0 || (unsigned)xLen % LANES != 0u) {
     return AEE_EBADPARM;
@@ -42,8 +43,15 @@ int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
     return AEE_EUNSUPPORTED;
   }
 
-  /* Stub: proves the rout buffer comes back. Task 2 fills it in. */
-  memset(y, 0, (size_t)yLen * sizeof(float));
+  // FastRPC buffers carry no vector alignment guarantee, so the unaligned
+  // vector type is what keeps this from faulting.
+  const HVX_UVector *vx = (const HVX_UVector *)x;
+  HVX_UVector *vy = (HVX_UVector *)y;
+
+  const int nvec = xLen / (int)LANES;
+  for (int i = 0; i < nvec; ++i) {
+    vy[i] = hvx_exp_sf(vx[i]);
+  }
   return AEE_SUCCESS;
 }
 

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   nntr_hvx_softmax.c
+ * @date   05 Aug 2026
+ * @brief  DSP-side entries that expose the HVX softmax kernel to the host test
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <string.h>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+#include <qurt.h>
+
+#include "nntr_hvx.h"
+
+/** @brief f32 lanes per HVX vector in 128B mode. */
+#define LANES 32u
+
+/** @brief Fails unless the DSP actually has a 128-byte HVX context. */
+static int have_hvx(void) {
+  /* Bits 15:8 hold the number of 128-byte HVX contexts. */
+  return ((qurt_hvx_get_units() >> 8) & 0xFF) != 0;
+}
+
+int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
+                     int yLen) {
+  (void)handle;
+  (void)x;
+
+  if (xLen != yLen || xLen <= 0 || (unsigned)xLen % LANES != 0u) {
+    return AEE_EBADPARM;
+  }
+  if (!have_hvx()) {
+    return AEE_EUNSUPPORTED;
+  }
+
+  /* Stub: proves the rout buffer comes back. Task 2 fills it in. */
+  memset(y, 0, (size_t)yLen * sizeof(float));
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
+                         float scale, const float *x, int xLen, float *y,
+                         int yLen) {
+  (void)handle;
+  (void)scale;
+  (void)x;
+
+  if (M == 0u || K == 0u) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32)xLen != M * K || xLen != yLen) {
+    return AEE_EBADPARM;
+  }
+  if (!have_hvx()) {
+    return AEE_EUNSUPPORTED;
+  }
+
+  /* Stub: proves the rout buffer comes back. Task 3 fills it in. */
+  memset(y, 0, (size_t)yLen * sizeof(float));
+  return AEE_SUCCESS;
+}

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -16,7 +16,6 @@
 
 #include <hexagon_types.h>
 #include <hvx_hexagon_protos.h>
-#include <qurt.h>
 
 #include "nntr_hvx.h"
 #include "nntr_hvx_session.h"
@@ -26,12 +25,6 @@
 
 /** @brief f32 lanes per HVX vector in 128B mode. */
 #define LANES 32u
-
-/** @brief Fails unless the DSP actually has a 128-byte HVX context. */
-static int have_hvx(void) {
-  /* Bits 15:8 hold the number of 128-byte HVX contexts. */
-  return ((qurt_hvx_get_units() >> 8) & 0xFF) != 0;
-}
 
 int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
                      int yLen) {
@@ -47,9 +40,6 @@ int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
   if (xLen <= 0 || (unsigned)xLen % LANES != 0u) {
     FARF(ERROR, "exp_f32: xLen not a multiple of %u (xLen=%d)", LANES, xLen);
     return AEE_EBADPARM;
-  }
-  if (!have_hvx()) {
-    return AEE_EUNSUPPORTED;
   }
 
   // FastRPC buffers carry no vector alignment guarantee, so the unaligned
@@ -81,9 +71,6 @@ int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
     FARF(ERROR, "softmax_f32: bad lengths (M=%u K=%u xLen=%d yLen=%d)",
          (unsigned)M, (unsigned)K, xLen, yLen);
     return AEE_EBADPARM;
-  }
-  if (!have_hvx()) {
-    return AEE_EUNSUPPORTED;
   }
 
   hvx_softmax_rows_f32(x, y, m_first, M, K, scale);

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -23,8 +23,10 @@
 #include "hvx_exp_f32.h"
 #include "hvx_softmax_f32.h"
 
-/** @brief f32 lanes per HVX vector in 128B mode. */
-#define LANES 32u
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 lanes per HVX vector. */
+#define LANES (VLEN / sizeof(float))
 
 int nntr_hvx_exp_f32(remote_handle64 handle, const float *x, int xLen, float *y,
                      int yLen) {

--- a/test/htp/nntr_hvx_softmax.c
+++ b/test/htp/nntr_hvx_softmax.c
@@ -10,8 +10,6 @@
  * @bug    No known bugs except for NYI items
  */
 
-#include <string.h>
-
 #include <AEEStdErr.h>
 #include <remote.h>
 
@@ -22,6 +20,7 @@
 #include "nntr_hvx.h"
 
 #include "hvx_exp_f32.h"
+#include "hvx_softmax_f32.h"
 
 /** @brief f32 lanes per HVX vector in 128B mode. */
 #define LANES 32u
@@ -59,8 +58,6 @@ int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
                          float scale, const float *x, int xLen, float *y,
                          int yLen) {
   (void)handle;
-  (void)scale;
-  (void)x;
 
   if (M == 0u || K == 0u) {
     return AEE_EBADPARM;
@@ -72,7 +69,6 @@ int nntr_hvx_softmax_f32(remote_handle64 handle, uint32 M, uint32 K,
     return AEE_EUNSUPPORTED;
   }
 
-  /* Stub: proves the rout buffer comes back. Task 3 fills it in. */
-  memset(y, 0, (size_t)yLen * sizeof(float));
+  hvx_softmax_rows_f32(x, y, 0u, M, K, scale);
   return AEE_SUCCESS;
 }

--- a/test/htp/run_u8i4_layer_on_device.sh
+++ b/test/htp/run_u8i4_layer_on_device.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds the DSP skel + the ARM gtest for the u8i4 layer endpoint
+# (HTP_PR_PLAN.md PR① / doc15 §8 item 3) and runs it on a connected device.
+#
+# What this checks, in order:
+#   1. DSP skel compiles clean against HexKL beta2 (-Wall -Werror)
+#   2. libnntrainer.so + the ARM gtest binary build for arm64-v8a
+#   3. unittest_hvx_mm_u8i4 passes on-device -- both the original accuracy
+#      harness (Shape1-4) and the new layer-endpoint tests
+#   4. the reported layer_x4/harness speedup lands near doc13 §3a's
+#      1.7-2x (printed, not asserted -- see ReportPerCallCost's comment)
+#
+# Override any of these if your paths differ:
+: "${HEXAGON_SDK_ROOT:=$HOME/workspace/Hexagon_SDK/6.4.0.2}"
+: "${HEXKL_ROOT:=$HOME/workspace/hxkl-beta2/hexkl_addon}"   # beta2, NOT the
+                                                            # one under
+                                                            # Hexagon_SDK/*/addons/
+: "${HEXKL_SDK_VER:=6.4.0.2}"
+: "${ANDROID_NDK:=$HOME/workspace/android-ndk-r26d}"
+: "${DEVICE_TMP:=/data/local/tmp/htp_u8i4_layer_test}"
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log()  { echo -e "\n\033[1;36m==> $*\033[0m"; }
+fail() { echo -e "\033[1;31mFAILED: $*\033[0m" >&2; exit 1; }
+
+for v in HEXAGON_SDK_ROOT HEXKL_ROOT ANDROID_NDK; do
+  [ -d "${!v}" ] || fail "$v does not exist: ${!v}"
+done
+
+export HEXAGON_SDK_ROOT
+export DEFAULT_HEXAGON_TOOLS_ROOT="$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/19.0.04"
+[ -d "$DEFAULT_HEXAGON_TOOLS_ROOT" ] ||
+  fail "Hexagon tools not at $DEFAULT_HEXAGON_TOOLS_ROOT -- check the toolchain version dir name"
+
+if ! adb get-state >/dev/null 2>&1; then
+  fail "no device visible to adb -- check 'adb devices'"
+fi
+DEVICE="$(adb get-serialno)"
+echo "device: $DEVICE"
+
+# --- 1. DSP skel -----------------------------------------------------------
+log "1/4  Building the DSP skel (test/htp/build.sh, HexKL $HEXKL_SDK_VER)"
+(
+  cd "$REPO_ROOT/test/htp"
+  HEXKL_ROOT="$HEXKL_ROOT" HEXKL_SDK_VER="$HEXKL_SDK_VER" bash build.sh
+)
+SKEL="$REPO_ROOT/test/htp/build/libnntr_hvx_skel.so"
+[ -f "$SKEL" ] || fail "skel did not build: $SKEL"
+
+# --- 2. libnntrainer.so for arm64-v8a --------------------------------------
+# unittest_hvx_mm_u8i4 does not itself call into nntrainer, but Android.mk's
+# PREBUILT_SHARED_LIBRARY entries for it are parsed unconditionally, so the
+# .so must exist on disk before ndk-build will process ANY target in this
+# file. -Denable-htp is not required for this test (it never goes through
+# nntrainer's HtpComputeOps seam), but matches what PR③ will eventually need
+# from the same builddir, so building it now saves a second full rebuild.
+LIBNNTRAINER="$REPO_ROOT/builddir/jni/arm64-v8a/libnntrainer.so"
+if [ -f "$LIBNNTRAINER" ]; then
+  log "2/4  libnntrainer.so already built, skipping (rm -rf builddir to force)"
+else
+  log "2/4  Building libnntrainer.so for arm64-v8a (tools/package_android.sh)"
+  # subprojects/iniparser (and occasionally others) can be an unfetched
+  # wrap-git placeholder in a fresh worktree -- same class of gotcha as the
+  # googletest one below, just tripped by the android build instead of the
+  # host one.
+  if [ ! -f "$REPO_ROOT/subprojects/iniparser/src/iniparser.c" ]; then
+    echo "  subprojects/iniparser looks unfetched -- running git submodule update"
+    git -C "$REPO_ROOT" submodule update --init subprojects/iniparser
+  fi
+  (
+    cd "$REPO_ROOT"
+    ANDROID_NDK="$ANDROID_NDK" PATH="$ANDROID_NDK:$PATH" \
+      ./tools/package_android.sh --arm-arch=armv8.2-a -Dwerror=false
+  )
+fi
+[ -f "$LIBNNTRAINER" ] || fail "libnntrainer.so did not build: $LIBNNTRAINER"
+
+# --- 3. ARM gtest -----------------------------------------------------------
+log "3/4  Building unittest_hvx_mm_u8i4 (ndk-build, arm64-v8a)"
+GTEST_SUBMODULE="$REPO_ROOT/subprojects/googletest"
+if [ ! -f "$GTEST_SUBMODULE/googletest/include/gtest/gtest.h" ]; then
+  echo "  googletest submodule looks unfetched -- running git submodule update"
+  git -C "$REPO_ROOT" submodule update --init subprojects/googletest
+fi
+# test/jni/Android.mk's googletest_main module expects ./googletest/{src,include}
+# relative to test/jni/ -- there is no setup script that creates this, so do
+# it here rather than committing a real copy into the tree.
+if [ ! -e "$REPO_ROOT/test/jni/googletest" ]; then
+  ln -sfn "$GTEST_SUBMODULE/googletest" "$REPO_ROOT/test/jni/googletest"
+fi
+(
+  cd "$REPO_ROOT/test/jni"
+  export ANDROID_NDK
+  # Override, do not rely on the default: this shell's profile may already
+  # export NNTRAINER_ROOT pointing at a different checkout (it does on at
+  # least one dev machine this was verified on), which Android.mk's
+  # ifndef-guarded default silently defers to.
+  "$ANDROID_NDK/ndk-build" \
+    NDK_PROJECT_PATH=. NDK_APPLICATION_MK=./Application.mk \
+    APP_BUILD_SCRIPT=./Android.mk \
+    NNTRAINER_ROOT="$REPO_ROOT" \
+    HEXAGON_SDK_ROOT="$HEXAGON_SDK_ROOT" \
+    unittest_hvx_mm_u8i4
+)
+TEST_BIN="$REPO_ROOT/test/jni/obj/local/arm64-v8a/unittest_hvx_mm_u8i4"
+[ -f "$TEST_BIN" ] || fail "test binary did not build: $TEST_BIN"
+
+# --- 4. push + run -----------------------------------------------------------
+log "4/4  Pushing to $DEVICE:$DEVICE_TMP and running"
+adb shell "mkdir -p $DEVICE_TMP"
+adb push "$SKEL" "$DEVICE_TMP/" >/dev/null
+adb push "$TEST_BIN" "$DEVICE_TMP/" >/dev/null
+# c++_shared runtime the test binary links against (APP_STL in Application.mk)
+CXX_SHARED="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so"
+[ -f "$CXX_SHARED" ] && adb push "$CXX_SHARED" "$DEVICE_TMP/" >/dev/null
+
+echo "  (unsigned-PD enable happens inside the test itself via remote_session_control)"
+adb shell "cd $DEVICE_TMP && \
+  chmod +x unittest_hvx_mm_u8i4 && \
+  LD_LIBRARY_PATH=$DEVICE_TMP ADSP_LIBRARY_PATH=$DEVICE_TMP \
+  ./unittest_hvx_mm_u8i4" 2>&1 | tee /tmp/hvx_mm_u8i4_device_run.log
+
+echo
+log "Summary"
+grep -E "^\[  (PASSED|FAILED)|U8I4_FIELD" /tmp/hvx_mm_u8i4_device_run.log || true
+echo
+echo "Full log: /tmp/hvx_mm_u8i4_device_run.log"
+echo "Gate to clear before starting PR②/③: all PASSED, and the printed"
+echo "U8I4_FIELD path=layer_x4 field=speedup_vs_harness value=... should be"
+echo "in the neighbourhood of 1.7-2 (doc13 §3a). If it is not, stop and find"
+echo "out why before building anything on top of this."

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -924,4 +924,27 @@ LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
 LOCAL_STATIC_LIBRARIES := googletest_main
 
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_hvx_mm_u8i4
+LOCAL_CFLAGS := -Igoogletest/include -pthread -fexceptions -O3 -DNDK_BUILD=1
+LOCAL_CXXFLAGS += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_hvx_mm_u8i4.cpp \
+	 ../htp/generated/nntr_hvx_stub.c
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../htp/generated \
+	 $(HEXAGON_SDK_ROOT)/incs \
+	 $(HEXAGON_SDK_ROOT)/incs/stddef \
+	 $(HEXAGON_SDK_ROOT)/ipc/fastrpc/incs
+
+LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
+	 -lcdsprpc
+
+LOCAL_STATIC_LIBRARIES := googletest_main
+
+include $(BUILD_EXECUTABLE)
 endif

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -897,3 +897,31 @@ LOCAL_STATIC_LIBRARIES += clblast
 endif
 
 include $(BUILD_EXECUTABLE)
+
+# HVX device bring-up test. Needs the Hexagon SDK for the FastRPC headers
+# and the generated stub, so it is skipped entirely when the SDK is absent.
+# Build the skel first: test/htp/build.sh
+ifdef HEXAGON_SDK_ROOT
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_hvx_add
+LOCAL_CFLAGS := -Igoogletest/include -pthread -fexceptions -O3 -DNDK_BUILD=1
+LOCAL_CXXFLAGS += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_hvx_kernels.cpp \
+	 ../htp/generated/nntr_hvx_stub.c
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../htp/generated \
+	 $(HEXAGON_SDK_ROOT)/incs \
+	 $(HEXAGON_SDK_ROOT)/incs/stddef \
+	 $(HEXAGON_SDK_ROOT)/ipc/fastrpc/incs
+
+LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
+	 -lcdsprpc
+
+LOCAL_STATIC_LIBRARIES := googletest_main
+
+include $(BUILD_EXECUTABLE)
+endif

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -947,4 +947,27 @@ LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
 LOCAL_STATIC_LIBRARIES := googletest_main
 
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_hvx_softmax
+LOCAL_CFLAGS := -Igoogletest/include -pthread -fexceptions -O3 -DNDK_BUILD=1
+LOCAL_CXXFLAGS += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_hvx_softmax.cpp \
+	 ../htp/generated/nntr_hvx_stub.c
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../htp/generated \
+	 $(HEXAGON_SDK_ROOT)/incs \
+	 $(HEXAGON_SDK_ROOT)/incs/stddef \
+	 $(HEXAGON_SDK_ROOT)/ipc/fastrpc/incs
+
+LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
+	 -lcdsprpc
+
+LOCAL_STATIC_LIBRARIES := googletest_main
+
+include $(BUILD_EXECUTABLE)
 endif

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
  * @file   unittest_hvx_kernels.cpp
- * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does.
+ * @date   03 Aug 2026
+ * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
  *
  * Runs on an Android device only. Requires libnntr_hvx_skel.so on
  * ADSP_LIBRARY_PATH. See test/htp/build.sh.
@@ -43,8 +49,7 @@ protected:
     remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
     int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
                                      &unsigned_pd, sizeof(unsigned_pd));
-    ASSERT_EQ(err, AEE_SUCCESS)
-      << "enabling unsigned PD failed: " << hex(err);
+    ASSERT_EQ(err, AEE_SUCCESS) << "enabling unsigned PD failed: " << hex(err);
 
     const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
     err = nntr_hvx_open(uri.c_str(), &handle_);
@@ -75,6 +80,18 @@ TEST_F(HvxAdd, MatchesCpuForFullVectorsPlusRemainder) {
   int err = nntr_hvx_add_f32(handle_, a.data(), n, b.data(), n, c.data(), n);
   ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
   EXPECT_EQ(c, expected);
+}
+
+TEST_F(HvxAdd, MatchesCpuBelowOneVector) {
+  // Fewer floats than a single vector holds: n_vec is 0 and only the
+  // scalar tail runs.
+  const std::vector<float> a = {1.5f};
+  const std::vector<float> b = {2.25f};
+  std::vector<float> c = {0.0f};
+
+  int err = nntr_hvx_add_f32(handle_, a.data(), 1, b.data(), 1, c.data(), 1);
+  ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
+  EXPECT_EQ(c[0], 3.75f);
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * @file   unittest_hvx_kernels.cpp
+ * @brief  Device test: an HVX kernel on the CDSP returns what the CPU does.
+ *
+ * Runs on an Android device only. Requires libnntr_hvx_skel.so on
+ * ADSP_LIBRARY_PATH. See test/htp/build.sh.
+ */
+
+#include <gtest/gtest.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+namespace {
+
+/** @brief Render a FastRPC error as hex so the code is searchable. */
+std::string hex(int err) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(8) << std::setfill('0')
+     << static_cast<unsigned>(err);
+  return os.str();
+}
+
+/**
+ * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ *
+ * A failure here is a hard FAIL rather than a skip: proving the DSP comes
+ * up on the device is the point of this test, so a quiet skip would
+ * report success for the thing being measured.
+ */
+class HvxAdd : public ::testing::Test {
+protected:
+  void SetUp() override {
+    remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
+    int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
+                                     &unsigned_pd, sizeof(unsigned_pd));
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "enabling unsigned PD failed: " << hex(err);
+
+    const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
+    err = nntr_hvx_open(uri.c_str(), &handle_);
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "nntr_hvx_open failed: " << hex(err)
+      << " -- is libnntr_hvx_skel.so on ADSP_LIBRARY_PATH?";
+  }
+
+  void TearDown() override {
+    if (handle_) {
+      nntr_hvx_close(handle_);
+    }
+  }
+
+  remote_handle64 handle_ = 0;
+};
+
+TEST_F(HvxAdd, MatchesCpuForFullVectorsPlusRemainder) {
+  // 100 floats = 3 full 128-byte vectors (32 floats each) + 4 left over.
+  const int n = 100;
+  std::vector<float> a(n), b(n), c(n, 0.0f), expected(n);
+  for (int i = 0; i < n; ++i) {
+    a[i] = static_cast<float>(i) * 0.5f;
+    b[i] = static_cast<float>(n - i) * 0.25f;
+    expected[i] = a[i] + b[i];
+  }
+
+  int err = nntr_hvx_add_f32(handle_, a.data(), n, b.data(), n, c.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "add_f32 failed: " << hex(err);
+  EXPECT_EQ(c, expected);
+}
+
+} // namespace
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_hvx_kernels.cpp
+++ b/test/unittest/unittest_hvx_kernels.cpp
@@ -37,7 +37,7 @@ std::string hex(int err) {
 }
 
 /**
- * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ * @brief Opens an unsigned-PD CDSP session for the each test.
  *
  * A failure here is a hard FAIL rather than a skip: proving the DSP comes
  * up on the device is the point of this test, so a quiet skip would

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -154,6 +154,40 @@ void ref_int_matmul(const std::vector<uint8_t> &u_rm,
   }
 }
 
+/**
+ * @brief Dequantization reference.
+ *
+ * out[m][n] = (acc[m][n] - zp[m]*colsum[n]) * scale[m] * d[n] + bias[n]
+ *
+ * The correction term comes from feeding HMX unsigned activations:
+ *   sum_k x*w = sum_k s*(u - zp) * d*q_w
+ *             = s*d * (sum_k u*q_w  -  zp * sum_k q_w)
+ * and sum_k q_w is colsum, which the weights alone determine.
+ *
+ * |acc| <= 255*8*K and |zp*colsum| <= 255*8*K, so the difference stays
+ * inside int32 and both operands are exactly representable in f32 (below
+ * 2^24), which is why the DSP may do the correction in either domain.
+ *
+ * @param[in] acc m_pad by n, row-major
+ * @param[out] out m_valid by n, row-major
+ */
+void ref_dequant(const std::vector<int32_t> &acc, uint32_t m_valid, uint32_t N,
+                 const std::vector<float> &act_scale,
+                 const std::vector<int32_t> &act_zp,
+                 const std::vector<int32_t> &colsum,
+                 const std::vector<float> &d, const std::vector<float> &bias,
+                 std::vector<float> &out) {
+  out.assign(static_cast<size_t>(m_valid) * N, 0.0f);
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      const int32_t corrected =
+        acc[static_cast<size_t>(m) * N + n] - act_zp[m] * colsum[n];
+      out[static_cast<size_t>(m) * N + n] =
+        static_cast<float>(corrected) * act_scale[m] * d[n] + bias[n];
+    }
+  }
+}
+
 /** @brief Deterministic pseudo-random fill in [-1, 1). */
 void fill_deterministic(std::vector<float> &v, uint32_t seed) {
   uint32_t s = seed;
@@ -162,6 +196,74 @@ void fill_deterministic(std::vector<float> &v, uint32_t seed) {
     v[i] = static_cast<float>(static_cast<int32_t>(s >> 8)) /
              static_cast<float>(1 << 23) -
            1.0f;
+  }
+}
+
+/**
+ * @brief Per-row asymmetric uint8 activation quantization: scale and zp.
+ *
+ * x[m][k] is recovered as scale[m] * (u[m][k] - zp[m]).
+ *
+ * Padded rows (m >= m_valid) get scale 1 and zp 0. Their uint8 values are
+ * zero, which does not decode to zero -- s*(0-zp) is nonzero whenever zp
+ * is -- so their outputs are meaningless. Rows are independent in a
+ * matmul so valid rows are unaffected; fixing scale and zp for pad rows
+ * just makes the host reference easy to keep identical to the DSP.
+ */
+void quantize_act_rows(const std::vector<float> &x, uint32_t m_valid,
+                       uint32_t m_pad, uint32_t K, std::vector<float> &scale,
+                       std::vector<int32_t> &zp) {
+  scale.assign(m_pad, 1.0f);
+  zp.assign(m_pad, 0);
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    float min0 = x[static_cast<size_t>(m) * K];
+    float max0 = min0;
+    for (uint32_t k = 0; k < K; ++k) {
+      const float v = x[static_cast<size_t>(m) * K + k];
+      min0 = std::min(min0, v);
+      max0 = std::max(max0, v);
+    }
+    const float rmin = std::min(0.0f, min0);
+    const float rmax = std::max(0.0f, max0);
+    if (rmin == rmax) {
+      scale[m] = 1.0f;
+      zp[m] = 0;
+      continue;
+    }
+    scale[m] = (rmax - rmin) / 255.0f;
+    int32_t z = static_cast<int32_t>(std::nearbyint(-rmin / scale[m]));
+    zp[m] = std::max(0, std::min(255, z));
+  }
+}
+
+/**
+ * @brief Per-row asymmetric uint8 activation quantization: the values.
+ *
+ * std::nearbyint, not std::round: this value is computed independently on
+ * the DSP and compared byte for byte, and HVX's float add rounds to
+ * nearest-even. std::round (half away from zero) would disagree at exact
+ * .5. Weight quantization uses std::round because it runs on the host
+ * only -- see quantize_weights_qs4cx.
+ *
+ * @param[out] u_rm row-major uint8, m_pad by K
+ */
+void quantize_act_values(const std::vector<float> &x, uint32_t m_valid,
+                         uint32_t m_pad, uint32_t K,
+                         const std::vector<float> &scale,
+                         const std::vector<int32_t> &zp,
+                         std::vector<uint8_t> &u_rm) {
+  u_rm.assign(static_cast<size_t>(m_pad) * K, 0);
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float inv_s = 1.0f / scale[m];
+    for (uint32_t k = 0; k < K; ++k) {
+      // Reciprocal multiply, matching the DSP kernel: f32 a/b and a*(1/b)
+      // can differ by 1 ULP, which breaks the S1 byte-exact check.
+      const float q = std::nearbyint(x[static_cast<size_t>(m) * K + k] * inv_s);
+      int32_t v = static_cast<int32_t>(q) + zp[m];
+      v = std::max(0, std::min(255, v));
+      u_rm[static_cast<size_t>(m) * K + k] = static_cast<uint8_t>(v);
+    }
   }
 }
 
@@ -268,6 +370,124 @@ TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
               << ((i % 32 == 31) ? "\n" : " ");
   }
   std::cout << std::dec << std::flush;
+}
+
+TEST_F(HmxMmU8I4, S1_ActivationQuantMatchesHost) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  std::vector<float> bias(N);
+  fill_deterministic(bias, 0x5EED0003u);
+
+  std::vector<float> exp_scale;
+  std::vector<int32_t> exp_zp;
+  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+  std::vector<uint8_t> exp_u_rm;
+  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+  std::vector<uint8_t> exp_ah;
+  pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
+  std::vector<int32_t> exp_acc;
+  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+
+  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> got_scale(m_pad, 0.0f);
+  std::vector<int32_t> got_zp(m_pad, -1);
+  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_from_f32(
+    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+    static_cast<int>(bias.size()), got_ah.data(),
+    static_cast<int>(got_ah.size()), got_scale.data(),
+    static_cast<int>(got_scale.size()), got_zp.data(),
+    static_cast<int>(got_zp.size()), got_acc.data(),
+    static_cast<int>(got_acc.size()), got_out.data(),
+    static_cast<int>(got_out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
+      << "scale[" << m << "]";
+    EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
+  }
+  EXPECT_EQ(got_ah, exp_ah);
+
+  // The activation the HMX actually consumed now comes from the HVX
+  // kernel, so this re-checks S2 end to end rather than with a fixed
+  // pattern.
+  EXPECT_EQ(got_acc, exp_acc);
+}
+
+TEST_F(HmxMmU8I4, S3_DequantMatchesHost) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  std::vector<float> bias(N);
+  fill_deterministic(bias, 0x5EED0003u);
+
+  std::vector<float> exp_scale;
+  std::vector<int32_t> exp_zp;
+  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+  std::vector<uint8_t> exp_u_rm;
+  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+  std::vector<int32_t> exp_acc;
+  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+  std::vector<float> exp_out;
+  ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
+
+  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> got_scale(m_pad, 0.0f);
+  std::vector<int32_t> got_zp(m_pad, -1);
+  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_from_f32(
+    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+    static_cast<int>(bias.size()), got_ah.data(),
+    static_cast<int>(got_ah.size()), got_scale.data(),
+    static_cast<int>(got_scale.size()), got_zp.data(),
+    static_cast<int>(got_zp.size()), got_acc.data(),
+    static_cast<int>(got_acc.size()), got_out.data(),
+    static_cast<int>(got_out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+  ASSERT_EQ(got_acc, exp_acc) << "accumulator diverged; S3 is meaningless";
+
+  size_t reported = 0;
+  for (uint32_t m = 0; m < M; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      const size_t i = static_cast<size_t>(m) * N + n;
+      const float tol = std::abs(exp_out[i]) * 1e-5f + 1e-6f;
+      if (std::abs(got_out[i] - exp_out[i]) > tol && reported < 10) {
+        ++reported;
+        ADD_FAILURE() << "out[" << m << "][" << n << "] = " << got_out[i]
+                      << ", expected " << exp_out[i];
+      }
+      EXPECT_NEAR(got_out[i], exp_out[i], tol);
+    }
+  }
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   unittest_hvx_mm_u8i4.cpp
+ * @date   03 Aug 2026
+ * @brief  Device test: A8W4 matmul on HMX matches the CPU reference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Runs on an Android device only. Requires libnntr_hvx_skel.so on
+ * ADSP_LIBRARY_PATH. See test/htp/build.sh.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+namespace {
+
+/** @brief Render a FastRPC error as hex so the code is searchable. */
+std::string hex(int err) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(8) << std::setfill('0')
+     << static_cast<unsigned>(err);
+  return os.str();
+}
+
+/** @brief Rounds @a v up to a multiple of @a a. */
+constexpr uint32_t round_up(uint32_t v, uint32_t a) {
+  return ((v + a - 1) / a) * a;
+}
+
+/** @brief HMX int8 tile geometry, mirrored from hexkl_micro.h. */
+constexpr uint32_t kTileRow = 64;   // HEXKL_HMX_INT8_BLOCK_N_ROW
+constexpr uint32_t kTileInner = 32; // HEXKL_HMX_INT8_BLOCK_N_INNER
+constexpr uint32_t kTileCol = 32;   // HEXKL_HMX_INT8_BLOCK_N_COL
+constexpr uint32_t kActTileBytes = 2048;
+
+/**
+ * @brief Byte offset of activation element (m, k) in AH layout.
+ *
+ * AH is a tiling, not a shuffle: each 64x32 tile is flat row-major, and
+ * the tiles run in (row_block, inner_tile) order at a 2048-byte stride.
+ */
+inline size_t ah_offset(uint32_t m, uint32_t k, uint32_t K) {
+  const uint32_t n_ktiles = K / kTileInner;
+  const uint32_t rb = m / kTileRow;
+  const uint32_t r = m % kTileRow;
+  const uint32_t kt = k / kTileInner;
+  const uint32_t c = k % kTileInner;
+  return static_cast<size_t>(rb * n_ktiles + kt) * kActTileBytes +
+         r * kTileInner + c;
+}
+
+/** @brief Scatters a row-major uint8 activation into AH layout. */
+void pack_ah_from_rowmajor(const std::vector<uint8_t> &u_rm, uint32_t m_pad,
+                           uint32_t K, std::vector<uint8_t> &out_ah) {
+  out_ah.assign(static_cast<size_t>(m_pad) * K, 0);
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    for (uint32_t k = 0; k < K; ++k) {
+      out_ah[ah_offset(m, k, K)] = u_rm[static_cast<size_t>(m) * K + k];
+    }
+  }
+}
+
+/**
+ * @brief Per-channel symmetric int4 weight quantization.
+ *
+ * Deliberately replicates __fallback_quant_nxk_qs4cx_f32 in
+ * nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp:713 so a
+ * later cross-check against nntrainer's CPU QS4CX path does not need a
+ * second quantizer. Note it derives the scale from the min/max span but
+ * quantizes symmetrically with no zero point, so skewed channels clamp.
+ *
+ * std::round (half away from zero) is correct here: this runs on the host
+ * only and the DSP consumes the result, so no rounding mismatch is
+ * possible. Activation quantization uses RNE instead -- see quantize_act.
+ *
+ * @param[in]  w_f32 weight matrix, K rows by N columns, row-major
+ * @param[out] q_w   quantized values in [-8, 7], K by N, row-major
+ * @param[out] d     per-channel dequantization multiplier, N entries
+ * @param[out] colsum per-channel sum of q_w over K, N entries
+ */
+void quantize_weights_qs4cx(const std::vector<float> &w_f32, uint32_t K,
+                            uint32_t N, std::vector<int8_t> &q_w,
+                            std::vector<float> &d,
+                            std::vector<int32_t> &colsum) {
+  q_w.assign(static_cast<size_t>(K) * N, 0);
+  d.assign(N, 0.0f);
+  colsum.assign(N, 0);
+
+  for (uint32_t n = 0; n < N; ++n) {
+    float min0 = w_f32[n];
+    float max0 = min0;
+    for (uint32_t k = 0; k < K; ++k) {
+      const float v = w_f32[static_cast<size_t>(k) * N + n];
+      min0 = std::min(min0, v);
+      max0 = std::max(max0, v);
+    }
+    const float rmin = std::min(0.0f, min0);
+    const float rmax = std::max(0.0f, max0);
+    const float scale = (rmin == rmax) ? 1.0f : 15.0f / (rmax - rmin);
+
+    int32_t sum = 0;
+    for (uint32_t k = 0; k < K; ++k) {
+      int32_t q = static_cast<int32_t>(
+        std::round(w_f32[static_cast<size_t>(k) * N + n] * scale));
+      q = std::max(-8, std::min(7, q));
+      q_w[static_cast<size_t>(k) * N + n] = static_cast<int8_t>(q);
+      sum += q;
+    }
+    d[n] = 1.0f / scale;
+    colsum[n] = sum;
+  }
+}
+
+/**
+ * @brief Integer reference matmul: uint8 activation by int4 weight.
+ *
+ * Deterministic integer arithmetic, so the HMX result must match this bit
+ * for bit. |acc| <= 255 * 8 * K, which is 2,088,960 at K=1024 -- three
+ * orders of magnitude inside int32.
+ *
+ * @param[in] u_rm activation, m_pad by K, row-major (NOT AH)
+ * @param[in] q_w  weights, K by N, row-major
+ */
+void ref_int_matmul(const std::vector<uint8_t> &u_rm,
+                    const std::vector<int8_t> &q_w, uint32_t m_pad, uint32_t K,
+                    uint32_t N, std::vector<int32_t> &acc) {
+  acc.assign(static_cast<size_t>(m_pad) * N, 0);
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      int32_t sum = 0;
+      for (uint32_t k = 0; k < K; ++k) {
+        sum += static_cast<int32_t>(u_rm[static_cast<size_t>(m) * K + k]) *
+               static_cast<int32_t>(q_w[static_cast<size_t>(k) * N + n]);
+      }
+      acc[static_cast<size_t>(m) * N + n] = sum;
+    }
+  }
+}
+
+/** @brief Deterministic pseudo-random fill in [-1, 1). */
+void fill_deterministic(std::vector<float> &v, uint32_t seed) {
+  uint32_t s = seed;
+  for (size_t i = 0; i < v.size(); ++i) {
+    s = s * 1664525u + 1013904223u;
+    v[i] = static_cast<float>(static_cast<int32_t>(s >> 8)) /
+             static_cast<float>(1 << 23) -
+           1.0f;
+  }
+}
+
+/**
+ * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ *
+ * A failure here is a hard FAIL rather than a skip: proving the DSP comes
+ * up on the device is the point of this test, so a quiet skip would
+ * report success for the thing being measured.
+ */
+class HmxMmU8I4 : public ::testing::Test {
+protected:
+  void SetUp() override {
+    remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
+    int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
+                                     &unsigned_pd, sizeof(unsigned_pd));
+    ASSERT_EQ(err, AEE_SUCCESS) << "enabling unsigned PD failed: " << hex(err);
+
+    const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
+    err = nntr_hvx_open(uri.c_str(), &handle_);
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "nntr_hvx_open failed: " << hex(err)
+      << " -- is libnntr_hvx_skel.so on ADSP_LIBRARY_PATH?";
+  }
+
+  void TearDown() override {
+    if (handle_) {
+      nntr_hvx_close(handle_);
+    }
+  }
+
+  remote_handle64 handle_ = 0;
+};
+
+TEST_F(HmxMmU8I4, HmxBringsUp) {
+  // Task 1 gate: the entry point links against libhexkl_micro.a, hw_init
+  // succeeds and the HMX lock round-trips. Buffers are unused here.
+  std::vector<uint8_t> act(64 * 128, 0);
+  std::vector<int8_t> w(128 * 128, 0);
+  std::vector<int32_t> acc(64 * 128, 0);
+  std::vector<uint8_t> dump(0);
+
+  int err = nntr_hvx_mm_u8i4_from_u8(
+    handle_, 64, 128, 128, act.data(), static_cast<int>(act.size()), w.data(),
+    static_cast<int>(w.size()), acc.data(), static_cast<int>(acc.size()),
+    dump.data(), 0);
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+}
+
+TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  // Host-side weight quantization: fp32 -> per-channel int4.
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  // Host-side activation: an arbitrary but deterministic uint8 pattern.
+  // Activation quantization from fp32 is Task 3; this task isolates the
+  // weight bake, the WH layout and the HMX matmul.
+  std::vector<uint8_t> u_rm(static_cast<size_t>(m_pad) * K);
+  for (size_t i = 0; i < u_rm.size(); ++i) {
+    u_rm[i] = static_cast<uint8_t>((i * 37u + 11u) & 0xFFu);
+  }
+  std::vector<uint8_t> act_ah;
+  pack_ah_from_rowmajor(u_rm, m_pad, K, act_ah);
+
+  std::vector<int32_t> expected;
+  ref_int_matmul(u_rm, q_w, m_pad, K, N, expected);
+
+  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<uint8_t> dump(static_cast<size_t>(K / kTileInner) *
+                            (N / kTileCol) * 512);
+
+  int err = nntr_hvx_mm_u8i4_from_u8(
+    handle_, M, K, N, act_ah.data(), static_cast<int>(act_ah.size()),
+    q_w.data(), static_cast<int>(q_w.size()), acc.data(),
+    static_cast<int>(acc.size()), dump.data(), static_cast<int>(dump.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+
+  size_t mismatches = 0;
+  for (uint32_t m = 0; m < m_pad && mismatches < 10; ++m) {
+    for (uint32_t n = 0; n < N && mismatches < 10; ++n) {
+      const size_t i = static_cast<size_t>(m) * N + n;
+      if (acc[i] != expected[i]) {
+        ++mismatches;
+        ADD_FAILURE() << "acc[" << m << "][" << n << "] = " << acc[i]
+                      << ", expected " << expected[i];
+      }
+    }
+  }
+  EXPECT_EQ(acc, expected);
+
+  // The baked buffer is the WH i4 layout, which HexKL does not document.
+  // Print the first tile so the offline converter has a reference.
+  std::cout << "WH tile 0 (512B, hex):" << std::endl;
+  for (size_t i = 0; i < 512; ++i) {
+    std::cout << std::hex << std::setw(2) << std::setfill('0')
+              << static_cast<unsigned>(dump[i])
+              << ((i % 32 == 31) ? "\n" : " ");
+  }
+  std::cout << std::dec << std::flush;
+}
+
+} // namespace
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -347,7 +347,7 @@ protected:
    * being absorbed into a tolerance. S3 allows f32 ordering slack. S4 is
    * reported, not gated.
    */
-  void CheckShape(uint32_t M, uint32_t K, uint32_t N, bool want_wh_dump) {
+  void CheckShape(uint32_t M, uint32_t K, uint32_t N) {
     SCOPED_TRACE("M=" + std::to_string(M) + " K=" + std::to_string(K) +
                  " N=" + std::to_string(N));
     const uint32_t m_pad = round_up(M, kTileRow);
@@ -431,24 +431,24 @@ protected:
 
 TEST_F(HmxMmU8I4, Shape1_Minimal) {
   // Same dimensions as HexKL's own example, so a failure here is ours.
-  CheckShape(64, 128, 128, /*want_wh_dump=*/true);
+  CheckShape(64, 128, 128);
 }
 
 TEST_F(HmxMmU8I4, Shape2_DecodeSingleToken) {
   // One token padded out to a 64-row tile: the decode case, and the one
   // that exercises the zero-pad path for 63 of 64 rows.
-  CheckShape(1, 1024, 1024, /*want_wh_dump=*/false);
+  CheckShape(1, 1024, 1024);
 }
 
 TEST_F(HmxMmU8I4, Shape3_PrefillQwen3Scale) {
   // Weights alone need (1024/32)*(1024/32)*512 = 512 KiB of VTCM here.
-  CheckShape(64, 1024, 1024, /*want_wh_dump=*/false);
+  CheckShape(64, 1024, 1024);
 }
 
 TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
   // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
   // ever runs with rb=0. This is the one that runs it twice.
-  CheckShape(128, 128, 128, /*want_wh_dump=*/false);
+  CheckShape(128, 128, 128);
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -16,8 +16,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -449,6 +451,264 @@ TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
   // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
   // ever runs with rb=0. This is the one that runs it twice.
   CheckShape(128, 128, 128);
+}
+
+/**
+ * @brief The performance path: weights registered once, several matmuls
+ *        per call sharing one activation.
+ *
+ * Shares HmxMmU8I4's helpers rather than duplicating a reference: the
+ * layer endpoint must produce exactly what calling the accuracy endpoint
+ * once per weight would, so that is what these compare against.
+ */
+class HmxMmU8I4Layer : public HmxMmU8I4 {
+protected:
+  /** @brief One weight plus everything needed to check its output. */
+  struct Weight {
+    uint32_t handle;
+    uint32_t N;
+    std::vector<int8_t> q_w;
+    std::vector<float> d;
+    std::vector<int32_t> colsum;
+    std::vector<float> bias;
+    std::vector<float> w_f32;
+  };
+
+  /** @brief Quantizes a deterministic K x N weight and registers it. */
+  void MakeAndRegister(uint32_t K, uint32_t N, uint32_t seed, Weight &w) {
+    w.N = N;
+    w.w_f32.resize(static_cast<size_t>(K) * N);
+    fill_deterministic(w.w_f32, seed);
+    quantize_weights_qs4cx(w.w_f32, K, N, w.q_w, w.d, w.colsum);
+    w.bias.resize(N);
+    fill_deterministic(w.bias, seed ^ 0xA5A5A5A5u);
+
+    w.handle = 0xFFFFFFFFu;
+    int err = nntr_hvx_weight_register_u8i4(
+      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()),
+      w.d.data(), static_cast<int>(w.d.size()), w.colsum.data(),
+      static_cast<int>(w.colsum.size()), w.bias.data(),
+      static_cast<int>(w.bias.size()), &w.handle);
+    ASSERT_EQ(err, AEE_SUCCESS) << "weight_register_u8i4 failed: " << hex(err);
+    ASSERT_NE(w.handle, 0xFFFFFFFFu) << "handle not written";
+  }
+
+  /** @brief Host reference for one weight's slice of the concatenated
+   *         output, via the same path the accuracy harness checks. */
+  void ExpectedFor(const Weight &w, const std::vector<float> &x, uint32_t M,
+                   uint32_t K, std::vector<float> &out) {
+    const uint32_t m_pad = round_up(M, kTileRow);
+    std::vector<float> scale;
+    std::vector<int32_t> zp;
+    quantize_act_rows(x, M, m_pad, K, scale, zp);
+    std::vector<uint8_t> u_rm;
+    quantize_act_values(x, M, m_pad, K, scale, zp, u_rm);
+    std::vector<int32_t> acc;
+    ref_int_matmul(u_rm, w.q_w, m_pad, K, w.N, acc);
+    ref_dequant(acc, M, w.N, scale, zp, w.colsum, w.d, w.bias, out);
+  }
+};
+
+TEST_F(HmxMmU8I4Layer, ThreeWeightsMatchPerWeightReference) {
+  // A Q/K/V set: three weights, one shared activation, one call. The
+  // shapes differ in N so a bug that assumes a uniform stride into
+  // out_cat shows up as a mismatch rather than passing by luck.
+  const uint32_t M = 64, K = 256;
+  const uint32_t Ns[3] = {128, 256, 64};
+
+  std::vector<Weight> ws(3);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, Ns[i], 0xB0B00001u + i * 0x1000u, ws[i]));
+  }
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  uint32_t n_total = 0;
+  std::vector<uint32_t> handles;
+  for (const auto &w : ws) {
+    handles.push_back(w.handle);
+    n_total += w.N;
+  }
+  std::vector<float> got(static_cast<size_t>(M) * n_total, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_layer(
+    handle_, M, K, handles.data(), static_cast<int>(handles.size()), x.data(),
+    static_cast<int>(x.size()), got.data(), static_cast<int>(got.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_layer failed: " << hex(err);
+
+  size_t off = 0;
+  for (int i = 0; i < 3; ++i) {
+    SCOPED_TRACE("weight " + std::to_string(i) + " N=" + std::to_string(Ns[i]));
+    std::vector<float> want;
+    ExpectedFor(ws[i], x, M, K, want);
+    for (size_t j = 0; j < want.size(); ++j) {
+      EXPECT_NEAR(got[off + j], want[j], std::abs(want[j]) * 1e-5f + 1e-6f)
+        << "element " << j;
+    }
+    off += want.size();
+  }
+
+  for (const auto &w : ws) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+  }
+}
+
+TEST_F(HmxMmU8I4Layer, RegisteredWeightSurvivesRepeatedCalls) {
+  // The whole point of registering is that the bake is not repaid per
+  // call, so the second call must return exactly what the first did --
+  // bitwise, since nothing between them is supposed to differ.
+  const uint32_t M = 1, K = 512, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xC0FFEE01u, w));
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  const uint32_t handles[1] = {w.handle};
+
+  std::vector<float> first(static_cast<size_t>(M) * N, 0.0f);
+  std::vector<float> second(static_cast<size_t>(M) * N, 1.0f);
+  for (int pass = 0; pass < 2; ++pass) {
+    std::vector<float> &dst = pass == 0 ? first : second;
+    int err = nntr_hvx_mm_u8i4_layer(handle_, M, K, handles, 1, x.data(),
+                                     static_cast<int>(x.size()), dst.data(),
+                                     static_cast<int>(dst.size()));
+    ASSERT_EQ(err, AEE_SUCCESS) << "pass " << pass << ": " << hex(err);
+  }
+  EXPECT_EQ(first, second);
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I4Layer, ReleasedHandleIsRejectedAndSlotIsReused) {
+  const uint32_t K = 128, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D0001u, w));
+  const uint32_t released = w.handle;
+  ASSERT_EQ(nntr_hvx_weight_release_u8i4(handle_, released), AEE_SUCCESS);
+
+  // Using a released handle must fail rather than read freed memory.
+  std::vector<float> x(K, 0.0f);
+  std::vector<float> out(N, 0.0f);
+  const uint32_t handles[1] = {released};
+  EXPECT_NE(nntr_hvx_mm_u8i4_layer(handle_, 1, K, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_NE(nntr_hvx_weight_release_u8i4(handle_, released), AEE_SUCCESS)
+    << "double release accepted";
+
+  // The freed slot must come back, or a long-running process leaks handles.
+  Weight w2;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D0002u, w2));
+  EXPECT_EQ(w2.handle, released);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w2.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I4Layer, MismatchedKIsRejected) {
+  // Every handle in one call shares the activation, so a handle baked for
+  // a different K is a caller bug that must not read out of bounds.
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(256, 128, 0xE0E00001u, w));
+  const uint32_t handles[1] = {w.handle};
+  std::vector<float> x(128, 0.0f); // K=128, but the weight was baked at 256
+  std::vector<float> out(128, 0.0f);
+  EXPECT_NE(nntr_hvx_mm_u8i4_layer(handle_, 1, 128, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+}
+
+/**
+ * @brief Per-call cost of the harness endpoint against the layer endpoint.
+ *
+ * Printed, never asserted. doc13 §3a measured 1.7-2x for cross-matmul
+ * prefetch on a V79, but that was inside a standalone DSP program with no
+ * FastRPC in the timed region, and thermal state moves these numbers
+ * between runs -- a threshold here would encode the lab conditions rather
+ * than a property of the code. Read the ratio, do not gate on it.
+ */
+TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
+  const uint32_t M = 64, K = 1024, N = 1024;
+  const int kReps = 20;
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xF00D0001u, w));
+  const uint32_t handles[1] = {w.handle};
+
+  std::vector<float> out(static_cast<size_t>(M) * N, 0.0f);
+  auto time_us = [&](const std::function<void()> &fn) {
+    fn(); // warm-up, discarded
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kReps; ++i) {
+      fn();
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::micro>(t1 - t0).count() / kReps;
+  };
+
+  const uint32_t m_pad = round_up(M, kTileRow);
+  std::vector<uint8_t> ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> sc(m_pad, 0.0f);
+  std::vector<int32_t> zp(m_pad, 0);
+  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> harness_out(static_cast<size_t>(M) * N, 0.0f);
+
+  const double harness_us = time_us([&] {
+    nntr_hvx_mm_u8i4_from_f32(
+      handle_, M, K, N, x.data(), static_cast<int>(x.size()), w.q_w.data(),
+      static_cast<int>(w.q_w.size()), w.d.data(), static_cast<int>(w.d.size()),
+      w.colsum.data(), static_cast<int>(w.colsum.size()), w.bias.data(),
+      static_cast<int>(w.bias.size()), ah.data(), static_cast<int>(ah.size()),
+      sc.data(), static_cast<int>(sc.size()), zp.data(),
+      static_cast<int>(zp.size()), acc.data(), static_cast<int>(acc.size()),
+      harness_out.data(), static_cast<int>(harness_out.size()));
+  });
+
+  const double layer_us = time_us([&] {
+    nntr_hvx_mm_u8i4_layer(handle_, M, K, handles, 1, x.data(),
+                           static_cast<int>(x.size()), out.data(),
+                           static_cast<int>(out.size()));
+  });
+
+  std::cout << "U8I4_FIELD path=harness  field=us_per_matmul value="
+            << harness_us << std::endl;
+  std::cout << "U8I4_FIELD path=layer_x1 field=us_per_matmul value="
+            << layer_us << std::endl;
+
+  // Several weights per call is where the prefetch has something to hide
+  // behind; x1 above cannot show it by construction (doc13 §3a: a single
+  // matmul is parity).
+  std::vector<Weight> ws(4);
+  std::vector<uint32_t> hs;
+  uint32_t n_total = 0;
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, N, 0xF00D1000u + i * 0x100u, ws[i]));
+    hs.push_back(ws[i].handle);
+    n_total += ws[i].N;
+  }
+  std::vector<float> out4(static_cast<size_t>(M) * n_total, 0.0f);
+  const double layer4_us = time_us([&] {
+    nntr_hvx_mm_u8i4_layer(handle_, M, K, hs.data(),
+                           static_cast<int>(hs.size()), x.data(),
+                           static_cast<int>(x.size()), out4.data(),
+                           static_cast<int>(out4.size()));
+  });
+  std::cout << "U8I4_FIELD path=layer_x4 field=us_per_matmul value="
+            << (layer4_us / 4.0) << std::endl;
+  std::cout << "U8I4_FIELD path=layer_x4 field=speedup_vs_harness value="
+            << (harness_us / (layer4_us / 4.0)) << std::endl;
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+  for (const auto &ww : ws) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, ww.handle), AEE_SUCCESS);
+  }
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -188,6 +189,47 @@ void ref_dequant(const std::vector<int32_t> &acc, uint32_t m_valid, uint32_t N,
   }
 }
 
+/**
+ * @brief Unquantized fp32 matmul. The yardstick S4 measures against.
+ */
+void ref_fp32_matmul(const std::vector<float> &x, const std::vector<float> &w,
+                     uint32_t M, uint32_t K, uint32_t N,
+                     const std::vector<float> &bias, std::vector<float> &out) {
+  out.assign(static_cast<size_t>(M) * N, 0.0f);
+  for (uint32_t m = 0; m < M; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      float sum = 0.0f;
+      for (uint32_t k = 0; k < K; ++k) {
+        sum +=
+          x[static_cast<size_t>(m) * K + k] * w[static_cast<size_t>(k) * N + n];
+      }
+      out[static_cast<size_t>(m) * N + n] = sum + bias[n];
+    }
+  }
+}
+
+/**
+ * @brief Signal-to-noise ratio in dB between a reference and a result.
+ *
+ * Reported rather than asserted tightly: no measurement exists yet for
+ * what per-channel int4 costs on this workload, and inventing a threshold
+ * before measuring would just encode a guess.
+ */
+double snr_db(const std::vector<float> &ref, const std::vector<float> &got) {
+  double sig = 0.0;
+  double noise = 0.0;
+  for (size_t i = 0; i < ref.size(); ++i) {
+    const double r = ref[i];
+    const double e = static_cast<double>(got[i]) - r;
+    sig += r * r;
+    noise += e * e;
+  }
+  if (noise == 0.0) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return 10.0 * std::log10(sig / noise);
+}
+
 /** @brief Deterministic pseudo-random fill in [-1, 1). */
 void fill_deterministic(std::vector<float> &v, uint32_t seed) {
   uint32_t s = seed;
@@ -296,198 +338,117 @@ protected:
   }
 
   remote_handle64 handle_ = 0;
+
+  /**
+   * @brief Runs S1 through S4 for one shape.
+   *
+   * S1 and S2 are bit-exact: integer arithmetic is deterministic, so any
+   * layout or wiring error shows up as an exact mismatch rather than
+   * being absorbed into a tolerance. S3 allows f32 ordering slack. S4 is
+   * reported, not gated.
+   */
+  void CheckShape(uint32_t M, uint32_t K, uint32_t N, bool want_wh_dump) {
+    SCOPED_TRACE("M=" + std::to_string(M) + " K=" + std::to_string(K) +
+                 " N=" + std::to_string(N));
+    const uint32_t m_pad = round_up(M, kTileRow);
+
+    std::vector<float> w_f32(static_cast<size_t>(K) * N);
+    fill_deterministic(w_f32, 0x5EED0001u);
+    std::vector<int8_t> q_w;
+    std::vector<float> d;
+    std::vector<int32_t> colsum;
+    quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+    std::vector<float> x(static_cast<size_t>(M) * K);
+    fill_deterministic(x, 0x5EED0002u);
+    std::vector<float> bias(N);
+    fill_deterministic(bias, 0x5EED0003u);
+
+    std::vector<float> exp_scale;
+    std::vector<int32_t> exp_zp;
+    quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+    std::vector<uint8_t> exp_u_rm;
+    quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+    std::vector<uint8_t> exp_ah;
+    pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
+    std::vector<int32_t> exp_acc;
+    ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+    std::vector<float> exp_out;
+    ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
+
+    std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+    std::vector<float> got_scale(m_pad, 0.0f);
+    std::vector<int32_t> got_zp(m_pad, -1);
+    std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+    std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+    int err = nntr_hvx_mm_u8i4_from_f32(
+      handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+      static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+      colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+      static_cast<int>(bias.size()), got_ah.data(),
+      static_cast<int>(got_ah.size()), got_scale.data(),
+      static_cast<int>(got_scale.size()), got_zp.data(),
+      static_cast<int>(got_zp.size()), got_acc.data(),
+      static_cast<int>(got_acc.size()), got_out.data(),
+      static_cast<int>(got_out.size()));
+    ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+    // S1
+    for (uint32_t m = 0; m < m_pad; ++m) {
+      EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
+        << "scale[" << m << "]";
+      EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
+    }
+    EXPECT_EQ(got_ah, exp_ah);
+
+    // S2
+    EXPECT_EQ(got_acc, exp_acc);
+
+    // S3
+    for (size_t i = 0; i < exp_out.size(); ++i) {
+      EXPECT_NEAR(got_out[i], exp_out[i], std::abs(exp_out[i]) * 1e-5f + 1e-6f);
+    }
+
+    // S4 -- measured and printed, deliberately not gated tightly.
+    std::vector<float> fp32_ref;
+    ref_fp32_matmul(x, w_f32, M, K, N, bias, fp32_ref);
+    double max_rel = 0.0;
+    for (size_t i = 0; i < fp32_ref.size(); ++i) {
+      const double denom = std::abs(static_cast<double>(fp32_ref[i]));
+      if (denom > 1e-6) {
+        max_rel = std::max(
+          max_rel,
+          std::abs(static_cast<double>(got_out[i]) - fp32_ref[i]) / denom);
+      }
+    }
+    const double snr = snr_db(fp32_ref, got_out);
+    std::cout << "[S4] M=" << M << " K=" << K << " N=" << N << " SNR=" << snr
+              << " dB  max_rel=" << max_rel << std::endl;
+    EXPECT_GT(snr, 0.0) << "quantized output carries no signal at all";
+  }
 };
 
-TEST_F(HmxMmU8I4, HmxBringsUp) {
-  // Task 1 gate: the entry point links against libhexkl_micro.a, hw_init
-  // succeeds and the HMX lock round-trips. Buffers are unused here.
-  std::vector<uint8_t> act(64 * 128, 0);
-  std::vector<int8_t> w(128 * 128, 0);
-  std::vector<int32_t> acc(64 * 128, 0);
-  std::vector<uint8_t> dump(0);
-
-  int err = nntr_hvx_mm_u8i4_from_u8(
-    handle_, 64, 128, 128, act.data(), static_cast<int>(act.size()), w.data(),
-    static_cast<int>(w.size()), acc.data(), static_cast<int>(acc.size()),
-    dump.data(), 0);
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+TEST_F(HmxMmU8I4, Shape1_Minimal) {
+  // Same dimensions as HexKL's own example, so a failure here is ours.
+  CheckShape(64, 128, 128, /*want_wh_dump=*/true);
 }
 
-TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  // Host-side weight quantization: fp32 -> per-channel int4.
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  // Host-side activation: an arbitrary but deterministic uint8 pattern.
-  // Activation quantization from fp32 is Task 3; this task isolates the
-  // weight bake, the WH layout and the HMX matmul.
-  std::vector<uint8_t> u_rm(static_cast<size_t>(m_pad) * K);
-  for (size_t i = 0; i < u_rm.size(); ++i) {
-    u_rm[i] = static_cast<uint8_t>((i * 37u + 11u) & 0xFFu);
-  }
-  std::vector<uint8_t> act_ah;
-  pack_ah_from_rowmajor(u_rm, m_pad, K, act_ah);
-
-  std::vector<int32_t> expected;
-  ref_int_matmul(u_rm, q_w, m_pad, K, N, expected);
-
-  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<uint8_t> dump(static_cast<size_t>(K / kTileInner) *
-                            (N / kTileCol) * 512);
-
-  int err = nntr_hvx_mm_u8i4_from_u8(
-    handle_, M, K, N, act_ah.data(), static_cast<int>(act_ah.size()),
-    q_w.data(), static_cast<int>(q_w.size()), acc.data(),
-    static_cast<int>(acc.size()), dump.data(), static_cast<int>(dump.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
-
-  size_t mismatches = 0;
-  for (uint32_t m = 0; m < m_pad && mismatches < 10; ++m) {
-    for (uint32_t n = 0; n < N && mismatches < 10; ++n) {
-      const size_t i = static_cast<size_t>(m) * N + n;
-      if (acc[i] != expected[i]) {
-        ++mismatches;
-        ADD_FAILURE() << "acc[" << m << "][" << n << "] = " << acc[i]
-                      << ", expected " << expected[i];
-      }
-    }
-  }
-  EXPECT_EQ(acc, expected);
-
-  // The baked buffer is the WH i4 layout, which HexKL does not document.
-  // Print the first tile so the offline converter has a reference.
-  std::cout << "WH tile 0 (512B, hex):" << std::endl;
-  for (size_t i = 0; i < 512; ++i) {
-    std::cout << std::hex << std::setw(2) << std::setfill('0')
-              << static_cast<unsigned>(dump[i])
-              << ((i % 32 == 31) ? "\n" : " ");
-  }
-  std::cout << std::dec << std::flush;
+TEST_F(HmxMmU8I4, Shape2_DecodeSingleToken) {
+  // One token padded out to a 64-row tile: the decode case, and the one
+  // that exercises the zero-pad path for 63 of 64 rows.
+  CheckShape(1, 1024, 1024, /*want_wh_dump=*/false);
 }
 
-TEST_F(HmxMmU8I4, S1_ActivationQuantMatchesHost) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  std::vector<float> x(static_cast<size_t>(M) * K);
-  fill_deterministic(x, 0x5EED0002u);
-  std::vector<float> bias(N);
-  fill_deterministic(bias, 0x5EED0003u);
-
-  std::vector<float> exp_scale;
-  std::vector<int32_t> exp_zp;
-  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
-  std::vector<uint8_t> exp_u_rm;
-  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
-  std::vector<uint8_t> exp_ah;
-  pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
-  std::vector<int32_t> exp_acc;
-  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
-
-  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
-  std::vector<float> got_scale(m_pad, 0.0f);
-  std::vector<int32_t> got_zp(m_pad, -1);
-  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
-
-  int err = nntr_hvx_mm_u8i4_from_f32(
-    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
-    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
-    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
-    static_cast<int>(bias.size()), got_ah.data(),
-    static_cast<int>(got_ah.size()), got_scale.data(),
-    static_cast<int>(got_scale.size()), got_zp.data(),
-    static_cast<int>(got_zp.size()), got_acc.data(),
-    static_cast<int>(got_acc.size()), got_out.data(),
-    static_cast<int>(got_out.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
-
-  for (uint32_t m = 0; m < m_pad; ++m) {
-    EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
-      << "scale[" << m << "]";
-    EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
-  }
-  EXPECT_EQ(got_ah, exp_ah);
-
-  // The activation the HMX actually consumed now comes from the HVX
-  // kernel, so this re-checks S2 end to end rather than with a fixed
-  // pattern.
-  EXPECT_EQ(got_acc, exp_acc);
+TEST_F(HmxMmU8I4, Shape3_PrefillQwen3Scale) {
+  // Weights alone need (1024/32)*(1024/32)*512 = 512 KiB of VTCM here.
+  CheckShape(64, 1024, 1024, /*want_wh_dump=*/false);
 }
 
-TEST_F(HmxMmU8I4, S3_DequantMatchesHost) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  std::vector<float> x(static_cast<size_t>(M) * K);
-  fill_deterministic(x, 0x5EED0002u);
-  std::vector<float> bias(N);
-  fill_deterministic(bias, 0x5EED0003u);
-
-  std::vector<float> exp_scale;
-  std::vector<int32_t> exp_zp;
-  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
-  std::vector<uint8_t> exp_u_rm;
-  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
-  std::vector<int32_t> exp_acc;
-  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
-  std::vector<float> exp_out;
-  ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
-
-  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
-  std::vector<float> got_scale(m_pad, 0.0f);
-  std::vector<int32_t> got_zp(m_pad, -1);
-  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
-
-  int err = nntr_hvx_mm_u8i4_from_f32(
-    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
-    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
-    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
-    static_cast<int>(bias.size()), got_ah.data(),
-    static_cast<int>(got_ah.size()), got_scale.data(),
-    static_cast<int>(got_scale.size()), got_zp.data(),
-    static_cast<int>(got_zp.size()), got_acc.data(),
-    static_cast<int>(got_acc.size()), got_out.data(),
-    static_cast<int>(got_out.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
-
-  ASSERT_EQ(got_acc, exp_acc) << "accumulator diverged; S3 is meaningless";
-
-  size_t reported = 0;
-  for (uint32_t m = 0; m < M; ++m) {
-    for (uint32_t n = 0; n < N; ++n) {
-      const size_t i = static_cast<size_t>(m) * N + n;
-      const float tol = std::abs(exp_out[i]) * 1e-5f + 1e-6f;
-      if (std::abs(got_out[i] - exp_out[i]) > tol && reported < 10) {
-        ++reported;
-        ADD_FAILURE() << "out[" << m << "][" << n << "] = " << got_out[i]
-                      << ", expected " << exp_out[i];
-      }
-      EXPECT_NEAR(got_out[i], exp_out[i], tol);
-    }
-  }
+TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
+  // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
+  // ever runs with rb=0. This is the one that runs it twice.
+  CheckShape(128, 128, 128, /*want_wh_dump=*/false);
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_softmax.cpp
+++ b/test/unittest/unittest_hvx_softmax.cpp
@@ -181,17 +181,6 @@ TEST_F(HvxExp, FlushesFarNegativeToZero) {
   }
 }
 
-TEST_F(HvxSoftmax, RoundTripsTheOutputBuffer) {
-  const uint32_t m = 1, k = 32;
-  std::vector<float> in(m * k, 1.0f), out(m * k, -1.0f);
-
-  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
-                                 static_cast<int>(in.size()), out.data(),
-                                 static_cast<int>(out.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "softmax_f32 failed: " << hex(err);
-  EXPECT_NE(out[0], -1.0f);
-}
-
 TEST_F(HvxSoftmax, RejectsLengthMismatch) {
   const uint32_t m = 2, k = 32;
   std::vector<float> in(m * k, 1.0f), out(k, 0.0f);
@@ -201,6 +190,142 @@ TEST_F(HvxSoftmax, RejectsLengthMismatch) {
                                  static_cast<int>(out.size()));
   EXPECT_EQ(err, AEE_EBADPARM + kDspOffset)
     << "expected EBADPARM, got " << hex(err);
+}
+
+TEST_F(HvxSoftmax, MatchesDoubleForOneFullRow) {
+  const uint32_t m = 1, k = 1024;
+  std::vector<float> in(m * k), out(m * k, 0.0f);
+
+  std::mt19937 rng(20260805u);
+  std::uniform_real_distribution<float> dist(-8.0f, 8.0f);
+  for (auto &v : in) {
+    v = dist(rng);
+  }
+
+  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
+                                 static_cast<int>(in.size()), out.data(),
+                                 static_cast<int>(out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "softmax_f32 failed: " << hex(err);
+
+  const std::vector<float> ref = ref_softmax(in, m, k, 1.0f);
+  double worst = 0.0;
+  double sum = 0.0;
+  for (uint32_t i = 0; i < k; ++i) {
+    worst = std::max(worst, std::abs(static_cast<double>(out[i]) - ref[i]));
+    sum += out[i];
+  }
+  EXPECT_LT(worst, 1e-6) << "worst absolute error";
+  EXPECT_NEAR(sum, 1.0, 1e-6) << "row does not sum to 1";
+}
+
+TEST_F(HvxSoftmax, IsInvariantToAConstantShift) {
+  // Adding a constant to every element must not change the result. This is
+  // what the max subtraction buys. exp(100) overflows f32, so 1e2 still
+  // forces max subtraction; going larger (e.g. 1e4) rounds f32 inputs to
+  // ULP ~0.001 on the host before the DSP sees them, making 1e-6
+  // unachievable regardless of kernel precision.
+  const uint32_t m = 1, k = 256;
+  std::vector<float> base(m * k), shifted(m * k);
+  std::vector<float> out_base(m * k, 0.0f), out_shift(m * k, 0.0f);
+
+  std::mt19937 rng(7u);
+  std::uniform_real_distribution<float> dist(-2.0f, 2.0f);
+  for (uint32_t i = 0; i < k; ++i) {
+    base[i] = dist(rng);
+    shifted[i] = base[i] + 1e2f;
+  }
+
+  const int n = static_cast<int>(m * k);
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 1.0f, base.data(), n,
+                                 out_base.data(), n),
+            AEE_SUCCESS);
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 1.0f, shifted.data(), n,
+                                 out_shift.data(), n),
+            AEE_SUCCESS);
+
+  for (uint32_t i = 0; i < k; ++i) {
+    EXPECT_NEAR(out_base[i], out_shift[i], 1e-6) << "lane " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, SpreadsUniformlyForEqualInputs) {
+  const uint32_t m = 1, k = 64;
+  const std::vector<float> in(m * k, 5.0f);
+  std::vector<float> out(m * k, 0.0f);
+
+  const int n = static_cast<int>(m * k);
+  ASSERT_EQ(
+    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
+    AEE_SUCCESS);
+
+  for (uint32_t i = 0; i < k; ++i) {
+    EXPECT_NEAR(out[i], 1.0f / 64.0f, 1e-6) << "lane " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, CollapsesOntoADominantElement) {
+  // Every other term underflows exp. Without the guard in hvx_exp_sf these
+  // come back as garbage rather than zero.
+  const uint32_t m = 1, k = 32;
+  std::vector<float> in(m * k, 0.0f);
+  in[7] = 100.0f;
+  std::vector<float> out(m * k, -1.0f);
+
+  const int n = static_cast<int>(m * k);
+  ASSERT_EQ(
+    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
+    AEE_SUCCESS);
+
+  for (uint32_t i = 0; i < k; ++i) {
+    EXPECT_NEAR(out[i], i == 7 ? 1.0f : 0.0f, 1e-6) << "lane " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, HandlesRowLengthsThatAreNotWholeVectors) {
+  // 1 is below one vector; 31 is one short; 33 is one over; 100 is three
+  // vectors plus four.
+  for (const uint32_t k : {1u, 31u, 33u, 100u}) {
+    const uint32_t m = 1;
+    std::vector<float> in(k), out(k, -1.0f);
+
+    std::mt19937 rng(k);
+    std::uniform_real_distribution<float> dist(-4.0f, 4.0f);
+    for (auto &v : in) {
+      v = dist(rng);
+    }
+
+    const int n = static_cast<int>(k);
+    ASSERT_EQ(
+      nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
+      AEE_SUCCESS)
+      << "k=" << k;
+
+    const std::vector<float> ref = ref_softmax(in, m, k, 1.0f);
+    double sum = 0.0;
+    for (uint32_t i = 0; i < k; ++i) {
+      EXPECT_NEAR(out[i], ref[i], 1e-6) << "k=" << k << " lane " << i;
+      sum += out[i];
+    }
+    EXPECT_NEAR(sum, 1.0, 1e-6) << "k=" << k << " does not sum to 1";
+  }
+}
+
+TEST_F(HvxSoftmax, DoesNotWritePastTheEndOfTheBuffer) {
+  // k=33 means the tail vector covers 32 lanes but only 1 is real. A
+  // full-vector store would clobber 31 floats of whatever follows.
+  const uint32_t m = 1, k = 33;
+  const uint32_t guard = 64;
+  std::vector<float> buf(k + guard, 12345.0f);
+  std::vector<float> in(k, 1.0f);
+
+  const int n = static_cast<int>(k);
+  ASSERT_EQ(
+    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, buf.data(), n),
+    AEE_SUCCESS);
+
+  for (uint32_t i = 0; i < guard; ++i) {
+    EXPECT_EQ(buf[k + i], 12345.0f) << "clobbered guard word " << i;
+  }
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_softmax.cpp
+++ b/test/unittest/unittest_hvx_softmax.cpp
@@ -185,7 +185,7 @@ TEST_F(HvxSoftmax, RejectsLengthMismatch) {
   const uint32_t m = 2, k = 32;
   std::vector<float> in(m * k, 1.0f), out(k, 0.0f);
 
-  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
+  int err = nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(),
                                  static_cast<int>(in.size()), out.data(),
                                  static_cast<int>(out.size()));
   EXPECT_EQ(err, AEE_EBADPARM + kDspOffset)
@@ -202,7 +202,7 @@ TEST_F(HvxSoftmax, MatchesDoubleForOneFullRow) {
     v = dist(rng);
   }
 
-  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
+  int err = nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(),
                                  static_cast<int>(in.size()), out.data(),
                                  static_cast<int>(out.size()));
   ASSERT_EQ(err, AEE_SUCCESS) << "softmax_f32 failed: " << hex(err);
@@ -236,10 +236,10 @@ TEST_F(HvxSoftmax, IsInvariantToAConstantShift) {
   }
 
   const int n = static_cast<int>(m * k);
-  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 1.0f, base.data(), n,
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, base.data(), n,
                                  out_base.data(), n),
             AEE_SUCCESS);
-  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 1.0f, shifted.data(), n,
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, shifted.data(), n,
                                  out_shift.data(), n),
             AEE_SUCCESS);
 
@@ -255,7 +255,7 @@ TEST_F(HvxSoftmax, SpreadsUniformlyForEqualInputs) {
 
   const int n = static_cast<int>(m * k);
   ASSERT_EQ(
-    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
+    nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n, out.data(), n),
     AEE_SUCCESS);
 
   for (uint32_t i = 0; i < k; ++i) {
@@ -273,7 +273,7 @@ TEST_F(HvxSoftmax, CollapsesOntoADominantElement) {
 
   const int n = static_cast<int>(m * k);
   ASSERT_EQ(
-    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
+    nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n, out.data(), n),
     AEE_SUCCESS);
 
   for (uint32_t i = 0; i < k; ++i) {
@@ -295,9 +295,9 @@ TEST_F(HvxSoftmax, HandlesRowLengthsThatAreNotWholeVectors) {
     }
 
     const int n = static_cast<int>(k);
-    ASSERT_EQ(
-      nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, out.data(), n),
-      AEE_SUCCESS)
+    ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n,
+                                   out.data(), n),
+              AEE_SUCCESS)
       << "k=" << k;
 
     const std::vector<float> ref = ref_softmax(in, m, k, 1.0f);
@@ -320,11 +320,117 @@ TEST_F(HvxSoftmax, DoesNotWritePastTheEndOfTheBuffer) {
 
   const int n = static_cast<int>(k);
   ASSERT_EQ(
-    nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(), n, buf.data(), n),
+    nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n, buf.data(), n),
     AEE_SUCCESS);
 
   for (uint32_t i = 0; i < guard; ++i) {
     EXPECT_EQ(buf[k + i], 12345.0f) << "clobbered guard word " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, KeepsRowsIndependent) {
+  // Different distributions per row: if one row's max or sum leaked into
+  // the next, these would not all normalize to 1.
+  const uint32_t m = 8, k = 100;
+  std::vector<float> in(m * k), out(m * k, -1.0f);
+
+  std::mt19937 rng(31u);
+  for (uint32_t r = 0; r < m; ++r) {
+    std::uniform_real_distribution<float> dist(-2.0f * (r + 1), 2.0f * (r + 1));
+    for (uint32_t i = 0; i < k; ++i) {
+      in[(size_t)r * k + i] = dist(rng);
+    }
+  }
+
+  const int n = static_cast<int>(in.size());
+  ASSERT_EQ(
+    nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n, out.data(), n),
+    AEE_SUCCESS);
+
+  const std::vector<float> ref = ref_softmax(in, m, k, 1.0f);
+  for (uint32_t r = 0; r < m; ++r) {
+    double sum = 0.0;
+    for (uint32_t i = 0; i < k; ++i) {
+      const size_t j = (size_t)r * k + i;
+      EXPECT_NEAR(out[j], ref[j], 1e-6) << "row " << r << " lane " << i;
+      sum += out[j];
+    }
+    EXPECT_NEAR(sum, 1.0, 1e-6) << "row " << r << " does not sum to 1";
+  }
+}
+
+TEST_F(HvxSoftmax, MatchesOutOfPlaceWhenComputedInPlace) {
+  const uint32_t m = 4, k = 65;
+  std::vector<float> in(m * k);
+
+  std::mt19937 rng(99u);
+  std::uniform_real_distribution<float> dist(-3.0f, 3.0f);
+  for (auto &v : in) {
+    v = dist(rng);
+  }
+
+  std::vector<float> out_of_place(m * k, 0.0f);
+  std::vector<float> in_place = in;
+
+  const int n = static_cast<int>(in.size());
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n,
+                                 out_of_place.data(), n),
+            AEE_SUCCESS);
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in_place.data(), n,
+                                 in_place.data(), n),
+            AEE_SUCCESS);
+
+  for (uint32_t i = 0; i < m * k; ++i) {
+    EXPECT_EQ(in_place[i], out_of_place[i]) << "lane " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, HandlesANegativeScale) {
+  // A negative scale flips which element is the maximum. Taking
+  // scale*max(x) instead of max(x*scale) would subtract the wrong value
+  // and overflow exp.
+  const uint32_t m = 2, k = 48;
+  std::vector<float> in(m * k), out(m * k, -1.0f);
+
+  std::mt19937 rng(5u);
+  std::uniform_real_distribution<float> dist(-6.0f, 6.0f);
+  for (auto &v : in) {
+    v = dist(rng);
+  }
+
+  const int n = static_cast<int>(in.size());
+  ASSERT_EQ(
+    nntr_hvx_softmax_f32(handle_, m, k, 0u, -1.0f, in.data(), n, out.data(), n),
+    AEE_SUCCESS);
+
+  const std::vector<float> ref = ref_softmax(in, m, k, -1.0f);
+  for (uint32_t i = 0; i < m * k; ++i) {
+    EXPECT_NEAR(out[i], ref[i], 1e-6) << "lane " << i;
+  }
+}
+
+TEST_F(HvxSoftmax, LeavesRowsBeforeTheRangeAlone) {
+  // m_first=2 of 5 rows. FastRPC zeroes the rout buffer before sending it
+  // to the DSP, so the untouched rows come back 0 regardless -- an in-place
+  // (inrout) IDL entry would be needed to see them directly. Instead, call
+  // twice -- (0, M) and (m_first, M) -- and compare the rows the range call
+  // should have produced.
+  const uint32_t m = 5, k = 64, m_first = 2;
+  std::vector<float> in(m * k, 1.0f);
+  std::vector<float> out_full(m * k, 0.0f);
+  std::vector<float> out_range(m * k, 0.0f);
+
+  const int n = static_cast<int>(in.size());
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, 0u, 1.0f, in.data(), n,
+                                 out_full.data(), n),
+            AEE_SUCCESS);
+  ASSERT_EQ(nntr_hvx_softmax_f32(handle_, m, k, m_first, 1.0f, in.data(), n,
+                                 out_range.data(), n),
+            AEE_SUCCESS);
+
+  for (uint32_t i = m_first * k; i < m * k; ++i) {
+    EXPECT_NEAR(out_range[i], out_full[i], 1e-6)
+      << "range result differs from full result at lane " << i;
   }
 }
 

--- a/test/unittest/unittest_hvx_softmax.cpp
+++ b/test/unittest/unittest_hvx_softmax.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   unittest_hvx_softmax.cpp
+ * @date   05 Aug 2026
+ * @brief  Device test: HVX exp and softmax match a double reference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Runs on an Android device only. Requires libnntr_hvx_skel.so on
+ * ADSP_LIBRARY_PATH. See test/htp/build.sh.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+namespace {
+
+/**
+ * @brief Offset AEEStdErr.h adds to every AEE_* code on the DSP side.
+ *
+ * DSP-side skel code is compiled with __hexagon__ defined, where
+ * AEEStdErr.h adds this offset to every AEE_* code before it crosses the
+ * FastRPC boundary. This host binary is not compiled with __hexagon__, so
+ * AEE_EBADPARM here is plain 14 -- the offset has to be added back when
+ * checking an error the DSP returned.
+ */
+constexpr int kDspOffset = 0x80000400;
+
+/** @brief Render a FastRPC error as hex so the code is searchable. */
+std::string hex(int err) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(8) << std::setfill('0')
+     << static_cast<unsigned>(err);
+  return os.str();
+}
+
+/**
+ * @brief Softmax reference in double, row by row.
+ *
+ * double rather than the nntrainer CPU softmax: comparing two f32
+ * approximations would blur where the error comes from.
+ */
+std::vector<float> ref_softmax(const std::vector<float> &x, uint32_t m,
+                               uint32_t k, float scale) {
+  std::vector<float> y(x.size());
+  std::vector<double> e(k);
+
+  for (uint32_t r = 0; r < m; ++r) {
+    const float *xr = x.data() + static_cast<size_t>(r) * k;
+    double mx = -std::numeric_limits<double>::infinity();
+    for (uint32_t i = 0; i < k; ++i) {
+      mx = std::max(mx, static_cast<double>(xr[i]) * scale);
+    }
+    double sum = 0.0;
+    for (uint32_t i = 0; i < k; ++i) {
+      e[i] = std::exp(static_cast<double>(xr[i]) * scale - mx);
+      sum += e[i];
+    }
+    for (uint32_t i = 0; i < k; ++i) {
+      y[static_cast<size_t>(r) * k + i] = static_cast<float>(e[i] / sum);
+    }
+  }
+  return y;
+}
+
+/**
+ * @brief Opens an unsigned-PD CDSP session for each test.
+ *
+ * A failure here is a hard FAIL rather than a skip: proving the DSP comes
+ * up on the device is part of what this test measures, so a quiet skip
+ * would report success for it.
+ */
+class HtpSession : public ::testing::Test {
+protected:
+  void SetUp() override {
+    remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
+    int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
+                                     &unsigned_pd, sizeof(unsigned_pd));
+    ASSERT_EQ(err, AEE_SUCCESS) << "enabling unsigned PD failed: " << hex(err);
+
+    const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
+    err = nntr_hvx_open(uri.c_str(), &handle_);
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "nntr_hvx_open failed: " << hex(err)
+      << " -- is libnntr_hvx_skel.so on ADSP_LIBRARY_PATH?";
+  }
+
+  void TearDown() override {
+    if (handle_) {
+      nntr_hvx_close(handle_);
+    }
+  }
+
+  remote_handle64 handle_ = 0;
+};
+
+class HvxExp : public HtpSession {};
+class HvxSoftmax : public HtpSession {};
+
+TEST_F(HvxExp, RoundTripsTheOutputBuffer) {
+  const int n = 32;
+  std::vector<float> in(n, 1.0f), out(n, -1.0f);
+
+  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "exp_f32 failed: " << hex(err);
+  /* The stub zeroes the buffer; this only proves rout came back. */
+  EXPECT_NE(out[0], -1.0f);
+}
+
+TEST_F(HvxExp, RejectsNonVectorLength) {
+  const int n = 33;
+  std::vector<float> in(n, 1.0f), out(n, 0.0f);
+
+  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
+  EXPECT_EQ(err, AEE_EBADPARM + kDspOffset)
+    << "expected EBADPARM, got " << hex(err);
+}
+
+TEST_F(HvxSoftmax, RoundTripsTheOutputBuffer) {
+  const uint32_t m = 1, k = 32;
+  std::vector<float> in(m * k, 1.0f), out(m * k, -1.0f);
+
+  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
+                                 static_cast<int>(in.size()), out.data(),
+                                 static_cast<int>(out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "softmax_f32 failed: " << hex(err);
+  EXPECT_NE(out[0], -1.0f);
+}
+
+TEST_F(HvxSoftmax, RejectsLengthMismatch) {
+  const uint32_t m = 2, k = 32;
+  std::vector<float> in(m * k, 1.0f), out(k, 0.0f);
+
+  int err = nntr_hvx_softmax_f32(handle_, m, k, 1.0f, in.data(),
+                                 static_cast<int>(in.size()), out.data(),
+                                 static_cast<int>(out.size()));
+  EXPECT_EQ(err, AEE_EBADPARM + kDspOffset)
+    << "expected EBADPARM, got " << hex(err);
+}
+
+} // namespace
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_hvx_softmax.cpp
+++ b/test/unittest/unittest_hvx_softmax.cpp
@@ -115,16 +115,6 @@ protected:
 class HvxExp : public HtpSession {};
 class HvxSoftmax : public HtpSession {};
 
-TEST_F(HvxExp, RoundTripsTheOutputBuffer) {
-  const int n = 32;
-  std::vector<float> in(n, 1.0f), out(n, -1.0f);
-
-  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
-  ASSERT_EQ(err, AEE_SUCCESS) << "exp_f32 failed: " << hex(err);
-  /* The stub zeroes the buffer; this only proves rout came back. */
-  EXPECT_NE(out[0], -1.0f);
-}
-
 TEST_F(HvxExp, RejectsNonVectorLength) {
   const int n = 33;
   std::vector<float> in(n, 1.0f), out(n, 0.0f);
@@ -132,6 +122,63 @@ TEST_F(HvxExp, RejectsNonVectorLength) {
   int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
   EXPECT_EQ(err, AEE_EBADPARM + kDspOffset)
     << "expected EBADPARM, got " << hex(err);
+}
+
+TEST_F(HvxExp, MatchesDoubleOverTheNormalRange) {
+  // 8192 is a multiple of 32. Sweep stops at -87: below that the true
+  // value is subnormal and the kernel flushes it to zero by contract.
+  const int n = 8192;
+  std::vector<float> in(n), out(n, 0.0f);
+  for (int i = 0; i < n; ++i) {
+    in[i] = -87.0f + 175.0f * static_cast<float>(i) / static_cast<float>(n - 1);
+  }
+
+  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "exp_f32 failed: " << hex(err);
+
+  double worst = 0.0;
+  int worst_i = 0;
+  for (int i = 0; i < n; ++i) {
+    const double ref = std::exp(static_cast<double>(in[i]));
+    const double rel = std::abs(static_cast<double>(out[i]) - ref) / ref;
+    if (rel > worst) {
+      worst = rel;
+      worst_i = i;
+    }
+  }
+  EXPECT_LT(worst, 1e-6) << "worst relative error at x=" << in[worst_i]
+                         << ": got " << out[worst_i] << ", want "
+                         << std::exp(static_cast<double>(in[worst_i]));
+}
+
+TEST_F(HvxExp, ExactlyOneAtZero) {
+  const int n = 32;
+  const std::vector<float> in(n, 0.0f);
+  std::vector<float> out(n, -1.0f);
+
+  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "exp_f32 failed: " << hex(err);
+  for (int i = 0; i < n; ++i) {
+    EXPECT_EQ(out[i], 1.0f) << "lane " << i;
+  }
+}
+
+TEST_F(HvxExp, FlushesFarNegativeToZero) {
+  // softmax feeds x - max, which can be arbitrarily negative. The low
+  // clamp inside hvx_exp_sf is what keeps the range reduction from
+  // overflowing its own valid domain on these.
+  const int n = 32;
+  std::vector<float> in(n, -90.0f);
+  in[1] = -200.0f;
+  in[2] = -1e30f;
+  in[3] = -3.4e38f;
+  std::vector<float> out(n, 1.0f);
+
+  int err = nntr_hvx_exp_f32(handle_, in.data(), n, out.data(), n);
+  ASSERT_EQ(err, AEE_SUCCESS) << "exp_f32 failed: " << hex(err);
+  for (int i = 0; i < n; ++i) {
+    EXPECT_EQ(out[i], 0.0f) << "lane " << i << " x=" << in[i];
+  }
 }
 
 TEST_F(HvxSoftmax, RoundTripsTheOutputBuffer) {


### PR DESCRIPTION
## Dependency of the PR

None. Standalone feature branch off `main` (Hexagon CDSP HTP backend bring-up, gated behind `HEXAGON_SDK_ROOT`; no effect on non-HTP builds).

## Commits to be reviewed in this PR


<details><summary>[htp] Add the FastRPC interface and DSP skel build for HVX bring-up</summary><br />

[htp] Add the FastRPC interface and DSP skel build for HVX bring-up

Defines a one-method IDL and the build script that turns it into a
loadable CDSP skel. qaic generates the stub and skel, hexagon-clang
builds them against v79 with HVX enabled; nothing here is hand-written
plumbing.

add_f32 returns AEE_EUNSUPPORTED for now, on purpose. The next commit's
test starts red against that return, which separates "the session
opened and the call reached the DSP" from "the kernel computes the
right values" -- two failures that are otherwise easy to confuse.

The build stays a manual step rather than a meson or ndk-build hook.
One kernel does not justify wiring a cross-compiler into the main build,
and a hook would have to be guarded for every environment without the
Hexagon SDK installed.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Verify an HVX kernel end to end on device</summary><br />

[htp] Verify an HVX kernel end to end on device

An nntrainer gtest opens an unsigned-PD CDSP session, calls an HVX
elementwise add across FastRPC, and compares the result bit for bit
against the CPU. 100 floats crosses three full 128-byte vectors and a
four-element tail, so one case covers both paths.

A failed session open is a FAIL, not a SKIP. Whether the DSP comes up on
the device is exactly what this test measures, and a skip would report
success for the measurement being absent.

Nothing locks HVX. The SDK's own profiling example uses HVX intrinsics
inside a skel with no lock -- the RPC thread already holds it -- so the
kernel only checks that a 128-byte context exists at all. Loads go
through HVX_UVector because FastRPC makes no alignment promise about
the buffers it hands the skel.

The module builds only under ifdef HEXAGON_SDK_ROOT and links neither
libnntrainer nor test_util; it needs FastRPC and gtest and nothing else.
Environments without the Hexagon SDK build exactly as before.

Deviation from plan (two changes, both required to build):

1. The test source is named unittest_hvx_kernels.cpp, not the plan's
   unittest_hvx_add.cpp. The LOCAL_MODULE (binary name) stays
   unittest_hvx_add so the existing adb push / run commands are
   unchanged.

2. The test defines its own int main(int argc, char**). The plan
   expected googletest_main to supply main(), but this repo's
   googletest_main module (Android.mk:82) compiles only gtest-all.cc;
   gtest_main.cc is absent. Every other unittest in this tree defines
   main at the bottom of its .cpp (e.g. unittest_common_properties.cpp:268). The
   new test follows that pattern rather than re-architecting the shared
   gtest module, which would touch every other test's build.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Cover the below-one-vector input for HVX add</summary><br />

[htp] Cover the below-one-vector input for HVX add

n=100 never exercises n_vec == 0, so the scalar tail runs unguarded for
any input shorter than a single 128-byte vector. This case pins that
boundary.

It likely passes without touching the kernel, which is the point: it is
a regression guard against a future rewrite that assumes at least one
full vector.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Fix an outdated comment in the HVX kernel unittest</summary><br />

[test] Fix an outdated comment in the HVX kernel unittest

- Refine the comment to accurately reflect the current code structure.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Link HexKL micro and bake u8i4 weights once</summary><br />

[htp] Link HexKL micro and bake u8i4 weights once

Add mm_u8i4_from_u8 and mm_u8i4_from_f32 to the FastRPC interface and a
DSP-side entry point that brings HMX up through hexkl_micro_hw_init and
round-trips the HMX lock. from_f32 returns AEE_EUNSUPPORTED until the
quantization kernels land.

build.sh now links libhexkl_micro.a. This requires Hexagon SDK 6.1.1.0 or
newer because HexKL ships a v79 static library only from lib/6.1.1.0 up;
6.4.0.1 is the combination HexKL's own examples were built against.

The harness logs the VTCM size so the budget in the design document can be
checked against hardware for the first time. Measured ~8 MB on S25 Ultra
(V79), ~13x the design's 598 KB peak footprint.

Add the VTCM partitioning, a one-shot weight bake and the HMX matmul loop
for the A8W4 path. HexKL's example converts each weight tile to WH layout
from inside the innermost loop; baking every tile up front lets the matmul
read them in place with no copy per tile.

The test quantizes weights on the host with the QS4CX algorithm, feeds a
fixed uint8 activation and requires the int32 accumulator to match a plain
C integer matmul bit for bit. Integer arithmetic is deterministic, so any
layout or wiring error shows up here rather than being absorbed into a
tolerance later.

The test also dumps the baked WH tile, which is the only record we have of
that layout -- HexKL does not document it.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Quantize and dequantize activations on the DSP</summary><br />

[htp] Quantize and dequantize activations on the DSP

Add per-row asymmetric uint8 dynamic quantization and write the result
straight into the HMX activation layout. Eight-bit activation tiles are
flat row-major inside a tile, so no separate layout pass is needed and the
kernel can target VTCM directly instead of going through HexKL's
copy_submatrix helper, which its own header marks as debug-only.

Also add hvx_convert.h. HVX has no numeric conversion between int32 and
f32 -- Q6_Vw_equals_Vsf and friends only reinterpret bits, and the vcvt
family does not cover sf<->w -- so both directions go through a
magic-number identity that is exact for |x| <= 2^22. Our accumulators are
bounded by 255 * 8 * K, leaving about 2x margin at K=1024.

The quantization implementation is scalar initially; vectorization comes
next and is gated on this same test staying green.

Rounding is nearest-even on both sides. The host reference uses nearbyint
rather than round because HVX's float add rounds that way and the two
disagree at exact .5. Weight quantization keeps round, since it runs only
on the host.

Scalar K3 (int32 acc -> f32 dequant) completes the A8W4 accuracy
pipeline: S1/S2/S3 all pass. Vectorize K1 (row min/max reduction),
K2 (per-row uint8 quantization), and K3 (i32 -> f32 dequant) on HVX.
K3 uses Q6_Vsf_equals_Vw for the int32 -> f32 lane conversion, matching
the production pattern in llama.cpp's ggml-hexagon backend; the
magic-number trick that K2 needed (bit reinterpret, not numeric
conversion) does not apply in the K3 direction.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Sisyphus <noreply@opencode.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Trim u8i4 harness and drop dead FastRPC endpoint</summary><br />

[test] Trim u8i4 harness and drop dead FastRPC endpoint

The per-task S1-S3 isolation tests and the HmxBringsUp smoke test
already proved out the individual pipeline stages; CheckShape's S1-S4
checks now cover the same ground end to end for every real workload
shape. Drop the now-redundant tests and the want_wh_dump debug dump
path so the suite only carries the four shapes that matter.

Drop the dead mm_u8i4_from_u8 FastRPC endpoint. Its only callers were
the unittest scaffolding removed above; mm_u8i4_from_f32 already exercises
the same weight-bake/HMX matmul path end to end, so the from_u8 entry point
and its WH-tile debug dump argument are unused now.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[chore] Fix doxygen comment</summary><br />

[chore] Fix doxygen comment

Convert two multi-line /* */ comments in the hvx_quant_u8.c to /** */ so the doxygen-cncpp checker does not flag them. Run clang-format-14 on both files.
No behavioral change.

Signed-off-by: dlwlzzero dlwlzzero@gmail.com
Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Tidy u8i4 harness: unify ROUND_UP and drop want_wh_dump</summary><br />

[test] Tidy u8i4 harness: unify ROUND_UP and drop want_wh_dump

Two unrelated cleanups in the u8i4 accuracy harness:

  * test/htp/nntr_hvx_mm_u8i4.c used a power-of-two-only bitmask
    ROUND_UP while hexkl_mm_u8i4.c used the division form. They
    agreed only because every alignment argument is a power of two
    today; switching the bitmask to the division form makes the two
    DSP sites identical and safe for any alignment value.

  * CheckShape still carried a want_wh_dump parameter after
    855569b6 removed the dump path it gated. Drop the parameter
    and its four literal call-site arguments.

No behavior change at the current call sites.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-authored-by: Sisyphus <noreply@anthropic.com>
Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Add FastRPC entries for the HVX softmax bring-up</summary><br />

[test] Add FastRPC entries for the HVX softmax bring-up

Open two IDL entries and wire the skel and the device test around them.
Both return zeroed output for now; the kernels land in the next commits.

exp gets its own entry rather than being checked through softmax alone.
softmax normalizes by the sum, so an error that moves every term the same
way cancels and never shows up in the output -- the polynomial's real
accuracy is only visible when exp is probed directly.

exp_f32 requires a length that is a multiple of 32. hvx_exp_sf is a
whole-vector operation and this entry is a test probe, so handling a tail
here would be code with no consumer.

The EBADPARM assertions add kDspOffset (0x80000400) before comparing:
AEEStdErr.h bakes that offset into every AEE_* code when __hexagon__ is
defined, so a DSP-side skel function returning AEE_EBADPARM crosses the
FastRPC boundary as 0x8000040e, not the host's plain 14.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Add a vector exp for f32 lanes on HVX</summary><br />

[htp] Add a vector exp for f32 lanes on HVX

exp(x) = 2^k * exp(r): k goes into the exponent field via a single bit
add, so the polynomial only has to cover r, which round-to-nearest
reduction narrows to [-ln2/2, ln2/2] -- half the floor-based range,
letting a 7th-order polynomial reach f32 epsilon.

Both the range reduction and the polynomial's Horner recurrence run in
qf32 rather than plain Vsf. On real HVX hardware (not reproducible in a
host-side float32 simulation), chained plain-Vsf multiply-adds lose
precision that qf32 retains; on-device testing on the S25 Ultra showed
this costing up to 1.68e-4 worst-case relative error before the fix,
against a 1e-6 target.

ln2 is split into ln2_hi + ln2_lo (the standard Cephes/fdlibm/SLEEF/glibc
technique) because a single f32 constant does not carry enough mantissa
bits once |k| is large -- the rounding error in ln2 gets multiplied by k,
and no amount of qf32 arithmetic downstream can recover precision that
was never in the input. ln2_hi's trailing zero mantissa bits make k*ln2_hi
exact in f32 over the whole k range this domain uses.

The low clamp at -120 is not cosmetic. hvx_sf_to_w_rne is only exact for
|v| <= 2^22, and softmax feeds x - max, which can be -1e30; without the
clamp k comes out as garbage and the underflow guard can be fooled into
letting it through.

No overflow clamp. softmax feeds x - max <= 0, so above the top of the
range is unreachable; clamping it would spend instructions per vector on
a path that cannot be taken. The header states the domain instead.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Add a row-wise f32 softmax on HVX with tail handling</summary><br />

[htp] Add a row-wise f32 softmax on HVX with tail handling

Three passes per row: max, then exp with the sum accumulated alongside
in qf32, then normalize. The exp results go straight into the output
buffer and pass three scales them in place, so there is no scratch
buffer -- no VTCM reservation, no per-thread scratch offsets. Reading a
vector before writing the same index also makes an in-place call safe.

Row lengths that are not a multiple of 32 go through the same vector
path via an aligned stack buffer (load_tail_sf / store_tail_sf). Reading
a vector straight off the row end would run up to 124 bytes past the
buffer; staging through the stack also keeps whatever follows the row
out of the max and the sum. The tail's pad lanes hold exp(0 - max), not
zero, so they are masked off after exp with Q6_Q_vsetq2_R before
reaching the sum.

1/sum is a scalar divide. sum ends up replicated across every lane, so a
vector reciprocal with a Newton iteration would be more code for a less
exact answer. The maximum is taken over the scaled values rather than as
scale*max(x); a negative scale flips which element is the maximum.

The shift-invariance test uses 1e2 rather than 1e4: a 1e4 shift rounds
f32 inputs to ULP ~0.001 on the host before the DSP sees them, and no
kernel can recover those lost bits. exp(100) still overflows f32, so the
max subtraction the test exists to check is still required.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: GLM 5.2 <noreply@z.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Cover multi-row, in-place, negative scale and row ranges for softmax</summary><br />

[test] Cover multi-row, in-place, negative scale and row ranges for softmax

Four properties of hvx_softmax_rows_f32 that the single-row tests could
not see: rows stay independent, an in-place call gives the same answer as
an out-of-place one, a negative scale still picks the right maximum, and
a row range leaves the rows outside it alone.

The row range is the one that needed new surface: softmax_f32 now takes
m_first, so the range API that a worker pool will split on is exercised
rather than only ever called as (0, M).

The LeavesRowsBeforeTheRangeAlone test compares the range call's output
rows against a full (0, M) call's, rather than checking the untouched
rows' values directly. FastRPC zeroes the rout buffer before sending it
to the DSP, so the untouched rows come back 0 regardless of whether the
kernel wrote them -- observing them would need an in-place (inrout) IDL
entry, which is not worth widening the test surface for.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: GLM 5.2 <noreply@z.ai>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[HTP] Add a dmlink user-DMA ring for weight staging</summary><br />

[HTP] Add a dmlink user-DMA ring for weight staging

Queues 2D transfers onto the single DMA engine by chaining descriptors
with dmlink, so a weight stream and the output write-back share one engine
and drain during compute instead of blocking on dmstart each.

Ported unchanged in behaviour from the doc13 measurement bench, which took
it from llama.cpp ggml-hexagon's dma-queue. Kept dtype-agnostic so the
u8i8 path can share it.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[HTP] Bake u8i4 weights once and prefetch across a layer</summary><br />

[HTP] Bake u8i4 weights once and prefetch across a layer

hexkl_mm_u8i4 bakes the weight to WH layout on every matmul, ~72 us per
call by doc15 §3, and runs one matmul per call so there is nothing to
overlap the DMA with. This adds a registry that bakes once and keeps the
WH bytes resident, plus a run that takes several weights sharing one
activation (Q/K/V, gate/up) and streams the next weight into VTCM while
the current one computes.

Weights stay in DSP heap, not VTCM: only the two being double-buffered
need to be resident, so total weight bytes are not capped by the arena.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[HTP] Hold HMX for the session and add the u8i4 layer endpoint</summary><br />

[HTP] Hold HMX for the session and add the u8i4 layer endpoint

nntr_hvx_open now does hw_init, takes the HMX lock and runs
setup_acc_read_int32 once for the session; close releases it and any
weights still registered. mm_u8i4_from_f32 reaches all three through the
handle instead of repeating the preamble per invoke.

mm_u8i4_layer is the performance entry point: handles in, f32 out, none
of the four rout buffers the accuracy harness returns. That harness keeps
its endpoint unchanged so unittest_hvx_mm_u8i4 still checks every stage.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Cover the u8i4 layer endpoint</summary><br />

[test] Cover the u8i4 layer endpoint

Reuses HmxMmU8I4's quantize/dequant helpers as the reference rather than
duplicating them: the layer endpoint's job is to match what calling the
accuracy endpoint once per weight would produce, so that is what these
compare against.

Covers: several weights against one shared activation matching the
per-weight reference, a registered weight surviving repeated calls
bit-for-bit, a released handle rejected and its slot reused, a
mismatched-K handle rejected, and a printed (not asserted) per-call
cost comparison against the accuracy harness -- thermal state moves the
numbers between runs, so a threshold here would encode lab conditions
rather than a property of the code.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Add an end-to-end device runner for the u8i4 layer endpoint</summary><br />

[test] Add an end-to-end device runner for the u8i4 layer endpoint

Builds the DSP skel, libnntrainer.so, and the ARM gtest, pushes all three
plus libc++_shared to the device, and runs unittest_hvx_mm_u8i4.

Verified on R3CY10WM83Y: all 9 tests pass, including the 4 existing
accuracy-harness shapes (the session-scoping refactor did not change their
result) and the 5 new layer-endpoint tests. Reported (not asserted)
speedup_vs_harness came out at 3.31x, above doc13 §3a's 1.7-2x -- that
number was DSP-only with no FastRPC in the timed region, this one is
end-to-end, so the session-scoped HMX and dropped debug buffers add on
top of the DMA/prefetch win doc13 measured in isolation.

Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Take the session handle in the softmax entries</summary><br />

[htp] Take the session handle in the softmax entries

Every other entry in this skel treats remote_handle64 as the
nntr_hvx_session that nntr_hvx_open now allocates, and rejects a null one.
The two softmax entries were still discarding it, so the meaning of the
handle differed per entry within one skel. Softmax needs neither the VTCM
arena nor the HMX lock, so it takes the session without reading any field
-- what is being matched is the calling convention, not the resource use.

Also logs the parameter-validation failures the way nntr_hvx_mm_u8i4.c
does. A bare AEE_EBADPARM coming back over FastRPC says nothing about
which length was wrong.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[htp] Check for HVX once per session instead of per call</summary><br />

[htp] Check for HVX once per session instead of per call

The HVX unit count does not change while a session is open, so it belongs
with hw_init and the HMX lock in nntr_hvx_open rather than being
re-read by add_f32 and by both softmax entries on every invoke. Three
copies of the same shift-and-mask become one.

This moves where the failure surfaces: on a DSP without HVX, open now
fails with AEE_EUNSUPPORTED instead of succeeding and letting each call
fail. Every entry in this skel uses HVX, so a session that cannot use it
has nothing to offer. Not observable on V79, where the units are always
there.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>


<details><summary>[test] Unify LANES and put the softmax IDL comments in English</summary><br />

[test] Unify LANES and put the softmax IDL comments in English

Merging the softmax and u8i4 lines brought back the kind of drift
f869d3a0 already cleaned up once. LANES was spelled three ways across
three files -- all of them 32, but with signedness that differed enough
to need casts at the use sites.

The softmax IDL entries were the only Korean comments in a file that is
otherwise English, and this one is headed upstream.

No behaviour change.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>

</details>

### Summary

- Bring up a Hexagon CDSP skel (v79, HVX) reachable from nntrainer's HTP backend over FastRPC: one-method IDL + `build.sh` (qaic + hexagon-clang), verified end to end with an HVX vector-add kernel before anything else is added.
- Add a u8i4 (A8W4) HMX matmul path: DSP-side dynamic activation quantization, a one-shot weight bake to HMX's WH layout, a weight registry so repeated calls skip the bake, a user-DMA ring that prefetches the next weight while the current one computes, and a layer endpoint that batches several weights sharing one activation (Q/K/V, gate/up). HMX init and the HMX lock move into `nntr_hvx_open` and live for the session instead of being reacquired per call.
- Add an f32 softmax path on HVX: a vector `exp` exposed as its own FastRPC entry (so its accuracy is visible independently of sum-normalization masking it) and a row-wise softmax with tail handling for row lengths that aren't a multiple of a vector. Both entries take the session handle and reject a null one, matching the calling convention every other entry in the skel already uses; the HVX-availability check that used to run per call now runs once in `nntr_hvx_open`.
- Verified on device (Snapdragon 8 Elite, S25 Ultra, V79, unsigned-PD CDSP session): `unittest_hvx_add` all pass, `unittest_hvx_mm_u8i4` 9/9, `unittest_hvx_softmax` 15/15, no regressions across the branch.

Signed-off-by: dlwlzzero <dlwlzzero@gmail.com>
