### PR TITLE
[CausalLM] Enforce Qwen3 CachedSlim expert cache limit

### DIFF
--- a/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
+++ b/Applications/CausalLM/models/qwen3_cached_slim_moe/qwen_moe_layer_cached.cpp
@@ -40,6 +40,7 @@ using std::chrono::nanoseconds;
 namespace causallm {
 
 static constexpr size_t SINGLE_INOUT_IDX = 0;
+static constexpr size_t EXPERT_CACHE_CAPACITY = 32;
 
 CachedSlimMoELayer::CachedSlimMoELayer() :
   LayerImpl(),
@@ -371,6 +372,26 @@ void CachedSlimMoELayer::incremental_forwarding(
         t1_miss = high_resolution_clock::now();
 #endif
 
+        int eviction_target = -1;
+        {
+          std::lock_guard<std::mutex> lock(cache_mutex);
+          if (loaded_expert_deque.size() >= EXPERT_CACHE_CAPACITY) {
+            eviction_target = loaded_expert_deque.front();
+            loaded_expert_deque.pop_front();
+            iteration_map.erase(eviction_target);
+            need_load[eviction_target] = true;
+          }
+        }
+
+        if (eviction_target >= 0) {
+          context.getWeight(expert_gate_proj_indices[eviction_target])
+            .deactivate();
+          context.getWeight(expert_up_proj_indices[eviction_target])
+            .deactivate();
+          context.getWeight(expert_down_proj_indices[eviction_target])
+            .deactivate();
+        }
+
         context.getWeight(expert_gate_proj_indices[expert_idx]).activate();
         context.getWeight(expert_up_proj_indices[expert_idx]).activate();
         context.getWeight(expert_down_proj_indices[expert_idx]).activate();
@@ -427,7 +448,7 @@ void CachedSlimMoELayer::incremental_forwarding(
 
     // Evict experts
     /// @todo apply multi thread loop
-    while (loaded_expert_deque.size() > 32) {
+    while (loaded_expert_deque.size() > EXPERT_CACHE_CAPACITY) {
       int target_idx;
       {
         std::lock_guard<std::mutex> lock(cache_mutex);


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR

<details><summary>[CausalLM] Enforce Qwen3 CachedSlim expert cache limit</summary><br />

[CausalLM] Enforce Qwen3 CachedSlim expert cache limit

Evict the least-recently-used expert before activating a cache miss so prefill never grows the mapped expert cache beyond 32 entries.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

### Summary

- Enforce the 32-entry Qwen3 CachedSlim expert cache limit before activating a cache miss.
- Unmap the least-recently-used expert first to reduce peak mapped memory during prefill.
- Reduce peak memory by 150 MB.

### Qwen3-30BA3B x86 Result
```
### Before
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 6027 ms, 72.5071 TPS
generation: 401 tokens, 22698 ms, 17.6668 TPS
total: 28727 ms
peak memory: **5464628** KB
==========================================================
[e2e time]: 29349 ms 
Max Resident Set Size: 5464628 KB
```

```
### After
=================[ LLM with NNTrainer ]===================
prefill: 437 tokens, 5996 ms, 72.8819 TPS
generation: 401 tokens, 22696 ms, 17.6683 TPS
total: 28695 ms
peak memory: **5309212** KB
==========================================================
[e2e time]: 29324 ms 
Max Resident Set Size: 5309212 KB
```
Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>