### PR TITLE
fix(causallm): rebase model_file_name/binary_config_path onto model dir

### DIFF
--- a/Applications/CausalLM/main.cpp
+++ b/Applications/CausalLM/main.cpp
@@ -352,6 +352,9 @@ int main(int argc, char *argv[]) {
     resolveNntrConfigPath(nntr_cfg, "tokenizer_file", model_path);
     resolveNntrConfigPath(nntr_cfg, "embedding_file_name", model_path);
     resolveNntrConfigPath(nntr_cfg, "ple_file_name", model_path);
+    resolveNntrConfigPath(nntr_cfg, "model_file_name", model_path);
+    resolveNntrConfigPath(nntr_cfg, "binary_config_path", model_path);
+    resolveNntrConfigPath(nntr_cfg, "image_newline_path", model_path);
 
     if (nntr_cfg.contains("system_prompt")) {
       system_head_prompt =
@@ -360,9 +363,9 @@ int main(int argc, char *argv[]) {
         nntr_cfg["system_prompt"]["tail_prompt"].get<std::string>();
     }
 
-    // Construct weight file path
+    // Construct weight file path (already rebased onto model_path above)
     const std::string weight_file =
-      model_path + "/" + nntr_cfg["model_file_name"].get<std::string>();
+      nntr_cfg["model_file_name"].get<std::string>();
 
     std::cout << weight_file << std::endl;
 


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR


<details><summary>c20752ae fix(causallm): rebase model_file_name/binary_config_path onto model dir</summary><br />

main.cpp only rebased tokenizer_file/embedding_file_name/ple_file_name onto
the model directory, leaving model_file_name and binary_config_path as bare
relative filenames in nntr_cfg. Quick_Dot_AI_QNN::setupParameters() then
tried to rebase binary_config_path relative to model_file_name's dirname,
which was empty (no '/'), so the path was resolved against the process CWD
instead of the model directory and failed to open (e.g. running
nntr_causallm/run_causallm.sh on a QNN model like gemma4-e2b directly by
path, as opposed to through the API's catalog path which already rebased
both keys onto abs_model_dir).

Rebase model_file_name, binary_config_path, and image_newline_path the same
way the other keys already are, and simplify the weight_file construction
to use the now-rebased model_file_name directly.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jayden0701 <jrock.oh@samsung.com>

</details>

### Summary

- Fix path resolution for `model_file_name`, `binary_config_path`, and `image_newline_path` in `Applications/CausalLM/main.cpp`.
- Previously only `tokenizer_file`, `embedding_file_name`, and `ple_file_name` were rebased onto the model directory, while `model_file_name` and `binary_config_path` were left as bare relative filenames. This caused `Quick_Dot_AI_QNN::setupParameters()` to resolve `binary_config_path` against the process CWD (since `model_file_name` had no `/` and thus an empty dirname), leading to a file-open failure when running a QNN model (e.g. gemma4-e2b) directly by path via `run_causallm.sh`.
- Rebase the three remaining keys onto the model directory using the existing `resolveNntrConfigPath()` helper, consistent with the other keys, and simplify the `weight_file` construction to use the now-fully-resolved `model_file_name` directly.
