### PR TITLE
[Wait for#4244][HTP] Optimize the quant/dequant path with async output copy, vectorized quant, and a worker pool

### DIFF
--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_dma_ring.c
+ * @date   06 Aug 2026
+ * @brief  Minimal dmlink user-DMA ring for cross-matmul weight prefetch
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Ported from the doc13 §3a measurement bench's ring_push2d/ring_drain,
+ * itself lifted from llama.cpp ggml-hexagon's dma-queue.{c,h}. Behaviour is
+ * unchanged; only the names are de-abbreviated and the file stands alone so
+ * both the u8i4 and (later) u8i8 matmul modules can share one ring.
+ */
+
+#include "hexkl_dma_ring.h"
+
+#include <hexagon_protos.h>
+#include <hexagon_types.h>
+#include <hmx_hexagon_protos.h>
+#include <string.h>
+
+/** @brief One 2D DMA descriptor. Hardware-defined layout; do not reorder. */
+typedef struct __attribute__((aligned(128))) hexkl_dma_desc2d_s {
+  void *next;
+  uint32_t dst_stride : 24;
+  uint32_t desc_size : 2;
+  uint32_t dst_comp : 1;
+  uint32_t src_comp : 1;
+  uint32_t dst_bypass : 1;
+  uint32_t src_bypass : 1;
+  uint32_t order : 1;
+  uint32_t done : 1;
+  void *src;
+  void *dst;
+  uint32_t desc_type : 8;
+  uint32_t reserved0 : 24;
+  uint32_t row_size : 24;
+  uint32_t nrows_lo : 8;
+  uint32_t nrows_hi : 8;
+  uint32_t src_stride : 24;
+  uint32_t offset : 24;
+  uint32_t reserved1 : 8;
+} hexkl_dma_desc2d;
+
+static inline void hexkl_dma_link(void *cur, void *next) {
+  asm volatile(" release(%0):at" : : "r"(next));
+  asm volatile(" dmlink(%0, %1)" : : "r"(cur), "r"(next));
+}
+
+static inline void hexkl_dma_start(void *p) {
+  asm volatile(" release(%0):at" : : "r"(p));
+  asm volatile(" dmstart(%0)" : : "r"(p));
+}
+
+/** @brief Power of two, comfortably above the pushes any one call issues,
+ *         so a call's transfers never wrap into ones still in flight. */
+#define HEXKL_DMA_RING_N 256u
+
+static hexkl_dma_desc2d g_ring[HEXKL_DMA_RING_N] __attribute__((aligned(128)));
+static uint32_t g_push, g_pop;
+static hexkl_dma_desc2d *g_tail;
+static int g_started;
+
+static void hexkl_dma_ring_wait_idx(uint32_t i) {
+  long guard = 0;
+  while (!g_ring[i].done && guard++ < 50000000L) {
+    unsigned r = 0;
+    asm volatile(" %0 = dmpoll" : "=r"(r) : : "memory");
+    (void)r;
+  }
+}
+
+void hexkl_dma_ring_reset(void) {
+  memset(g_ring, 0, sizeof(g_ring));
+  g_push = 0;
+  g_pop = 0;
+  g_tail = &g_ring[HEXKL_DMA_RING_N - 1];
+  g_started = 0;
+}
+
+void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
+                          uint32_t src_stride, uint32_t row_size,
+                          uint32_t nrows, int src_vtcm, int dst_vtcm) {
+  if (((g_push + 1) & (HEXKL_DMA_RING_N - 1)) == g_pop) {
+    // Ring full: the oldest transfer must have already finished by the time
+    // we have wrapped this far around, so reclaiming it is a formality, not
+    // a stall -- but wait for `done` explicitly rather than assume it.
+    hexkl_dma_ring_wait_idx(g_pop);
+    g_pop = (g_pop + 1) & (HEXKL_DMA_RING_N - 1);
+  }
+  hexkl_dma_desc2d *d = &g_ring[g_push];
+  d->next = 0;
+  d->desc_size = 1;
+  d->desc_type = 9;
+  d->src_comp = 0;
+  d->dst_comp = 0;
+  d->src_bypass = src_vtcm ? 1 : 0;
+  d->dst_bypass = dst_vtcm ? 1 : 0;
+  d->order = 0;
+  d->done = 0;
+  d->reserved0 = 0;
+  d->reserved1 = 0;
+  d->offset = 0;
+  d->src = (void *)src;
+  d->dst = dst;
+  d->src_stride = src_stride;
+  d->dst_stride = dst_stride;
+  d->row_size = row_size;
+  d->nrows_lo = nrows & 0xffu;
+  d->nrows_hi = (nrows >> 8) & 0xffu;
+  Q6_dccleaninva_A((void *)d); // push the descriptor to memory for the DMA engine
+  if (!g_started) {
+    hexkl_dma_start(d);
+    g_started = 1;
+  } else {
+    hexkl_dma_link(g_tail, d);
+  }
+  g_tail = d;
+  g_push = (g_push + 1) & (HEXKL_DMA_RING_N - 1);
+}
+
+void hexkl_dma_ring_drain(void) {
+  while (g_pop != g_push) {
+    hexkl_dma_ring_wait_idx(g_pop);
+    g_pop = (g_pop + 1) & (HEXKL_DMA_RING_N - 1);
+  }
+  g_started = 0; // engine idle after drain -- the next push must dmstart
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
@@ -9,7 +9,7 @@
  * @author SeungHui Lee <shsh1004.lee@samsung.com>
  * @bug    No known bugs except for NYI items
  *
- * Ported from the doc13 §3a measurement bench's ring_push2d/ring_drain,
+ * Ported from the measurement bench's ring_push2d/ring_drain,
  * itself lifted from llama.cpp ggml-hexagon's dma-queue.{c,h}. Behaviour is
  * unchanged; only the names are de-abbreviated and the file stands alone so
  * both the u8i4 and (later) u8i8 matmul modules can share one ring.

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.c
@@ -82,8 +82,8 @@ void hexkl_dma_ring_reset(void) {
 }
 
 void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
-                          uint32_t src_stride, uint32_t row_size,
-                          uint32_t nrows, int src_vtcm, int dst_vtcm) {
+                           uint32_t src_stride, uint32_t row_size,
+                           uint32_t nrows, int src_vtcm, int dst_vtcm) {
   if (((g_push + 1) & (HEXKL_DMA_RING_N - 1)) == g_pop) {
     // Ring full: the oldest transfer must have already finished by the time
     // we have wrapped this far around, so reclaiming it is a formality, not
@@ -111,7 +111,8 @@ void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
   d->row_size = row_size;
   d->nrows_lo = nrows & 0xffu;
   d->nrows_hi = (nrows >> 8) & 0xffu;
-  Q6_dccleaninva_A((void *)d); // push the descriptor to memory for the DMA engine
+  Q6_dccleaninva_A(
+    (void *)d); // push the descriptor to memory for the DMA engine
   if (!g_started) {
     hexkl_dma_start(d);
     g_started = 1;

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
@@ -33,8 +33,8 @@ void hexkl_dma_ring_reset(void);
  * @param dst_vtcm  nonzero if @a dst is in VTCM (bypasses L2)
  */
 void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
-                          uint32_t src_stride, uint32_t row_size,
-                          uint32_t nrows, int src_vtcm, int dst_vtcm);
+                           uint32_t src_stride, uint32_t row_size,
+                           uint32_t nrows, int src_vtcm, int dst_vtcm);
 
 /** @brief Blocks until every queued transfer has completed. */
 void hexkl_dma_ring_drain(void);

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_dma_ring.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_dma_ring.h
+ * @date   06 Aug 2026
+ * @brief  Minimal dmlink user-DMA ring for cross-matmul weight prefetch
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HEXKL_DMA_RING_H__
+#define __NNTRAINER_HEXKL_DMA_RING_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Resets the ring to empty.
+ *
+ * Call once per logical group of transfers (here: once per mm_u8i4_layer
+ * call), not once per transfer -- hexkl_dma_ring_push2d's own wraparound
+ * handling is what keeps a long-running ring correct across many pushes.
+ */
+void hexkl_dma_ring_reset(void);
+
+/**
+ * @brief Queues one 2D transfer; starts the DMA engine if idle, otherwise
+ *        chains onto the in-flight descriptor via dmlink so many transfers
+ *        run on the single DMA engine without a second dmstart.
+ *
+ * @param src_vtcm  nonzero if @a src is in VTCM (bypasses L2)
+ * @param dst_vtcm  nonzero if @a dst is in VTCM (bypasses L2)
+ */
+void hexkl_dma_ring_push2d(void *dst, const void *src, uint32_t dst_stride,
+                          uint32_t src_stride, uint32_t row_size,
+                          uint32_t nrows, int src_vtcm, int dst_vtcm);
+
+/** @brief Blocks until every queued transfer has completed. */
+void hexkl_dma_ring_drain(void);
+
+#endif /* __NNTRAINER_HEXKL_DMA_RING_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_hmx_geom.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_hmx_geom.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_hmx_geom.h
+ * @date   11 Aug 2026
+ * @brief  HMX tile geometry derived from HexKL's block macros
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Every file that lays bytes out for the HMX ports needs the same handful of
+ * tile sizes. They were previously spelled out as literals in three places --
+ * hexkl_mm_u8i4.c, hexkl_mm_u8i4_dma.c and hvx_quant_u8.c -- which agreed
+ * only by inspection. The quantizer writes activation tiles at one stride
+ * and the matmul reads them at another, so a divergence there is silent
+ * wrong data rather than a build failure.
+ *
+ * Deriving them from HEXKL_HMX_* instead means HexKL's own header is the
+ * single source, and the static assertions below fail the build if a future
+ * SDK changes a block size out from under an assumption in this tree.
+ */
+
+#ifndef __NNTRAINER_HEXKL_HMX_GEOM_H__
+#define __NNTRAINER_HEXKL_HMX_GEOM_H__
+
+#include "hexkl_micro.h"
+
+/** @brief Rounds @a v up to a multiple of @a a. Division form, not a
+ *         power-of-two bitmask, so it is correct for any alignment. */
+#define HEXKL_ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Rows in one HMX tile (activation and accumulator). */
+#define HEXKL_TILE_ROW ((uint32_t)HEXKL_HMX_INT8_BLOCK_N_ROW)
+/** @brief Reduction depth of one HMX tile. */
+#define HEXKL_TILE_INNER ((uint32_t)HEXKL_HMX_INT8_BLOCK_N_INNER)
+/** @brief Columns in one HMX tile. */
+#define HEXKL_TILE_COL ((uint32_t)HEXKL_HMX_INT8_BLOCK_N_COL)
+
+/** @brief Bytes in one uint8 activation tile: one byte per value. */
+#define HEXKL_ACT_TILE_BYTES (HEXKL_TILE_ROW * HEXKL_TILE_INNER)
+/** @brief Bytes in one packed int4 weight tile: two values per byte. */
+#define HEXKL_WEIGHT_TILE_BYTES_I4 (HEXKL_TILE_INNER * HEXKL_TILE_COL / 2u)
+/** @brief Bytes in one int32 accumulator tile. */
+#define HEXKL_ACC_TILE_BYTES (HEXKL_TILE_ROW * HEXKL_TILE_COL * 4u)
+
+/** The activation port reads tiles at the alignment HexKL publishes, so a
+    tile that is not exactly that many bytes would make the quantizer's
+    stride and the matmul's disagree. */
+_Static_assert(HEXKL_ACT_TILE_BYTES == HEXKL_HMX_ACTIVATION_ALIGNMENT,
+               "activation tile size must equal the activation alignment");
+_Static_assert(HEXKL_ACT_TILE_BYTES == 2048u, "HMX activation tile is 64x32");
+_Static_assert(HEXKL_WEIGHT_TILE_BYTES_I4 == 512u, "i4 weight tile is 32x32/2");
+_Static_assert(HEXKL_ACC_TILE_BYTES == 8192u,
+               "int32 accumulator tile is 64x32");
+
+#endif /* __NNTRAINER_HEXKL_HMX_GEOM_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hexkl_mm_u8i4.c
+ * @date   03 Aug 2026
+ * @brief  VTCM layout and HMX orchestration for the A8W4 matmul
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <AEEStdErr.h>
+
+#include "hexkl_micro.h"
+
+#include "hexkl_mm_u8i4.h"
+
+#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Bytes in one packed i4 weight tile (32x32 values). */
+#define WEIGHT_TILE_BYTES 512u
+/** @brief Bytes in one int32 accumulator tile (64x32 values). */
+#define ACC_TILE_BYTES 8192u
+
+int hexkl_mm_u8i4_plan(uint8_t *vtcm_base, uint32_t vtcm_size, uint32_t m_pad,
+                       uint32_t k, uint32_t n, hexkl_mm_u8i4_layout *out) {
+  if (!vtcm_base || !out || k == 0 || n == 0 || m_pad == 0) {
+    return AEE_EBADPARM;
+  }
+  if ((k % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0 ||
+      (n % HEXKL_HMX_INT8_BLOCK_N_COL) != 0 ||
+      (m_pad % HEXKL_HMX_INT8_BLOCK_N_ROW) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+
+  out->vtcm_base = vtcm_base;
+  out->vtcm_size = vtcm_size;
+
+  out->w_base = 0u;
+  out->w_size = n_ktiles * n_ntiles * WEIGHT_TILE_BYTES;
+
+  // Activation tiles must sit on HEXKL_HMX_ACTIVATION_ALIGNMENT, and each
+  // tile is exactly that many bytes, so aligning the base is enough.
+  out->act_base = ROUND_UP_U32(out->w_size, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  out->act_size = n_rblocks * n_ktiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+
+  out->result_off = out->act_base + out->act_size;
+
+  // Put the config region at the top of the arena, rounded down to its
+  // alignment so the rounding can never eat into the result region.
+  if (vtcm_size < hexkl_micro_hmx_config_size()) {
+    return AEE_ENOMEMORY;
+  }
+  out->config_off = (vtcm_size - hexkl_micro_hmx_config_size()) &
+                    ~(HEXKL_HMX_CONFIG_ALIGNMENT - 1u);
+
+  if (out->result_off + ACC_TILE_BYTES > out->config_off) {
+    return AEE_ENOMEMORY;
+  }
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_bake_weights(const hexkl_mm_u8i4_layout *L,
+                               const int8_t *w_i4_rm, uint32_t k, uint32_t n) {
+  if (!L || !w_i4_rm) {
+    return AEE_EBADPARM;
+  }
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+
+  for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+    for (uint32_t nt = 0; nt < n_ntiles; ++nt) {
+      const uint32_t off = L->w_base + (kt * n_ntiles + nt) * WEIGHT_TILE_BYTES;
+      int res =
+        hexkl_micro_hmx_rm_to_wh_i4(L->vtcm_base, off, w_i4_rm, kt, nt, n);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_run(const hexkl_mm_u8i4_layout *L, uint32_t m_pad, uint32_t k,
+                      uint32_t n, int32_t *acc_i32) {
+  if (!L || !acc_i32) {
+    return AEE_EBADPARM;
+  }
+  const uint32_t n_ktiles = k / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_ntiles = n / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+
+  for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
+    for (uint32_t nt = 0; nt < n_ntiles; ++nt) {
+      hexkl_micro_hmx_acc_clear_int32();
+
+      for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+        const uint32_t act_off =
+          L->act_base + (rb * n_ktiles + kt) * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+        const uint32_t w_off =
+          L->w_base + (kt * n_ntiles + nt) * WEIGHT_TILE_BYTES;
+        int res = hexkl_micro_hmx_mm_u8i4(L->vtcm_base, act_off, w_off);
+        if (res != AEE_SUCCESS) {
+          return res;
+        }
+      }
+
+      int res = hexkl_micro_hmx_acc_read_int32(L->vtcm_base, L->config_off,
+                                               L->result_off);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+      // Going through copy_32b_to_submatrix keeps us off the accumulator's
+      // shuffled layout, which HexKL does not document.
+      res = hexkl_micro_hmx_copy_32b_to_submatrix(L->vtcm_base, L->result_off,
+                                                  acc_i32, rb, nt, m_pad, n);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+  return AEE_SUCCESS;
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.c
@@ -12,16 +12,14 @@
 
 #include <AEEStdErr.h>
 
+#include "hexkl_hmx_geom.h"
 #include "hexkl_micro.h"
 
 #include "hexkl_mm_u8i4.h"
 
-#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
-
-/** @brief Bytes in one packed i4 weight tile (32x32 values). */
-#define WEIGHT_TILE_BYTES 512u
-/** @brief Bytes in one int32 accumulator tile (64x32 values). */
-#define ACC_TILE_BYTES 8192u
+#define WEIGHT_TILE_BYTES HEXKL_WEIGHT_TILE_BYTES_I4
+#define ACC_TILE_BYTES HEXKL_ACC_TILE_BYTES
+#define ROUND_UP_U32(v, a) HEXKL_ROUND_UP_U32(v, a)
 
 int hexkl_mm_u8i4_plan(uint8_t *vtcm_base, uint32_t vtcm_size, uint32_t m_pad,
                        uint32_t k, uint32_t n, hexkl_mm_u8i4_layout *out) {

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hexkl_mm_u8i4.h
+ * @date   03 Aug 2026
+ * @brief  VTCM layout and HMX orchestration for the A8W4 matmul
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HEXKL_MM_U8I4_H__
+#define __NNTRAINER_HEXKL_MM_U8I4_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Where each region lives inside the VTCM arena.
+ *
+ * Byte offsets from @a vtcm_base, not pointers, because that is what the
+ * HexKL micro API takes.
+ */
+typedef struct {
+  uint8_t *vtcm_base;  /**< base of the VTCM arena from hexkl_micro_hw_init */
+  uint32_t vtcm_size;  /**< total arena size in bytes */
+  uint32_t w_base;     /**< all baked weight tiles, (K/32)*(N/32)*512 bytes */
+  uint32_t w_size;     /**< byte span of the weight region */
+  uint32_t act_base;   /**< activation AH tiles, m_pad*K bytes, 2048-aligned */
+  uint32_t act_size;   /**< byte span of the activation region */
+  uint32_t result_off; /**< 8192-byte accumulator readout, 2048-aligned */
+  uint32_t config_off; /**< HMX config region, 256-aligned */
+} hexkl_mm_u8i4_layout;
+
+/**
+ * @brief Computes the VTCM partitioning and checks it against the arena.
+ *
+ * Pure arithmetic apart from reading hexkl_micro_hmx_config_size(), so it
+ * is the one piece of this file that could be unit tested on the host.
+ *
+ * @return AEE_SUCCESS, AEE_EBADPARM on a shape violation, or
+ *         AEE_ENOMEMORY when the partitioning does not fit.
+ */
+int hexkl_mm_u8i4_plan(uint8_t *vtcm_base, uint32_t vtcm_size, uint32_t m_pad,
+                       uint32_t k, uint32_t n, hexkl_mm_u8i4_layout *out);
+
+/**
+ * @brief Converts every weight tile to WH layout once, into VTCM.
+ *
+ * HexKL's example calls rm_to_wh_i4 from the innermost matmul loop, which
+ * serializes the layout conversion against the multiply. Hoisting it here
+ * means the matmul reads the tiles in place with no copy at all.
+ *
+ * @param[in] w_i4_rm weights as int4 values in int8 containers, range
+ *                    [-8, 7], K rows by N columns, row-major
+ */
+int hexkl_mm_u8i4_bake_weights(const hexkl_mm_u8i4_layout *L,
+                               const int8_t *w_i4_rm, uint32_t k, uint32_t n);
+
+/**
+ * @brief Runs the HMX matmul over the baked weights and staged activation.
+ *
+ * Requires hexkl_micro_hmx_setup_acc_read_int32() to have been called for
+ * L->config_off, the HMX lock to be held, and the activation to already be
+ * in AH layout at L->act_base.
+ *
+ * @param[out] acc_i32 m_pad by n int32 accumulators, row-major, in DDR
+ */
+int hexkl_mm_u8i4_run(const hexkl_mm_u8i4_layout *L, uint32_t m_pad, uint32_t k,
+                      uint32_t n, int32_t *acc_i32);
+
+#endif /* __NNTRAINER_HEXKL_MM_U8I4_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -26,8 +26,9 @@
 #define ROUND_UP_U32(v, a) HEXKL_ROUND_UP_U32(v, a)
 #define WEIGHT_TILE_BYTES_U8I4 HEXKL_WEIGHT_TILE_BYTES_I4
 #define ACC_TILE_BYTES HEXKL_ACC_TILE_BYTES
-/** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
- *         this size have a documented hardware bug (doc13 §3a, §5). */
+/** @brief Largest single DMA row the engine will move correctly. Rows
+ *         above 256 KB hit a known hardware erratum, so a transfer is
+ *         chunked into rows at or below this size. */
 #define MAX_DMA_ROW_BYTES 262144u
 
 static uint32_t dma_row_size_dividing(uint32_t total_bytes) {
@@ -228,7 +229,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     const uint32_t wcur = wbuf[i & 1u];
 
     if (i + 1 < n_handles) {
-      // Cross-matmul prefetch (doc13 §3a): while handle i computes below,
+      // Cross-matmul prefetch: while handle i computes below,
       // stream handle i+1's weight into the OTHER buffer in the
       // background. One transfer, chunked under the >512KB-row DMA bug's
       // threshold, not one per tile.

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -135,16 +135,23 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     return AEE_EBADPARM;
   }
 
-  const uint32_t m_pad = ROUND_UP_U32(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
-  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
-  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
   if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0) {
     return AEE_EBADPARM;
   }
+  // config_off comes from the session rather than being computed here, so
+  // check it against the arena before deriving any offset from it.
+  if (config_off > vtcm_size) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t m_pad = ROUND_UP_U32(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
 
   // Validate every handle up front -- K must match, and this is also where
-  // the widest weight (for the double-buffer size) and the total output
-  // width (for out_cat bounds) come from.
+  // the widest weight comes from, which sizes both the VTCM double-buffer
+  // and the accumulator scratch. The caller checks out_cat's length against
+  // the sum of the handles' N; this loop only needs the maximum.
   uint32_t n_tiles_max = 0, n_max = 0;
   for (uint32_t i = 0; i < n_handles; ++i) {
     if (handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
@@ -176,11 +183,10 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   };
   const uint32_t result_off =
     ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  // config_off is at or below vtcm_size (checked above), so clearing it also
+  // clears the arena -- one bound, not two.
   if (result_off + ACC_TILE_BYTES > config_off) {
     return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
-  }
-  if (result_off + ACC_TILE_BYTES > vtcm_size) {
-    return AEE_ENOMEMORY;
   }
 
   // K1/K2: quantize the shared activation once, straight into its AH tiles

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -173,7 +173,13 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   }
 
   // VTCM layout: activation (all row-bands, shared across every handle) |
-  // weight double-buffer (sized for the widest handle) | one result tile.
+  // weight double-buffer (sized for the widest handle) | one result slot
+  // per (row-band, output-tile) pair, so that async-DMA-ing one tile out
+  // to DDR never has to be waited on before the next tile's acc_read can
+  // reuse its slot -- they simply don't share a slot within one handle.
+  // Slots ARE reused across handles: the ring is drained (see below)
+  // before a handle's dequant, which is also before the next handle's
+  // acc_read could touch them again.
   const uint32_t act_bytes =
     n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
   const uint32_t act_off = 0;
@@ -182,12 +188,13 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT),
     ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT) + wb_max,
   };
+  const uint32_t n_slots = n_tiles_max * n_rblocks;
   const uint32_t result_off =
     ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
   // config_off is at or below vtcm_size (checked above), so clearing it also
   // clears the arena -- one bound, not two.
-  if (result_off + ACC_TILE_BYTES > config_off) {
-    return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
+  if (result_off + (uint64_t)n_slots * ACC_TILE_BYTES > config_off) {
+    return AEE_ENOMEMORY; // the per-slot result tiles do not fit VTCM
   }
 
   // K1/K2: quantize the shared activation once, straight into its AH tiles
@@ -255,23 +262,35 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
             goto out;
           }
         }
-        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, result_off);
+        // This tile's own slot -- see the VTCM layout comment above for
+        // why (rb, nt) never collide with another in-flight tile.
+        const uint32_t slot_off =
+          result_off + (rb * n_tiles_max + nt) * ACC_TILE_BYTES;
+        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, slot_off);
         if (rc != AEE_SUCCESS) {
           goto out;
         }
-        rc = hexkl_micro_hmx_copy_32b_to_submatrix(
-          vtcm_base, result_off, acc_scratch, rb, nt, m_pad, h->N);
-        if (rc != AEE_SUCCESS) {
-          goto out;
-        }
+
+        // Async VTCM -> DDR write-back, queued onto the same ring as the
+        // weight prefetch below: replaces
+        // hexkl_micro_hmx_copy_32b_to_submatrix's scalar strided copy with
+        // a transfer that overlaps the NEXT tile's HMX+acc_read instead of
+        // blocking on it. Matches hexkl_micro_hmx_copy_32b_to_submatrix's
+        // own addressing exactly (tile (rb, nt) of an m_pad x h->N
+        // row-major matrix), just moved by DMA rather than a scalar loop.
+        int32_t *dst = acc_scratch + (size_t)rb * 64 * h->N + (size_t)nt * 32;
+        hexkl_dma_ring_push2d(dst, vtcm_base + slot_off, h->N * 4, 32 * 4,
+                              32 * 4, 64, /*src_vtcm=*/1, /*dst_vtcm=*/0);
       }
     }
 
-    // Block until handle i+1's weight has fully landed before moving on to
-    // it -- matches the measured bench's "next weight fully in wnxt before
-    // matmul i+1" invariant. Dequant below does not touch the DMA engine,
-    // so a later pass could move it ahead of this drain to overlap with
-    // the prefetch; left as-is for correctness first.
+    // Drains two things queued on this one ring: handle i+1's weight
+    // prefetch (must have fully landed before matmul i+1, matching the
+    // measured bench's invariant) and every output tile pushed above
+    // (must have landed before dequant below reads acc_scratch). Dequant
+    // does not touch the DMA engine, so a later pass could move it ahead
+    // of this drain to overlap with the next handle's weight prefetch;
+    // left as-is for correctness first.
     hexkl_dma_ring_drain();
 
     hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i4_dma.c
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i4 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include "hexkl_mm_u8i4_dma.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <AEEStdErr.h>
+
+#include "hexkl_dma_ring.h"
+#include "hexkl_micro.h"
+#include "hvx_dequant_i32.h"
+#include "hvx_quant_u8.h"
+
+#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Bytes in one packed i4 weight tile (32x32 values). Matches
+ *         hexkl_mm_u8i4.c's local definition -- both are file-scoped, so
+ *         this is not a redefinition, just the same constant kept in sync
+ *         by inspection. If HexKL ever exposes it from hexkl_micro.h, both
+ *         files should switch to that instead of this comment. */
+#define WEIGHT_TILE_BYTES_U8I4 512u
+/** @brief Bytes in one int32 accumulator tile (64x32 values). */
+#define ACC_TILE_BYTES 8192u
+/** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
+ *         this size have a documented hardware bug (doc13 §3a, §5). */
+#define MAX_DMA_ROW_BYTES 262144u
+
+static uint32_t dma_row_size_dividing(uint32_t total_bytes) {
+  uint32_t rs = MAX_DMA_ROW_BYTES;
+  while (rs > 1 && (total_bytes % rs) != 0) {
+    rs >>= 1;
+  }
+  return rs;
+}
+
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
+                               uint8_t *vtcm_base, uint32_t vtcm_size,
+                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
+                               const float *w_scale, const int32_t *colsum_w,
+                               const float *bias, uint32_t *out_handle) {
+  if (!tbl || !vtcm_base || !w_i4_rm || !w_scale || !colsum_w || !bias ||
+      !out_handle || K == 0 || N == 0) {
+    return AEE_EBADPARM;
+  }
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0 ||
+      (N % HEXKL_HMX_INT8_BLOCK_N_COL) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  uint32_t slot = HEXKL_MM_U8I4_MAX_WEIGHTS;
+  for (uint32_t i = 0; i < HEXKL_MM_U8I4_MAX_WEIGHTS; ++i) {
+    if (!tbl->slots[i].in_use) {
+      slot = i;
+      break;
+    }
+  }
+  if (slot == HEXKL_MM_U8I4_MAX_WEIGHTS) {
+    return AEE_ENOMEMORY;
+  }
+
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_tiles = N / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t wh_bytes = k_tiles * n_tiles * WEIGHT_TILE_BYTES_U8I4;
+  if (wh_bytes > vtcm_size) {
+    return AEE_ENOMEMORY; // weight alone does not fit the VTCM scratch arena
+  }
+
+  // Bake every tile into VTCM (borrowed as scratch -- caller holds the HMX
+  // lock and has no other VTCM use in flight), then copy the baked bytes
+  // out to DSP heap memory where they stay resident across calls. A plain
+  // copy, not the DMA ring: registration happens once per weight at model
+  // load, off the per-token hot path, so its cost is not what this file
+  // exists to optimise.
+  for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+    for (uint32_t nt = 0; nt < n_tiles; ++nt) {
+      const uint32_t off = (kt * n_tiles + nt) * WEIGHT_TILE_BYTES_U8I4;
+      int res =
+        hexkl_micro_hmx_rm_to_wh_i4(vtcm_base, off, w_i4_rm, kt, nt, N);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+
+  hexkl_weight_u8i4 *h = &tbl->slots[slot];
+  h->wh_bytes = (uint8_t *)malloc(wh_bytes);
+  h->w_scale = (float *)malloc(sizeof(float) * N);
+  h->colsum_w = (int32_t *)malloc(sizeof(int32_t) * N);
+  h->bias = (float *)malloc(sizeof(float) * N);
+  if (!h->wh_bytes || !h->w_scale || !h->colsum_w || !h->bias) {
+    free(h->wh_bytes);
+    free(h->w_scale);
+    free(h->colsum_w);
+    free(h->bias);
+    memset(h, 0, sizeof(*h));
+    return AEE_ENOMEMORY;
+  }
+  memcpy(h->wh_bytes, vtcm_base, wh_bytes);
+  memcpy(h->w_scale, w_scale, sizeof(float) * N);
+  memcpy(h->colsum_w, colsum_w, sizeof(int32_t) * N);
+  memcpy(h->bias, bias, sizeof(float) * N);
+  h->K = K;
+  h->N = N;
+  h->in_use = 1;
+
+  *out_handle = slot;
+  return AEE_SUCCESS;
+}
+
+int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle) {
+  if (!tbl || handle >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
+      !tbl->slots[handle].in_use) {
+    return AEE_EBADPARM;
+  }
+  hexkl_weight_u8i4 *h = &tbl->slots[handle];
+  free(h->wh_bytes);
+  free(h->w_scale);
+  free(h->colsum_w);
+  free(h->bias);
+  memset(h, 0, sizeof(*h));
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off,
+                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat) {
+  if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
+      !out_cat || M == 0 || K == 0) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t m_pad = ROUND_UP_U32(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  // Validate every handle up front -- K must match, and this is also where
+  // the widest weight (for the double-buffer size) and the total output
+  // width (for out_cat bounds) come from.
+  uint32_t n_tiles_max = 0, n_max = 0;
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    if (handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS || !tbl->slots[handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    const hexkl_weight_u8i4 *h = &tbl->slots[handles[i]];
+    if (h->K != K) {
+      return AEE_EBADPARM;
+    }
+    const uint32_t nt = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    if (nt > n_tiles_max) {
+      n_tiles_max = nt;
+    }
+    if (h->N > n_max) {
+      n_max = h->N;
+    }
+  }
+
+  // VTCM layout: activation (all row-bands, shared across every handle) |
+  // weight double-buffer (sized for the widest handle) | one result tile.
+  const uint32_t act_bytes = n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+  const uint32_t act_off = 0;
+  const uint32_t wb_max = k_tiles * n_tiles_max * WEIGHT_TILE_BYTES_U8I4;
+  const uint32_t wbuf[2] = {
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT),
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT) + wb_max,
+  };
+  const uint32_t result_off =
+    ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  if (result_off + ACC_TILE_BYTES > config_off) {
+    return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
+  }
+  if (result_off + ACC_TILE_BYTES > vtcm_size) {
+    return AEE_ENOMEMORY;
+  }
+
+  // K1/K2: quantize the shared activation once, straight into its AH tiles
+  // in VTCM -- no separate layout pass, matching hvx_quant_pack_u8_ah's
+  // contract.
+  float *act_scale = (float *)malloc(sizeof(float) * m_pad);
+  int32_t *act_zp = (int32_t *)malloc(sizeof(int32_t) * m_pad);
+  int32_t *acc_scratch = (int32_t *)malloc(sizeof(int32_t) * (size_t)m_pad * n_max);
+  if (!act_scale || !act_zp || !acc_scratch) {
+    free(act_scale);
+    free(act_zp);
+    free(acc_scratch);
+    return AEE_ENOMEMORY;
+  }
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
+  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                      vtcm_base + act_off);
+
+  int rc = AEE_SUCCESS;
+  size_t out_off = 0;
+  hexkl_dma_ring_reset();
+
+  // Load handle 0's weight before the loop starts -- there is nothing to
+  // prefetch it behind yet, so this one transfer is blocking.
+  {
+    const hexkl_weight_u8i4 *h0 = &tbl->slots[handles[0]];
+    const uint32_t nt0 = h0->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wb0 = k_tiles * nt0 * WEIGHT_TILE_BYTES_U8I4;
+    const uint32_t rs0 = dma_row_size_dividing(wb0);
+    hexkl_dma_ring_push2d(vtcm_base + wbuf[0], h0->wh_bytes, rs0, rs0, rs0,
+                         wb0 / rs0, /*src_vtcm=*/0, /*dst_vtcm=*/1);
+    hexkl_dma_ring_drain();
+  }
+
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    const hexkl_weight_u8i4 *h = &tbl->slots[handles[i]];
+    const uint32_t nt_n = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wcur = wbuf[i & 1u];
+
+    if (i + 1 < n_handles) {
+      // Cross-matmul prefetch (doc13 §3a): while handle i computes below,
+      // stream handle i+1's weight into the OTHER buffer in the
+      // background. One transfer, chunked under the >512KB-row DMA bug's
+      // threshold, not one per tile.
+      const hexkl_weight_u8i4 *hn = &tbl->slots[handles[i + 1]];
+      const uint32_t nt_next = hn->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+      const uint32_t wb_next = k_tiles * nt_next * WEIGHT_TILE_BYTES_U8I4;
+      const uint32_t rs = dma_row_size_dividing(wb_next);
+      hexkl_dma_ring_push2d(vtcm_base + wbuf[(i + 1) & 1u], hn->wh_bytes, rs,
+                           rs, rs, wb_next / rs, /*src_vtcm=*/0,
+                           /*dst_vtcm=*/1);
+    }
+
+    for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
+      for (uint32_t nt = 0; nt < nt_n; ++nt) {
+        hexkl_micro_hmx_acc_clear_int32();
+        for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+          const uint32_t act_tile_off =
+            act_off + (rb * k_tiles + kt) * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+          const uint32_t w_tile_off =
+            wcur + (kt * nt_n + nt) * WEIGHT_TILE_BYTES_U8I4;
+          rc = hexkl_micro_hmx_mm_u8i4(vtcm_base, act_tile_off, w_tile_off);
+          if (rc != AEE_SUCCESS) {
+            goto out;
+          }
+        }
+        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, result_off);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+        rc = hexkl_micro_hmx_copy_32b_to_submatrix(
+          vtcm_base, result_off, acc_scratch, rb, nt, m_pad, h->N);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+      }
+    }
+
+    // Block until handle i+1's weight has fully landed before moving on to
+    // it -- matches the measured bench's "next weight fully in wnxt before
+    // matmul i+1" invariant. Dequant below does not touch the DMA engine,
+    // so a later pass could move it ahead of this drain to overlap with
+    // the prefetch; left as-is for correctness first.
+    hexkl_dma_ring_drain();
+
+    hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,
+                           h->colsum_w, h->w_scale, h->bias,
+                           out_cat + out_off);
+    out_off += (size_t)M * h->N;
+  }
+
+out:
+  free(act_scale);
+  free(act_zp);
+  free(acc_scratch);
+  return rc;
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -130,7 +130,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
                             uint32_t vtcm_size, uint32_t config_off, uint32_t M,
                             uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
-                            float *out_cat) {
+                            float *out_cat, hvx_worker_pool *pool) {
   if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
       !out_cat || M == 0 || K == 0) {
     return AEE_EBADPARM;
@@ -210,11 +210,13 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     free(acc_scratch);
     return AEE_ENOMEMORY;
   }
-  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
-  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                       vtcm_base + act_off);
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp, pool);
+  int rc = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                               vtcm_base + act_off, pool);
+  if (rc != AEE_SUCCESS) {
+    goto out;
+  }
 
-  int rc = AEE_SUCCESS;
   size_t out_off = 0;
   hexkl_dma_ring_reset();
 

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -212,7 +212,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   }
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp, pool);
   int rc = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                               vtcm_base + act_off, pool);
+                                vtcm_base + act_off, pool);
   if (rc != AEE_SUCCESS) {
     goto out;
   }

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -18,20 +18,14 @@
 #include <AEEStdErr.h>
 
 #include "hexkl_dma_ring.h"
+#include "hexkl_hmx_geom.h"
 #include "hexkl_micro.h"
 #include "hvx_dequant_i32.h"
 #include "hvx_quant_u8.h"
 
-#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
-
-/** @brief Bytes in one packed i4 weight tile (32x32 values). Matches
- *         hexkl_mm_u8i4.c's local definition -- both are file-scoped, so
- *         this is not a redefinition, just the same constant kept in sync
- *         by inspection. If HexKL ever exposes it from hexkl_micro.h, both
- *         files should switch to that instead of this comment. */
-#define WEIGHT_TILE_BYTES_U8I4 512u
-/** @brief Bytes in one int32 accumulator tile (64x32 values). */
-#define ACC_TILE_BYTES 8192u
+#define ROUND_UP_U32(v, a) HEXKL_ROUND_UP_U32(v, a)
+#define WEIGHT_TILE_BYTES_U8I4 HEXKL_WEIGHT_TILE_BYTES_I4
+#define ACC_TILE_BYTES HEXKL_ACC_TILE_BYTES
 /** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
  *         this size have a documented hardware bug (doc13 §3a, §5). */
 #define MAX_DMA_ROW_BYTES 262144u

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.c
@@ -44,11 +44,11 @@ static uint32_t dma_row_size_dividing(uint32_t total_bytes) {
   return rs;
 }
 
-int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
-                               uint8_t *vtcm_base, uint32_t vtcm_size,
-                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
-                               const float *w_scale, const int32_t *colsum_w,
-                               const float *bias, uint32_t *out_handle) {
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                               uint32_t vtcm_size, uint32_t K, uint32_t N,
+                               const int8_t *w_i4_rm, const float *w_scale,
+                               const int32_t *colsum_w, const float *bias,
+                               uint32_t *out_handle) {
   if (!tbl || !vtcm_base || !w_i4_rm || !w_scale || !colsum_w || !bias ||
       !out_handle || K == 0 || N == 0) {
     return AEE_EBADPARM;
@@ -85,8 +85,7 @@ int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
   for (uint32_t kt = 0; kt < k_tiles; ++kt) {
     for (uint32_t nt = 0; nt < n_tiles; ++nt) {
       const uint32_t off = (kt * n_tiles + nt) * WEIGHT_TILE_BYTES_U8I4;
-      int res =
-        hexkl_micro_hmx_rm_to_wh_i4(vtcm_base, off, w_i4_rm, kt, nt, N);
+      int res = hexkl_micro_hmx_rm_to_wh_i4(vtcm_base, off, w_i4_rm, kt, nt, N);
       if (res != AEE_SUCCESS) {
         return res;
       }
@@ -133,8 +132,8 @@ int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle) {
 }
 
 int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
-                            uint32_t vtcm_size, uint32_t config_off,
-                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t vtcm_size, uint32_t config_off, uint32_t M,
+                            uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
                             float *out_cat) {
   if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
@@ -154,7 +153,8 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   // width (for out_cat bounds) come from.
   uint32_t n_tiles_max = 0, n_max = 0;
   for (uint32_t i = 0; i < n_handles; ++i) {
-    if (handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS || !tbl->slots[handles[i]].in_use) {
+    if (handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
+        !tbl->slots[handles[i]].in_use) {
       return AEE_EBADPARM;
     }
     const hexkl_weight_u8i4 *h = &tbl->slots[handles[i]];
@@ -172,7 +172,8 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
 
   // VTCM layout: activation (all row-bands, shared across every handle) |
   // weight double-buffer (sized for the widest handle) | one result tile.
-  const uint32_t act_bytes = n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+  const uint32_t act_bytes =
+    n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
   const uint32_t act_off = 0;
   const uint32_t wb_max = k_tiles * n_tiles_max * WEIGHT_TILE_BYTES_U8I4;
   const uint32_t wbuf[2] = {
@@ -193,7 +194,8 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   // contract.
   float *act_scale = (float *)malloc(sizeof(float) * m_pad);
   int32_t *act_zp = (int32_t *)malloc(sizeof(int32_t) * m_pad);
-  int32_t *acc_scratch = (int32_t *)malloc(sizeof(int32_t) * (size_t)m_pad * n_max);
+  int32_t *acc_scratch =
+    (int32_t *)malloc(sizeof(int32_t) * (size_t)m_pad * n_max);
   if (!act_scale || !act_zp || !acc_scratch) {
     free(act_scale);
     free(act_zp);
@@ -202,7 +204,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
   }
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
   hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                      vtcm_base + act_off);
+                       vtcm_base + act_off);
 
   int rc = AEE_SUCCESS;
   size_t out_off = 0;
@@ -216,7 +218,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     const uint32_t wb0 = k_tiles * nt0 * WEIGHT_TILE_BYTES_U8I4;
     const uint32_t rs0 = dma_row_size_dividing(wb0);
     hexkl_dma_ring_push2d(vtcm_base + wbuf[0], h0->wh_bytes, rs0, rs0, rs0,
-                         wb0 / rs0, /*src_vtcm=*/0, /*dst_vtcm=*/1);
+                          wb0 / rs0, /*src_vtcm=*/0, /*dst_vtcm=*/1);
     hexkl_dma_ring_drain();
   }
 
@@ -235,8 +237,8 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
       const uint32_t wb_next = k_tiles * nt_next * WEIGHT_TILE_BYTES_U8I4;
       const uint32_t rs = dma_row_size_dividing(wb_next);
       hexkl_dma_ring_push2d(vtcm_base + wbuf[(i + 1) & 1u], hn->wh_bytes, rs,
-                           rs, rs, wb_next / rs, /*src_vtcm=*/0,
-                           /*dst_vtcm=*/1);
+                            rs, rs, wb_next / rs, /*src_vtcm=*/0,
+                            /*dst_vtcm=*/1);
     }
 
     for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
@@ -272,8 +274,7 @@ int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
     hexkl_dma_ring_drain();
 
     hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,
-                           h->colsum_w, h->w_scale, h->bias,
-                           out_cat + out_off);
+                           h->colsum_w, h->w_scale, h->bias, out_cat + out_off);
     out_off += (size_t)M * h->N;
   }
 

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i4_dma.h
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i4 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Turns hexkl_mm_u8i4's accuracy-harness building blocks (plan / bake /
+ * run, one matmul at a time, weight baked fresh every call) into the
+ * performance path doc15 §4/§8 item 3 describes: a weight is baked once
+ * and kept DSP-resident until released, and a "layer" of matmuls that share
+ * one activation (Q/K/V, or gate/up) runs back to back with the next
+ * weight prefetched into VTCM while the current one computes -- the
+ * cross-matmul win measured in doc13 §3a (1.7-2x over SDKL on V79).
+ */
+
+#ifndef __NNTRAINER_HEXKL_MM_U8I4_DMA_H__
+#define __NNTRAINER_HEXKL_MM_U8I4_DMA_H__
+
+#include <stdint.h>
+
+/** @brief Upper bound on weights resident at once. A 28-layer qwen3-sized
+ *         model registers 7 per layer (q,k,v,o,gate,up,down) = 196; this
+ *         leaves headroom without making the table itself large. */
+#define HEXKL_MM_U8I4_MAX_WEIGHTS 512
+
+/**
+ * @brief One registered weight: WH-baked bytes plus its dequant constants,
+ *        resident in DSP heap memory (not VTCM -- VTCM is compute
+ *        scratch) until hexkl_weight_u8i4_release.
+ */
+typedef struct {
+  int in_use;
+  uint8_t *wh_bytes; /**< k_tiles*n_tiles*512 bytes, WH layout */
+  float *w_scale;    /**< N entries */
+  int32_t *colsum_w; /**< N entries */
+  float *bias;       /**< N entries */
+  uint32_t K, N;
+} hexkl_weight_u8i4;
+
+typedef struct {
+  hexkl_weight_u8i4 slots[HEXKL_MM_U8I4_MAX_WEIGHTS];
+} hexkl_weight_u8i4_table;
+
+/**
+ * @brief Bakes a K x N int4 weight (int4 values in int8 containers,
+ *        row-major) to WH layout and keeps the result resident until
+ *        hexkl_weight_u8i4_release.
+ *
+ * Borrows the caller's VTCM arena as scratch for the bake -- the caller
+ * must hold the HMX lock, and no other VTCM use may be in flight for the
+ * duration of this call.
+ *
+ * @param[out] out_handle  index into @a tbl; pass back to
+ *                         hexkl_mm_u8i4_layer_run / hexkl_weight_u8i4_release
+ * @return AEE_SUCCESS, AEE_EBADPARM on a shape violation, AEE_ENOMEMORY if
+ *         the table is full or a host allocation fails, or a HexKL error
+ *         code from the bake itself.
+ */
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
+                               uint8_t *vtcm_base, uint32_t vtcm_size,
+                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
+                               const float *w_scale, const int32_t *colsum_w,
+                               const float *bias, uint32_t *out_handle);
+
+/** @brief Frees a registered weight's resident bytes. */
+int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle);
+
+/**
+ * @brief Runs matmuls against several registered weights that share one
+ *        quantized activation, double-buffering each weight into VTCM and
+ *        prefetching the next handle's weight while the current one
+ *        computes.
+ *
+ * Every handle must have been registered with K == @a K; this is checked,
+ * not assumed. Output is dequantized f32, one contiguous M x handle[i].N
+ * block per handle in call order (not interleaved row-by-row).
+ *
+ * @param config_off  session-constant HMX config region offset (from
+ *                     hexkl_mm_u8i4_plan; the same for every M/K/N because
+ *                     it depends only on vtcm_size). The caller must have
+ *                     called hexkl_micro_hmx_setup_acc_read_int32 for it
+ *                     once already -- this function does not repeat that
+ *                     because it is session-scoped, not call-scoped.
+ * @param[out] out_cat  sum(handles[i].N) * M f32 entries
+ */
+int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off,
+                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat);
+
+#endif /* __NNTRAINER_HEXKL_MM_U8I4_DMA_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
@@ -61,11 +61,11 @@ typedef struct {
  *         the table is full or a host allocation fails, or a HexKL error
  *         code from the bake itself.
  */
-int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl,
-                               uint8_t *vtcm_base, uint32_t vtcm_size,
-                               uint32_t K, uint32_t N, const int8_t *w_i4_rm,
-                               const float *w_scale, const int32_t *colsum_w,
-                               const float *bias, uint32_t *out_handle);
+int hexkl_weight_u8i4_register(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
+                               uint32_t vtcm_size, uint32_t K, uint32_t N,
+                               const int8_t *w_i4_rm, const float *w_scale,
+                               const int32_t *colsum_w, const float *bias,
+                               uint32_t *out_handle);
 
 /** @brief Frees a registered weight's resident bytes. */
 int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle);
@@ -89,8 +89,8 @@ int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle);
  * @param[out] out_cat  sum(handles[i].N) * M f32 entries
  */
 int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
-                            uint32_t vtcm_size, uint32_t config_off,
-                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t vtcm_size, uint32_t config_off, uint32_t M,
+                            uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
                             float *out_cat);
 

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
@@ -10,12 +10,12 @@
  * @bug    No known bugs except for NYI items
  *
  * Turns hexkl_mm_u8i4's accuracy-harness building blocks (plan / bake /
- * run, one matmul at a time, weight baked fresh every call) into the
- * performance path doc15 §4/§8 item 3 describes: a weight is baked once
- * and kept DSP-resident until released, and a "layer" of matmuls that share
- * one activation (Q/K/V, or gate/up) runs back to back with the next
- * weight prefetched into VTCM while the current one computes -- the
- * cross-matmul win measured in doc13 §3a (1.7-2x over SDKL on V79).
+ * run, one matmul at a time, weight baked fresh every call) into a
+ * performance path: a weight is baked once and kept DSP-resident until
+ * released, and a "layer" of matmuls that share one activation (Q/K/V, or
+ * gate/up) runs back to back with the next weight prefetched into VTCM
+ * while the current one computes. That cross-matmul overlap measured
+ * 1.7-2x over SDKL on V79.
  */
 
 #ifndef __NNTRAINER_HEXKL_MM_U8I4_DMA_H__

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i4_dma.h
@@ -23,6 +23,8 @@
 
 #include <stdint.h>
 
+#include "hvx_worker_pool.h"
+
 /** @brief Upper bound on weights resident at once. A 28-layer qwen3-sized
  *         model registers 7 per layer (q,k,v,o,gate,up,down) = 196; this
  *         leaves headroom without making the table itself large. */
@@ -87,11 +89,13 @@ int hexkl_weight_u8i4_release(hexkl_weight_u8i4_table *tbl, uint32_t handle);
  *                     once already -- this function does not repeat that
  *                     because it is session-scoped, not call-scoped.
  * @param[out] out_cat  sum(handles[i].N) * M f32 entries
+ * @param[in]  pool     forwarded to hvx_quant_rows_u8_params/
+ *                      hvx_quant_pack_u8_ah; NULL runs quant single-threaded
  */
 int hexkl_mm_u8i4_layer_run(hexkl_weight_u8i4_table *tbl, uint8_t *vtcm_base,
                             uint32_t vtcm_size, uint32_t config_off, uint32_t M,
                             uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
-                            float *out_cat);
+                            float *out_cat, hvx_worker_pool *pool);
 
 #endif /* __NNTRAINER_HEXKL_MM_U8I4_DMA_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i8_dma.c
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i8 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Mirrors hexkl_mm_u8i4_dma.c exactly, at the wider weight width -- see
+ * that file for the reasoning behind the VTCM layout, the registry, and
+ * the cross-matmul prefetch. The only differences are the tile byte count
+ * (1024 vs 512, since u8i8 doubles the weight bytes per tile) and the
+ * HexKL primitives used to bake and multiply (the _i8 pair instead of
+ * _i4). Kept as a parallel file rather than a dtype-parametrised one: the
+ * two are proven independently and a shared abstraction would need
+ * re-verifying both on device to trust.
+ */
+
+#include "hexkl_mm_u8i8_dma.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <AEEStdErr.h>
+
+#include "hexkl_dma_ring.h"
+#include "hexkl_micro.h"
+#include "hvx_dequant_i32.h"
+#include "hvx_quant_u8.h"
+
+#define ROUND_UP_U32(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+
+/** @brief Bytes in one packed i8 weight tile (32x32 values, 1 byte each --
+ *         twice hexkl_mm_u8i4_dma.c's WEIGHT_TILE_BYTES_U8I4 since i8 does
+ *         not pack two values per byte the way i4 does). */
+#define WEIGHT_TILE_BYTES_U8I8 1024u
+/** @brief Bytes in one int32 accumulator tile (64x32 values). Same as the
+ *         u8i4 module -- the accumulator width does not depend on the
+ *         weight width. */
+#define ACC_TILE_BYTES 8192u
+/** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
+ *         this size have a documented hardware bug (doc13 §3a, §5). */
+#define MAX_DMA_ROW_BYTES 262144u
+
+static uint32_t dma_row_size_dividing(uint32_t total_bytes) {
+  uint32_t rs = MAX_DMA_ROW_BYTES;
+  while (rs > 1 && (total_bytes % rs) != 0) {
+    rs >>= 1;
+  }
+  return rs;
+}
+
+int hexkl_weight_u8i8_register(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
+                               uint32_t vtcm_size, uint32_t K, uint32_t N,
+                               const int8_t *w_i8_rm, const float *w_scale,
+                               const int32_t *colsum_w, const float *bias,
+                               uint32_t *out_handle) {
+  if (!tbl || !vtcm_base || !w_i8_rm || !w_scale || !colsum_w || !bias ||
+      !out_handle || K == 0 || N == 0) {
+    return AEE_EBADPARM;
+  }
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0 ||
+      (N % HEXKL_HMX_INT8_BLOCK_N_COL) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  uint32_t slot = HEXKL_MM_U8I8_MAX_WEIGHTS;
+  for (uint32_t i = 0; i < HEXKL_MM_U8I8_MAX_WEIGHTS; ++i) {
+    if (!tbl->slots[i].in_use) {
+      slot = i;
+      break;
+    }
+  }
+  if (slot == HEXKL_MM_U8I8_MAX_WEIGHTS) {
+    return AEE_ENOMEMORY;
+  }
+
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_tiles = N / HEXKL_HMX_INT8_BLOCK_N_COL;
+  const uint32_t wh_bytes = k_tiles * n_tiles * WEIGHT_TILE_BYTES_U8I8;
+  if (wh_bytes > vtcm_size) {
+    return AEE_ENOMEMORY; // weight alone does not fit the VTCM scratch arena
+  }
+
+  // Bake every tile into VTCM (borrowed as scratch -- caller holds the HMX
+  // lock and has no other VTCM use in flight), then copy the baked bytes
+  // out to DSP heap memory where they stay resident across calls.
+  for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+    for (uint32_t nt = 0; nt < n_tiles; ++nt) {
+      const uint32_t off = (kt * n_tiles + nt) * WEIGHT_TILE_BYTES_U8I8;
+      int res = hexkl_micro_hmx_rm_to_wh_i8(vtcm_base, off, w_i8_rm, kt, nt, N);
+      if (res != AEE_SUCCESS) {
+        return res;
+      }
+    }
+  }
+
+  hexkl_weight_u8i8 *h = &tbl->slots[slot];
+  h->wh_bytes = (uint8_t *)malloc(wh_bytes);
+  h->w_scale = (float *)malloc(sizeof(float) * N);
+  h->colsum_w = (int32_t *)malloc(sizeof(int32_t) * N);
+  h->bias = (float *)malloc(sizeof(float) * N);
+  if (!h->wh_bytes || !h->w_scale || !h->colsum_w || !h->bias) {
+    free(h->wh_bytes);
+    free(h->w_scale);
+    free(h->colsum_w);
+    free(h->bias);
+    memset(h, 0, sizeof(*h));
+    return AEE_ENOMEMORY;
+  }
+  memcpy(h->wh_bytes, vtcm_base, wh_bytes);
+  memcpy(h->w_scale, w_scale, sizeof(float) * N);
+  memcpy(h->colsum_w, colsum_w, sizeof(int32_t) * N);
+  memcpy(h->bias, bias, sizeof(float) * N);
+  h->K = K;
+  h->N = N;
+  h->in_use = 1;
+
+  *out_handle = slot;
+  return AEE_SUCCESS;
+}
+
+int hexkl_weight_u8i8_release(hexkl_weight_u8i8_table *tbl, uint32_t handle) {
+  if (!tbl || handle >= HEXKL_MM_U8I8_MAX_WEIGHTS ||
+      !tbl->slots[handle].in_use) {
+    return AEE_EBADPARM;
+  }
+  hexkl_weight_u8i8 *h = &tbl->slots[handle];
+  free(h->wh_bytes);
+  free(h->w_scale);
+  free(h->colsum_w);
+  free(h->bias);
+  memset(h, 0, sizeof(*h));
+  return AEE_SUCCESS;
+}
+
+int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off, uint32_t M,
+                            uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat) {
+  if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
+      !out_cat || M == 0 || K == 0) {
+    return AEE_EBADPARM;
+  }
+
+  const uint32_t m_pad = ROUND_UP_U32(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+  const uint32_t k_tiles = K / HEXKL_HMX_INT8_BLOCK_N_INNER;
+  const uint32_t n_rblocks = m_pad / HEXKL_HMX_INT8_BLOCK_N_ROW;
+  if ((K % HEXKL_HMX_INT8_BLOCK_N_INNER) != 0) {
+    return AEE_EBADPARM;
+  }
+
+  uint32_t n_tiles_max = 0, n_max = 0;
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    if (handles[i] >= HEXKL_MM_U8I8_MAX_WEIGHTS ||
+        !tbl->slots[handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    const hexkl_weight_u8i8 *h = &tbl->slots[handles[i]];
+    if (h->K != K) {
+      return AEE_EBADPARM;
+    }
+    const uint32_t nt = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    if (nt > n_tiles_max) {
+      n_tiles_max = nt;
+    }
+    if (h->N > n_max) {
+      n_max = h->N;
+    }
+  }
+
+  const uint32_t act_bytes =
+    n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+  const uint32_t act_off = 0;
+  const uint32_t wb_max = k_tiles * n_tiles_max * WEIGHT_TILE_BYTES_U8I8;
+  const uint32_t wbuf[2] = {
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT),
+    ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT) + wb_max,
+  };
+  const uint32_t result_off =
+    ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
+  if (result_off + ACC_TILE_BYTES > config_off) {
+    return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
+  }
+  if (result_off + ACC_TILE_BYTES > vtcm_size) {
+    return AEE_ENOMEMORY;
+  }
+
+  float *act_scale = (float *)malloc(sizeof(float) * m_pad);
+  int32_t *act_zp = (int32_t *)malloc(sizeof(int32_t) * m_pad);
+  int32_t *acc_scratch =
+    (int32_t *)malloc(sizeof(int32_t) * (size_t)m_pad * n_max);
+  if (!act_scale || !act_zp || !acc_scratch) {
+    free(act_scale);
+    free(act_zp);
+    free(acc_scratch);
+    return AEE_ENOMEMORY;
+  }
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
+  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                       vtcm_base + act_off);
+
+  int rc = AEE_SUCCESS;
+  size_t out_off = 0;
+  hexkl_dma_ring_reset();
+
+  {
+    const hexkl_weight_u8i8 *h0 = &tbl->slots[handles[0]];
+    const uint32_t nt0 = h0->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wb0 = k_tiles * nt0 * WEIGHT_TILE_BYTES_U8I8;
+    const uint32_t rs0 = dma_row_size_dividing(wb0);
+    hexkl_dma_ring_push2d(vtcm_base + wbuf[0], h0->wh_bytes, rs0, rs0, rs0,
+                          wb0 / rs0, /*src_vtcm=*/0, /*dst_vtcm=*/1);
+    hexkl_dma_ring_drain();
+  }
+
+  for (uint32_t i = 0; i < n_handles; ++i) {
+    const hexkl_weight_u8i8 *h = &tbl->slots[handles[i]];
+    const uint32_t nt_n = h->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+    const uint32_t wcur = wbuf[i & 1u];
+
+    if (i + 1 < n_handles) {
+      const hexkl_weight_u8i8 *hn = &tbl->slots[handles[i + 1]];
+      const uint32_t nt_next = hn->N / HEXKL_HMX_INT8_BLOCK_N_COL;
+      const uint32_t wb_next = k_tiles * nt_next * WEIGHT_TILE_BYTES_U8I8;
+      const uint32_t rs = dma_row_size_dividing(wb_next);
+      hexkl_dma_ring_push2d(vtcm_base + wbuf[(i + 1) & 1u], hn->wh_bytes, rs,
+                            rs, rs, wb_next / rs, /*src_vtcm=*/0,
+                            /*dst_vtcm=*/1);
+    }
+
+    for (uint32_t rb = 0; rb < n_rblocks; ++rb) {
+      for (uint32_t nt = 0; nt < nt_n; ++nt) {
+        hexkl_micro_hmx_acc_clear_int32();
+        for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+          const uint32_t act_tile_off =
+            act_off + (rb * k_tiles + kt) * HEXKL_HMX_ACTIVATION_ALIGNMENT;
+          const uint32_t w_tile_off =
+            wcur + (kt * nt_n + nt) * WEIGHT_TILE_BYTES_U8I8;
+          rc = hexkl_micro_hmx_mm_u8i8(vtcm_base, act_tile_off, w_tile_off);
+          if (rc != AEE_SUCCESS) {
+            goto out;
+          }
+        }
+        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, result_off);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+        rc = hexkl_micro_hmx_copy_32b_to_submatrix(
+          vtcm_base, result_off, acc_scratch, rb, nt, m_pad, h->N);
+        if (rc != AEE_SUCCESS) {
+          goto out;
+        }
+      }
+    }
+
+    hexkl_dma_ring_drain();
+
+    hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,
+                           h->colsum_w, h->w_scale, h->bias, out_cat + out_off);
+    out_off += (size_t)M * h->N;
+  }
+
+out:
+  free(act_scale);
+  free(act_zp);
+  free(acc_scratch);
+  return rc;
+}

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
@@ -207,7 +207,7 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
   }
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp, pool);
   int rc = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                               vtcm_base + act_off, pool);
+                                vtcm_base + act_off, pool);
   if (rc != AEE_SUCCESS) {
     goto out;
   }
@@ -267,7 +267,7 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
         // the scalar hexkl_micro_hmx_copy_32b_to_submatrix.
         int32_t *dst = acc_scratch + (size_t)rb * 64 * h->N + (size_t)nt * 32;
         hexkl_dma_ring_push2d(dst, vtcm_base + slot_off, h->N * 4, 32 * 4,
-                             32 * 4, 64, /*src_vtcm=*/1, /*dst_vtcm=*/0);
+                              32 * 4, 64, /*src_vtcm=*/1, /*dst_vtcm=*/0);
       }
     }
 

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
@@ -142,7 +142,7 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
                             uint32_t vtcm_size, uint32_t config_off, uint32_t M,
                             uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
-                            float *out_cat) {
+                            float *out_cat, hvx_worker_pool *pool) {
   if (!tbl || !vtcm_base || !handles || n_handles == 0 || !act_f32 ||
       !out_cat || M == 0 || K == 0) {
     return AEE_EBADPARM;
@@ -205,11 +205,13 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
     free(acc_scratch);
     return AEE_ENOMEMORY;
   }
-  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
-  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                       vtcm_base + act_off);
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp, pool);
+  int rc = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                               vtcm_base + act_off, pool);
+  if (rc != AEE_SUCCESS) {
+    goto out;
+  }
 
-  int rc = AEE_SUCCESS;
   size_t out_off = 0;
   hexkl_dma_ring_reset();
 

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
@@ -174,6 +174,9 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
     }
   }
 
+  // See hexkl_mm_u8i4_dma.c's VTCM layout comment: one result slot per
+  // (row-band, output-tile) pair, so async output write-back never has
+  // to be waited on before the next tile's acc_read reuses a slot.
   const uint32_t act_bytes =
     n_rblocks * k_tiles * HEXKL_HMX_ACTIVATION_ALIGNMENT;
   const uint32_t act_off = 0;
@@ -182,12 +185,13 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
     ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT),
     ROUND_UP_U32(act_off + act_bytes, HEXKL_HMX_ACTIVATION_ALIGNMENT) + wb_max,
   };
+  const uint32_t n_slots = n_tiles_max * n_rblocks;
   const uint32_t result_off =
     ROUND_UP_U32(wbuf[1] + wb_max, HEXKL_HMX_ACTIVATION_ALIGNMENT);
-  if (result_off + ACC_TILE_BYTES > config_off) {
+  if (result_off + (uint64_t)n_slots * ACC_TILE_BYTES > config_off) {
     return AEE_ENOMEMORY; // double-buffered widest weight does not fit VTCM
   }
-  if (result_off + ACC_TILE_BYTES > vtcm_size) {
+  if (result_off + (uint64_t)n_slots * ACC_TILE_BYTES > vtcm_size) {
     return AEE_ENOMEMORY;
   }
 
@@ -247,18 +251,26 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
             goto out;
           }
         }
-        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, result_off);
+        // This tile's own slot -- see hexkl_mm_u8i4_dma.c's VTCM layout
+        // comment for why (rb, nt) never collide with another in-flight
+        // tile.
+        const uint32_t slot_off =
+          result_off + (rb * n_tiles_max + nt) * ACC_TILE_BYTES;
+        rc = hexkl_micro_hmx_acc_read_int32(vtcm_base, config_off, slot_off);
         if (rc != AEE_SUCCESS) {
           goto out;
         }
-        rc = hexkl_micro_hmx_copy_32b_to_submatrix(
-          vtcm_base, result_off, acc_scratch, rb, nt, m_pad, h->N);
-        if (rc != AEE_SUCCESS) {
-          goto out;
-        }
+
+        // See hexkl_mm_u8i4_dma.c: async VTCM -> DDR write-back replacing
+        // the scalar hexkl_micro_hmx_copy_32b_to_submatrix.
+        int32_t *dst = acc_scratch + (size_t)rb * 64 * h->N + (size_t)nt * 32;
+        hexkl_dma_ring_push2d(dst, vtcm_base + slot_off, h->N * 4, 32 * 4,
+                             32 * 4, 64, /*src_vtcm=*/1, /*dst_vtcm=*/0);
       }
     }
 
+    // See hexkl_mm_u8i4_dma.c: this drain covers both the next handle's
+    // weight prefetch and every output tile pushed above.
     hexkl_dma_ring_drain();
 
     hvx_dequant_i32_to_f32(acc_scratch, M, m_pad, h->N, act_scale, act_zp,

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.c
@@ -41,8 +41,9 @@
  *         u8i4 module -- the accumulator width does not depend on the
  *         weight width. */
 #define ACC_TILE_BYTES 8192u
-/** @brief Largest single DMA row HexKL/HVX will move correctly; rows above
- *         this size have a documented hardware bug (doc13 §3a, §5). */
+/** @brief Largest single DMA row the engine will move correctly. Rows
+ *         above 256 KB hit a known hardware erratum, so a transfer is
+ *         chunked into rows at or below this size. */
 #define MAX_DMA_ROW_BYTES 262144u
 
 static uint32_t dma_row_size_dividing(uint32_t total_bytes) {

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hexkl_mm_u8i8_dma.h
+ * @date   06 Aug 2026
+ * @brief  Persistent u8i8 weight registry and the cross-matmul DMA layer path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Mirrors hexkl_mm_u8i4_dma.h exactly, at the wider weight width: u8i8
+ * fixes the activation at uint8 (same as u8i4 -- HMX's activation port is
+ * always 8-bit) and widens only the weight slot, so the tile byte count
+ * doubles (1024 vs 512) and the bake/matmul primitives are HexKL's _i8
+ * pair instead of _i4, but the VTCM layout, registry, and cross-matmul
+ * prefetch logic are otherwise identical -- see hexkl_mm_u8i4_dma.c's
+ * comments for the reasoning behind each of them.
+ */
+
+#ifndef __NNTRAINER_HEXKL_MM_U8I8_DMA_H__
+#define __NNTRAINER_HEXKL_MM_U8I8_DMA_H__
+
+#include <stdint.h>
+
+/** @brief Upper bound on weights resident at once -- see the u8i4 header
+ *         for the sizing rationale; identical here. */
+#define HEXKL_MM_U8I8_MAX_WEIGHTS 512
+
+typedef struct {
+  int in_use;
+  uint8_t *wh_bytes; /**< k_tiles*n_tiles*1024 bytes, WH layout */
+  float *w_scale;    /**< N entries */
+  int32_t *colsum_w; /**< N entries */
+  float *bias;       /**< N entries */
+  uint32_t K, N;
+} hexkl_weight_u8i8;
+
+typedef struct {
+  hexkl_weight_u8i8 slots[HEXKL_MM_U8I8_MAX_WEIGHTS];
+} hexkl_weight_u8i8_table;
+
+/**
+ * @brief Bakes a K x N int8 weight (row-major) to WH layout and keeps the
+ *        result resident until hexkl_weight_u8i8_release. See
+ *        hexkl_weight_u8i4_register -- same contract, wider weight.
+ */
+int hexkl_weight_u8i8_register(hexkl_weight_u8i8_table *tbl,
+                               uint8_t *vtcm_base, uint32_t vtcm_size,
+                               uint32_t K, uint32_t N, const int8_t *w_i8_rm,
+                               const float *w_scale, const int32_t *colsum_w,
+                               const float *bias, uint32_t *out_handle);
+
+/** @brief Frees a registered weight's resident bytes. */
+int hexkl_weight_u8i8_release(hexkl_weight_u8i8_table *tbl, uint32_t handle);
+
+/**
+ * @brief Runs matmuls against several registered u8i8 weights that share
+ *        one quantized activation. See hexkl_mm_u8i4_layer_run -- same
+ *        contract, wider weight; every handle must share K, and (as with
+ *        u8i4) all in one call.
+ */
+int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
+                            uint32_t vtcm_size, uint32_t config_off,
+                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t n_handles, const float *act_f32,
+                            float *out_cat);
+
+#endif /* __NNTRAINER_HEXKL_MM_U8I8_DMA_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
@@ -23,6 +23,8 @@
 
 #include <stdint.h>
 
+#include "hvx_worker_pool.h"
+
 /** @brief Upper bound on weights resident at once -- see the u8i4 header
  *         for the sizing rationale; identical here. */
 #define HEXKL_MM_U8I8_MAX_WEIGHTS 512
@@ -64,6 +66,6 @@ int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
                             uint32_t vtcm_size, uint32_t config_off, uint32_t M,
                             uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
-                            float *out_cat);
+                            float *out_cat, hvx_worker_pool *pool);
 
 #endif /* __NNTRAINER_HEXKL_MM_U8I8_DMA_H__ */

--- a/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
+++ b/nntrainer/tensor/htp_backend/hmx/hexkl_mm_u8i8_dma.h
@@ -45,11 +45,11 @@ typedef struct {
  *        result resident until hexkl_weight_u8i8_release. See
  *        hexkl_weight_u8i4_register -- same contract, wider weight.
  */
-int hexkl_weight_u8i8_register(hexkl_weight_u8i8_table *tbl,
-                               uint8_t *vtcm_base, uint32_t vtcm_size,
-                               uint32_t K, uint32_t N, const int8_t *w_i8_rm,
-                               const float *w_scale, const int32_t *colsum_w,
-                               const float *bias, uint32_t *out_handle);
+int hexkl_weight_u8i8_register(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
+                               uint32_t vtcm_size, uint32_t K, uint32_t N,
+                               const int8_t *w_i8_rm, const float *w_scale,
+                               const int32_t *colsum_w, const float *bias,
+                               uint32_t *out_handle);
 
 /** @brief Frees a registered weight's resident bytes. */
 int hexkl_weight_u8i8_release(hexkl_weight_u8i8_table *tbl, uint32_t handle);
@@ -61,8 +61,8 @@ int hexkl_weight_u8i8_release(hexkl_weight_u8i8_table *tbl, uint32_t handle);
  *        u8i4) all in one call.
  */
 int hexkl_mm_u8i8_layer_run(hexkl_weight_u8i8_table *tbl, uint8_t *vtcm_base,
-                            uint32_t vtcm_size, uint32_t config_off,
-                            uint32_t M, uint32_t K, const uint32_t *handles,
+                            uint32_t vtcm_size, uint32_t config_off, uint32_t M,
+                            uint32_t K, const uint32_t *handles,
                             uint32_t n_handles, const float *act_f32,
                             float *out_cat);
 

--- a/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_convert.h
+ * @date   03 Aug 2026
+ * @brief  int32 <-> f32 vector conversion for HVX, which has no such
+ *         instruction
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_CONVERT_H__
+#define __NNTRAINER_HVX_CONVERT_H__
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+/**
+ * @brief Bit pattern of 1.5 * 2^23 (12582912.0f).
+ *
+ * HVX has no numeric conversion between int32 and f32. Q6_Vw_equals_Vsf
+ * and Q6_Vsf_equals_Vw are bit reinterpretations, and the vcvt family
+ * only covers hf<->h/uh/b/ub and sf<->hf/bf. The magic-number identity
+ * below is the way across.
+ *
+ * Adding an integer x to the bit pattern of 1.5 * 2^23 lands x in the low
+ * mantissa bits, because that float's exponent puts the mantissa's least
+ * significant bit at value 1. Subtracting the same constant as a float
+ * then leaves exactly (float)x.
+ *
+ * Valid for |x| <= 2^22 = 4194304. Our accumulators are bounded by
+ * 255 * 8 * K, which is 2088960 at K=1024, so the margin is about 2x.
+ * Nothing here is safe for larger K without revisiting this bound.
+ */
+#define HVX_CONVERT_MAGIC_BITS 0x4B400000u
+
+/**
+ * @brief Converts int32 lanes to f32 lanes. Exact for |x| <= 2^22.
+ *
+ * HVX_Vector is type-agnostic: passing it directly to an f32 intrinsic
+ * reinterprets the bits without conversion. Q6_Vsf_equals_Vw /
+ * Q6_Vw_equals_Vsf look like reinterpret but are in fact NUMERIC
+ * conversions (V79 HVX Programmer's Reference Manual: "Convert IEEE
+ * floating point to integer... round to zero"), which would destroy the
+ * magic-number identity.
+ */
+static inline HVX_Vector hvx_w_to_sf(HVX_Vector v) {
+  const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);
+  const HVX_Vector bits = Q6_Vw_vadd_VwVw(v, magic);
+  return Q6_Vsf_vsub_VsfVsf(bits, magic);
+}
+
+/**
+ * @brief Converts f32 lanes to int32 lanes, rounding to nearest even.
+ *
+ * The rounding comes from the float add, so it is round-to-nearest-even.
+ * Host references that compare against this must use nearbyint, not round.
+ * Valid for results in |x| <= 2^22.
+ *
+ * Same reinterpret note as hvx_w_to_sf: the cross-type handoff is implicit.
+ */
+static inline HVX_Vector hvx_sf_to_w_rne(HVX_Vector v) {
+  const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);
+  const HVX_Vector biased = Q6_Vsf_vadd_VsfVsf(v, magic);
+  return Q6_Vw_vsub_VwVw(biased, magic);
+}
+
+/**
+ * @brief Broadcasts a float to every lane.
+ *
+ * Q6_V_vsplat_R takes a word, so the float's bits have to get there
+ * somehow. memcpy is the way that does not punt on strict aliasing --
+ * casting through int* is what -Wstrict-aliasing objects to, and this
+ * build uses -Wall -Werror. The compiler folds the memcpy away.
+ */
+static inline HVX_Vector hvx_splat_sf(float f) {
+  int bits;
+  __builtin_memcpy(&bits, &f, sizeof(bits));
+  return Q6_V_vsplat_R(bits);
+}
+
+#endif /* __NNTRAINER_HVX_CONVERT_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_convert.h
@@ -37,29 +37,15 @@
 #define HVX_CONVERT_MAGIC_BITS 0x4B400000u
 
 /**
- * @brief Converts int32 lanes to f32 lanes. Exact for |x| <= 2^22.
- *
- * HVX_Vector is type-agnostic: passing it directly to an f32 intrinsic
- * reinterprets the bits without conversion. Q6_Vsf_equals_Vw /
- * Q6_Vw_equals_Vsf look like reinterpret but are in fact NUMERIC
- * conversions (V79 HVX Programmer's Reference Manual: "Convert IEEE
- * floating point to integer... round to zero"), which would destroy the
- * magic-number identity.
- */
-static inline HVX_Vector hvx_w_to_sf(HVX_Vector v) {
-  const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);
-  const HVX_Vector bits = Q6_Vw_vadd_VwVw(v, magic);
-  return Q6_Vsf_vsub_VsfVsf(bits, magic);
-}
-
-/**
  * @brief Converts f32 lanes to int32 lanes, rounding to nearest even.
  *
  * The rounding comes from the float add, so it is round-to-nearest-even.
  * Host references that compare against this must use nearbyint, not round.
  * Valid for results in |x| <= 2^22.
  *
- * Same reinterpret note as hvx_w_to_sf: the cross-type handoff is implicit.
+ * The cross-type handoff between sf and w intrinsics is implicit: HVX_Vector
+ * is type-agnostic, so the same vector flows from Q6_Vsf_vadd_VsfVsf to
+ * Q6_Vw_vsub_VwVw without an explicit convert.
  */
 static inline HVX_Vector hvx_sf_to_w_rne(HVX_Vector v) {
   const HVX_Vector magic = Q6_V_vsplat_R(HVX_CONVERT_MAGIC_BITS);

--- a/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_dequant_i32.c
+ * @date   03 Aug 2026
+ * @brief  int32 accumulator to f32 dequantization for the A8W4 path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <stddef.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+#include "hvx_dequant_i32.h"
+
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 or int32 lanes per HVX vector. */
+#define LANES (VLEN / 4u)
+
+void hvx_dequant_i32_to_f32(const int32_t *acc, uint32_t m_valid,
+                            uint32_t m_pad, uint32_t n, const float *act_scale,
+                            const int32_t *act_zp, const int32_t *colsum_w,
+                            const float *w_scale, const float *bias,
+                            float *out) {
+  (void)m_pad;
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const int32_t *arow = acc + (size_t)m * n;
+    float *orow = out + (size_t)m * n;
+    const float s = act_scale[m];
+    const int32_t z = act_zp[m];
+
+    const uint32_t n_vec = n / LANES;
+    const HVX_Vector vs = hvx_splat_sf(s);
+    const HVX_Vector vzf = Q6_Vsf_equals_Vw(Q6_V_vsplat_R(z));
+
+    const HVX_UVector *vacc = (const HVX_UVector *)arow;
+    const HVX_UVector *vcs = (const HVX_UVector *)colsum_w;
+    const HVX_UVector *vws = (const HVX_UVector *)w_scale;
+    const HVX_UVector *vb = (const HVX_UVector *)bias;
+    HVX_UVector *vout = (HVX_UVector *)orow;
+
+    for (uint32_t v = 0; v < n_vec; ++v) {
+      const HVX_Vector af = Q6_Vsf_equals_Vw(vacc[v]);
+      const HVX_Vector csf = Q6_Vsf_equals_Vw(vcs[v]);
+      const HVX_Vector corrected =
+        Q6_Vsf_vsub_VsfVsf(af, Q6_Vsf_vmpy_VsfVsf(vzf, csf));
+      const HVX_Vector scaled =
+        Q6_Vsf_vmpy_VsfVsf(Q6_Vsf_vmpy_VsfVsf(corrected, vs), vws[v]);
+      vout[v] = Q6_Vsf_vadd_VsfVsf(scaled, vb[v]);
+    }
+
+    for (uint32_t j = n_vec * LANES; j < n; ++j) {
+      const int32_t corrected = arow[j] - z * colsum_w[j];
+      orow[j] = (float)corrected * s * w_scale[j] + bias[j];
+    }
+  }
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_dequant_i32.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_dequant_i32.h
+ * @date   03 Aug 2026
+ * @brief  int32 accumulator to f32 dequantization for the A8W4 path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_DEQUANT_I32_H__
+#define __NNTRAINER_HVX_DEQUANT_I32_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Turns HMX int32 accumulators back into f32 (K3).
+ *
+ * out[m][n] = (acc[m][n] - act_zp[m]*colsum_w[n]) * act_scale[m]
+ *             * w_scale[n] + bias[n]
+ *
+ * The zp*colsum term corrects for HMX taking unsigned activations: with
+ * x = s*(u - zp), the dot product expands to s*d*(sum u*q_w - zp*sum q_w),
+ * and sum q_w over the reduction depends only on the weights, so it is a
+ * precomputed table rather than runtime work.
+ *
+ * HexKL micro exposes no bias, scale or zero-point registers, which is why
+ * this pass exists at all.
+ *
+ * @param[in]  acc      m_pad by n int32, row-major
+ * @param[in]  m_valid  rows to emit; padded rows are skipped because their
+ *                      quantization parameters are synthetic
+ * @param[in]  colsum_w per-channel sum of the int4 weights, n entries
+ * @param[in]  w_scale  per-channel dequantization multiplier, n entries
+ * @param[out] out      m_valid by n f32, row-major
+ */
+void hvx_dequant_i32_to_f32(const int32_t *acc, uint32_t m_valid,
+                            uint32_t m_pad, uint32_t n, const float *act_scale,
+                            const int32_t *act_zp, const int32_t *colsum_w,
+                            const float *w_scale, const float *bias,
+                            float *out);
+
+#endif /* __NNTRAINER_HVX_DEQUANT_I32_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -79,7 +79,7 @@ void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
       continue; /* leaves scale 1, zp 0 */
     }
     const float s = (rmax - rmin) / 255.0f;
-    /* nearbyintf, not roundf: the vectorized path rounds to nearest even
+    /** nearbyintf, not roundf: the vectorized path rounds to nearest even
        and the host reference is written to match. */
     int32_t z = (int32_t)nearbyintf(-rmin / s);
     if (z < 0) {

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -97,6 +97,30 @@ void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
   }
 }
 
+/**
+ * @brief One row's worth of K2, unvectorized -- used only for the 0-3 rows
+ *        left over when m_valid is not a multiple of 4.
+ */
+static void quant_pack_row_scalar(const float *row, uint32_t n_ktiles,
+                                  HVX_Vector vinv, HVX_Vector vz,
+                                  uint8_t *dst_tile0, uint32_t tile_stride) {
+  const HVX_Vector vlo = Q6_V_vzero();
+  const HVX_Vector vhi = Q6_V_vsplat_R(255);
+  for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+    const HVX_UVector *vin = (const HVX_UVector *)(row + kt * TILE_INNER);
+    HVX_Vector vq = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin[0], vinv));
+    vq = Q6_Vw_vadd_VwVw(vq, vz);
+    vq = Q6_Vw_vmax_VwVw(vq, vlo);
+    vq = Q6_Vw_vmin_VwVw(vq, vhi);
+    int32_t lane[FLANES];
+    *(HVX_UVector *)lane = vq;
+    uint8_t *dst = dst_tile0 + (size_t)kt * tile_stride;
+    for (uint32_t c = 0; c < TILE_INNER; ++c) {
+      dst[c] = (uint8_t)lane[c];
+    }
+  }
+}
+
 void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
                           uint32_t k, const float *scale, const int32_t *zp,
                           uint8_t *out_ah) {
@@ -104,36 +128,76 @@ void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
 
   memset(out_ah, 0, (size_t)m_pad * k);
 
-  for (uint32_t m = 0; m < m_valid; ++m) {
-    const float *row = x + (size_t)m * k;
-    const float inv_s = 1.0f / scale[m];
-    const int32_t z = zp[m];
+  // Four rows at a time: TILE_ROW (64) is a multiple of 4, so a group of 4
+  // consecutive rows never straddles a row-block boundary, and the group's
+  // 4*32=128 destination bytes are exactly one HVX vector -- one store
+  // replaces the 32 scalar byte stores (per row, per k-tile) the row-at-a-
+  // time version needed.
+  //
+  // Q6_Vub_vpack_VhVh_sat's saturation to [0,255] is byte-identical to the
+  // Vw_vmax/Vw_vmin clamp it replaces for every input, not just the common
+  // case: [0,255] sits inside int16's range, so the first narrowing pack
+  // (int32->int16) never saturates a value this clamp would have kept, and
+  // any int32 value the clamp WOULD have clipped saturates the same way at
+  // the int16->uint8 stage (V79 HVX Programmer Reference Manual, "Pack").
+  const uint32_t m_vec_end = (m_valid / 4u) * 4u;
+  for (uint32_t m = 0; m < m_vec_end; m += 4u) {
     const uint32_t rb = m / TILE_ROW;
-    const uint32_t r = m % TILE_ROW;
-
-    const HVX_Vector vinv = hvx_splat_sf(inv_s);
-    const HVX_Vector vz = Q6_V_vsplat_R(z);
-    const HVX_Vector vlo = Q6_V_vzero();
-    const HVX_Vector vhi = Q6_V_vsplat_R(255);
+    const uint32_t r0 = m % TILE_ROW; // multiple of 4; group never wraps rb
+    const float *row0 = x + (size_t)(m + 0) * k;
+    const float *row1 = x + (size_t)(m + 1) * k;
+    const float *row2 = x + (size_t)(m + 2) * k;
+    const float *row3 = x + (size_t)(m + 3) * k;
+    const HVX_Vector vinv0 = hvx_splat_sf(1.0f / scale[m + 0]);
+    const HVX_Vector vinv1 = hvx_splat_sf(1.0f / scale[m + 1]);
+    const HVX_Vector vinv2 = hvx_splat_sf(1.0f / scale[m + 2]);
+    const HVX_Vector vinv3 = hvx_splat_sf(1.0f / scale[m + 3]);
+    const HVX_Vector vz0 = Q6_V_vsplat_R(zp[m + 0]);
+    const HVX_Vector vz1 = Q6_V_vsplat_R(zp[m + 1]);
+    const HVX_Vector vz2 = Q6_V_vsplat_R(zp[m + 2]);
+    const HVX_Vector vz3 = Q6_V_vsplat_R(zp[m + 3]);
 
     for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
-      const HVX_UVector *vin = (const HVX_UVector *)(row + kt * TILE_INNER);
-      // 32 f32 lanes is exactly one vector, and TILE_INNER is 32.
-      HVX_Vector vq = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin[0], vinv));
-      vq = Q6_Vw_vadd_VwVw(vq, vz);
-      vq = Q6_Vw_vmax_VwVw(vq, vlo);
-      vq = Q6_Vw_vmin_VwVw(vq, vhi);
+      const HVX_UVector *vin0 = (const HVX_UVector *)(row0 + kt * TILE_INNER);
+      const HVX_UVector *vin1 = (const HVX_UVector *)(row1 + kt * TILE_INNER);
+      const HVX_UVector *vin2 = (const HVX_UVector *)(row2 + kt * TILE_INNER);
+      const HVX_UVector *vin3 = (const HVX_UVector *)(row3 + kt * TILE_INNER);
 
-      // Only the low 32 lanes carry data, so stage the vector and copy the
-      // 32 bytes we want. A packed store would need three quarters of the
-      // vector to be live.
-      int32_t lane[FLANES];
-      *(HVX_UVector *)lane = vq;
-      uint8_t *dst =
-        out_ah + (size_t)(rb * n_ktiles + kt) * ACT_TILE_BYTES + r * TILE_INNER;
-      for (uint32_t c = 0; c < TILE_INNER; ++c) {
-        dst[c] = (uint8_t)lane[c];
-      }
+      const HVX_Vector vq0 = Q6_Vw_vadd_VwVw(
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin0[0], vinv0)), vz0);
+      const HVX_Vector vq1 = Q6_Vw_vadd_VwVw(
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin1[0], vinv1)), vz1);
+      const HVX_Vector vq2 = Q6_Vw_vadd_VwVw(
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin2[0], vinv2)), vz2);
+      const HVX_Vector vq3 = Q6_Vw_vadd_VwVw(
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin3[0], vinv3)), vz3);
+
+      // vpack(Vu, Vv):sat places Vv's (narrowed, saturated) elements in the
+      // low half of the result and Vu's in the high half, in order --
+      // same convention as vpacke/vpacko (V79 HVX Programmer Reference
+      // Manual, "Pack"). Vv first each time keeps row order intact:
+      // vh01 = [row0(32), row1(32)], vh23 = [row2(32), row3(32)],
+      // vb = [row0, row1, row2, row3] (128 bytes).
+      const HVX_Vector vh01 = Q6_Vh_vpack_VwVw_sat(vq1, vq0);
+      const HVX_Vector vh23 = Q6_Vh_vpack_VwVw_sat(vq3, vq2);
+      const HVX_Vector vb = Q6_Vub_vpack_VhVh_sat(vh23, vh01);
+
+      uint8_t *dst = out_ah +
+                    (size_t)(rb * n_ktiles + kt) * ACT_TILE_BYTES +
+                    r0 * TILE_INNER;
+      *(HVX_UVector *)dst = vb;
     }
+  }
+
+  // Tail: 0-3 rows that didn't fit a group of 4 (e.g. every row when
+  // m_valid == 1, the decode case). Unvectorized, same as before.
+  for (uint32_t m = m_vec_end; m < m_valid; ++m) {
+    const uint32_t rb = m / TILE_ROW;
+    const uint32_t r = m % TILE_ROW;
+    uint8_t *dst_tile0 = out_ah + (size_t)rb * n_ktiles * ACT_TILE_BYTES +
+                        r * TILE_INNER;
+    quant_pack_row_scalar(x + (size_t)m * k, n_ktiles,
+                          hvx_splat_sf(1.0f / scale[m]), Q6_V_vsplat_R(zp[m]),
+                          dst_tile0, ACT_TILE_BYTES);
   }
 }

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -174,21 +174,24 @@ typedef struct {
 static void quant_pack_worker(uint32_t n_threads, uint32_t i, void *ctx_) {
   quant_pack_ctx *ctx = (quant_pack_ctx *)ctx_;
   const uint32_t lo = (uint32_t)((uint64_t)ctx->n_ktiles * i / n_threads);
-  const uint32_t hi =
-    (uint32_t)((uint64_t)ctx->n_ktiles * (i + 1) / n_threads);
+  const uint32_t hi = (uint32_t)((uint64_t)ctx->n_ktiles * (i + 1) / n_threads);
 
   for (uint32_t kt = lo; kt < hi; ++kt) {
     for (uint32_t m = 0; m < ctx->m_vec_end; m += 4u) {
       const uint32_t rb = m / TILE_ROW;
       const uint32_t r0 = m % TILE_ROW; // multiple of 4; group never wraps rb
       const HVX_UVector *vin0 =
-        (const HVX_UVector *)(ctx->x + (size_t)(m + 0) * ctx->k + kt * TILE_INNER);
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 0) * ctx->k +
+                              kt * TILE_INNER);
       const HVX_UVector *vin1 =
-        (const HVX_UVector *)(ctx->x + (size_t)(m + 1) * ctx->k + kt * TILE_INNER);
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 1) * ctx->k +
+                              kt * TILE_INNER);
       const HVX_UVector *vin2 =
-        (const HVX_UVector *)(ctx->x + (size_t)(m + 2) * ctx->k + kt * TILE_INNER);
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 2) * ctx->k +
+                              kt * TILE_INNER);
       const HVX_UVector *vin3 =
-        (const HVX_UVector *)(ctx->x + (size_t)(m + 3) * ctx->k + kt * TILE_INNER);
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 3) * ctx->k +
+                              kt * TILE_INNER);
 
       const HVX_Vector vq0 = Q6_Vw_vadd_VwVw(
         hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin0[0], ctx->vinv[m + 0])),
@@ -214,16 +217,16 @@ static void quant_pack_worker(uint32_t n_threads, uint32_t i, void *ctx_) {
       const HVX_Vector vb = Q6_Vub_vpack_VhVh_sat(vh23, vh01);
 
       uint8_t *dst = ctx->out_ah +
-                    (size_t)(rb * ctx->n_ktiles + kt) * ACT_TILE_BYTES +
-                    r0 * TILE_INNER;
+                     (size_t)(rb * ctx->n_ktiles + kt) * ACT_TILE_BYTES +
+                     r0 * TILE_INNER;
       *(HVX_UVector *)dst = vb;
     }
   }
 }
 
 int hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
-                        uint32_t k, const float *scale, const int32_t *zp,
-                        uint8_t *out_ah, hvx_worker_pool *pool) {
+                         uint32_t k, const float *scale, const int32_t *zp,
+                         uint8_t *out_ah, hvx_worker_pool *pool) {
   const uint32_t n_ktiles = k / TILE_INNER;
 
   memset(out_ah, 0, (size_t)m_pad * k);
@@ -274,8 +277,8 @@ int hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
   for (uint32_t m = m_vec_end; m < m_valid; ++m) {
     const uint32_t rb = m / TILE_ROW;
     const uint32_t r = m % TILE_ROW;
-    uint8_t *dst_tile0 = out_ah + (size_t)rb * n_ktiles * ACT_TILE_BYTES +
-                        r * TILE_INNER;
+    uint8_t *dst_tile0 =
+      out_ah + (size_t)rb * n_ktiles * ACT_TILE_BYTES + r * TILE_INNER;
     quant_pack_row_scalar(x + (size_t)m * k, n_ktiles,
                           hvx_splat_sf(1.0f / scale[m]), Q6_V_vsplat_R(zp[m]),
                           dst_tile0, ACT_TILE_BYTES);

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -11,7 +11,10 @@
  */
 
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <AEEStdErr.h>
 
 #include <hexagon_types.h>
 #include <hvx_hexagon_protos.h>
@@ -32,69 +35,93 @@
 /** @brief f32 lanes per HVX vector. */
 #define FLANES (VLEN / 4u)
 
+/** @brief One row of K1: scale[m]/zp[m] from x's m-th row. Independent of
+ *         every other row, which is what makes splitting this by row
+ *         range across worker threads safe. */
+static void quant_row_params_one(const float *x, uint32_t m, uint32_t k,
+                                 float *scale, int32_t *zp) {
+  const float *row = x + (size_t)m * k;
+  const uint32_t n_vec = k / FLANES;
+  float min0 = row[0];
+  float max0 = row[0];
+
+  if (n_vec > 0) {
+    // FastRPC buffers carry no vector alignment guarantee, so the
+    // unaligned vector type is what keeps this from faulting.
+    const HVX_UVector *vrow = (const HVX_UVector *)row;
+    HVX_Vector vmin = vrow[0];
+    HVX_Vector vmax = vrow[0];
+    for (uint32_t i = 1; i < n_vec; ++i) {
+      vmin = Q6_Vsf_vmin_VsfVsf(vmin, vrow[i]);
+      vmax = Q6_Vsf_vmax_VsfVsf(vmax, vrow[i]);
+    }
+    // Fold 32 lanes down to 1 by rotating half the remaining width each
+    // step: 64, 32, 16, 8, 4 bytes.
+    for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
+      vmin = Q6_Vsf_vmin_VsfVsf(vmin, Q6_V_vror_VR(vmin, (int)rot));
+      vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_V_vror_VR(vmax, (int)rot));
+    }
+    float lane_min[FLANES];
+    float lane_max[FLANES];
+    *(HVX_UVector *)lane_min = vmin;
+    *(HVX_UVector *)lane_max = vmax;
+    min0 = lane_min[0];
+    max0 = lane_max[0];
+  }
+
+  for (uint32_t i = n_vec * FLANES; i < k; ++i) {
+    if (row[i] < min0) {
+      min0 = row[i];
+    }
+    if (row[i] > max0) {
+      max0 = row[i];
+    }
+  }
+  const float rmin = min0 < 0.0f ? min0 : 0.0f;
+  const float rmax = max0 > 0.0f ? max0 : 0.0f;
+  if (rmin == rmax) {
+    return; /* leaves scale 1, zp 0 */
+  }
+  const float s = (rmax - rmin) / 255.0f;
+  /** nearbyintf, not roundf: the vectorized path rounds to nearest even
+     and the host reference is written to match. */
+  int32_t z = (int32_t)nearbyintf(-rmin / s);
+  if (z < 0) {
+    z = 0;
+  }
+  if (z > 255) {
+    z = 255;
+  }
+  scale[m] = s;
+  zp[m] = z;
+}
+
+typedef struct {
+  const float *x;
+  uint32_t m_valid, k;
+  float *scale;
+  int32_t *zp;
+} quant_rows_ctx;
+
+static void quant_rows_worker(uint32_t n_threads, uint32_t i, void *ctx_) {
+  quant_rows_ctx *ctx = (quant_rows_ctx *)ctx_;
+  const uint32_t lo = (uint32_t)((uint64_t)ctx->m_valid * i / n_threads);
+  const uint32_t hi = (uint32_t)((uint64_t)ctx->m_valid * (i + 1) / n_threads);
+  for (uint32_t m = lo; m < hi; ++m) {
+    quant_row_params_one(ctx->x, m, ctx->k, ctx->scale, ctx->zp);
+  }
+}
+
 void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
-                              uint32_t k, float *scale, int32_t *zp) {
+                              uint32_t k, float *scale, int32_t *zp,
+                              hvx_worker_pool *pool) {
   for (uint32_t m = 0; m < m_pad; ++m) {
     scale[m] = 1.0f;
     zp[m] = 0;
   }
 
-  for (uint32_t m = 0; m < m_valid; ++m) {
-    const float *row = x + (size_t)m * k;
-    const uint32_t n_vec = k / FLANES;
-    float min0 = row[0];
-    float max0 = row[0];
-
-    if (n_vec > 0) {
-      // FastRPC buffers carry no vector alignment guarantee, so the
-      // unaligned vector type is what keeps this from faulting.
-      const HVX_UVector *vrow = (const HVX_UVector *)row;
-      HVX_Vector vmin = vrow[0];
-      HVX_Vector vmax = vrow[0];
-      for (uint32_t i = 1; i < n_vec; ++i) {
-        vmin = Q6_Vsf_vmin_VsfVsf(vmin, vrow[i]);
-        vmax = Q6_Vsf_vmax_VsfVsf(vmax, vrow[i]);
-      }
-      // Fold 32 lanes down to 1 by rotating half the remaining width each
-      // step: 64, 32, 16, 8, 4 bytes.
-      for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
-        vmin = Q6_Vsf_vmin_VsfVsf(vmin, Q6_V_vror_VR(vmin, (int)rot));
-        vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_V_vror_VR(vmax, (int)rot));
-      }
-      float lane_min[FLANES];
-      float lane_max[FLANES];
-      *(HVX_UVector *)lane_min = vmin;
-      *(HVX_UVector *)lane_max = vmax;
-      min0 = lane_min[0];
-      max0 = lane_max[0];
-    }
-
-    for (uint32_t i = n_vec * FLANES; i < k; ++i) {
-      if (row[i] < min0) {
-        min0 = row[i];
-      }
-      if (row[i] > max0) {
-        max0 = row[i];
-      }
-    }
-    const float rmin = min0 < 0.0f ? min0 : 0.0f;
-    const float rmax = max0 > 0.0f ? max0 : 0.0f;
-    if (rmin == rmax) {
-      continue; /* leaves scale 1, zp 0 */
-    }
-    const float s = (rmax - rmin) / 255.0f;
-    /** nearbyintf, not roundf: the vectorized path rounds to nearest even
-       and the host reference is written to match. */
-    int32_t z = (int32_t)nearbyintf(-rmin / s);
-    if (z < 0) {
-      z = 0;
-    }
-    if (z > 255) {
-      z = 255;
-    }
-    scale[m] = s;
-    zp[m] = z;
-  }
+  quant_rows_ctx ctx = {x, m_valid, k, scale, zp};
+  hvx_worker_pool_run(pool, quant_rows_worker, &ctx, m_valid);
 }
 
 /**
@@ -112,6 +139,10 @@ static void quant_pack_row_scalar(const float *row, uint32_t n_ktiles,
     vq = Q6_Vw_vadd_VwVw(vq, vz);
     vq = Q6_Vw_vmax_VwVw(vq, vlo);
     vq = Q6_Vw_vmin_VwVw(vq, vhi);
+
+    // Only the low 32 lanes carry data, so stage the vector and copy the
+    // 32 bytes we want. A packed store would need three quarters of the
+    // vector to be live.
     int32_t lane[FLANES];
     *(HVX_UVector *)lane = vq;
     uint8_t *dst = dst_tile0 + (size_t)kt * tile_stride;
@@ -121,56 +152,56 @@ static void quant_pack_row_scalar(const float *row, uint32_t n_ktiles,
   }
 }
 
-void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
-                          uint32_t k, const float *scale, const int32_t *zp,
-                          uint8_t *out_ah) {
-  const uint32_t n_ktiles = k / TILE_INNER;
+typedef struct {
+  const float *x;
+  uint32_t m_vec_end, k, n_ktiles;
+  const HVX_UVector *vinv; /**< m_vec_end entries, precomputed once --
+                               malloc'd, so unaligned: see the two heap
+                               HVX_UVector arrays below. */
+  const HVX_UVector *vz;   /**< m_vec_end entries, precomputed once */
+  uint8_t *out_ah;
+} quant_pack_ctx;
 
-  memset(out_ah, 0, (size_t)m_pad * k);
+/**
+ * @brief One k-tile's worth of K2, every row-group in it.
+ *
+ * A k-tile's destination bytes ((rb*n_ktiles+kt)*ACT_TILE_BYTES + r0*32,
+ * for every rb/r0) never overlap another k-tile's, so splitting by k-tile
+ * (not by row) is what lets workers write without touching each other's
+ * memory -- and it keeps every row-group's four rows on one worker, which
+ * is what the vectorized store below needs.
+ */
+static void quant_pack_worker(uint32_t n_threads, uint32_t i, void *ctx_) {
+  quant_pack_ctx *ctx = (quant_pack_ctx *)ctx_;
+  const uint32_t lo = (uint32_t)((uint64_t)ctx->n_ktiles * i / n_threads);
+  const uint32_t hi =
+    (uint32_t)((uint64_t)ctx->n_ktiles * (i + 1) / n_threads);
 
-  // Four rows at a time: TILE_ROW (64) is a multiple of 4, so a group of 4
-  // consecutive rows never straddles a row-block boundary, and the group's
-  // 4*32=128 destination bytes are exactly one HVX vector -- one store
-  // replaces the 32 scalar byte stores (per row, per k-tile) the row-at-a-
-  // time version needed.
-  //
-  // Q6_Vub_vpack_VhVh_sat's saturation to [0,255] is byte-identical to the
-  // Vw_vmax/Vw_vmin clamp it replaces for every input, not just the common
-  // case: [0,255] sits inside int16's range, so the first narrowing pack
-  // (int32->int16) never saturates a value this clamp would have kept, and
-  // any int32 value the clamp WOULD have clipped saturates the same way at
-  // the int16->uint8 stage (V79 HVX Programmer Reference Manual, "Pack").
-  const uint32_t m_vec_end = (m_valid / 4u) * 4u;
-  for (uint32_t m = 0; m < m_vec_end; m += 4u) {
-    const uint32_t rb = m / TILE_ROW;
-    const uint32_t r0 = m % TILE_ROW; // multiple of 4; group never wraps rb
-    const float *row0 = x + (size_t)(m + 0) * k;
-    const float *row1 = x + (size_t)(m + 1) * k;
-    const float *row2 = x + (size_t)(m + 2) * k;
-    const float *row3 = x + (size_t)(m + 3) * k;
-    const HVX_Vector vinv0 = hvx_splat_sf(1.0f / scale[m + 0]);
-    const HVX_Vector vinv1 = hvx_splat_sf(1.0f / scale[m + 1]);
-    const HVX_Vector vinv2 = hvx_splat_sf(1.0f / scale[m + 2]);
-    const HVX_Vector vinv3 = hvx_splat_sf(1.0f / scale[m + 3]);
-    const HVX_Vector vz0 = Q6_V_vsplat_R(zp[m + 0]);
-    const HVX_Vector vz1 = Q6_V_vsplat_R(zp[m + 1]);
-    const HVX_Vector vz2 = Q6_V_vsplat_R(zp[m + 2]);
-    const HVX_Vector vz3 = Q6_V_vsplat_R(zp[m + 3]);
-
-    for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
-      const HVX_UVector *vin0 = (const HVX_UVector *)(row0 + kt * TILE_INNER);
-      const HVX_UVector *vin1 = (const HVX_UVector *)(row1 + kt * TILE_INNER);
-      const HVX_UVector *vin2 = (const HVX_UVector *)(row2 + kt * TILE_INNER);
-      const HVX_UVector *vin3 = (const HVX_UVector *)(row3 + kt * TILE_INNER);
+  for (uint32_t kt = lo; kt < hi; ++kt) {
+    for (uint32_t m = 0; m < ctx->m_vec_end; m += 4u) {
+      const uint32_t rb = m / TILE_ROW;
+      const uint32_t r0 = m % TILE_ROW; // multiple of 4; group never wraps rb
+      const HVX_UVector *vin0 =
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 0) * ctx->k + kt * TILE_INNER);
+      const HVX_UVector *vin1 =
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 1) * ctx->k + kt * TILE_INNER);
+      const HVX_UVector *vin2 =
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 2) * ctx->k + kt * TILE_INNER);
+      const HVX_UVector *vin3 =
+        (const HVX_UVector *)(ctx->x + (size_t)(m + 3) * ctx->k + kt * TILE_INNER);
 
       const HVX_Vector vq0 = Q6_Vw_vadd_VwVw(
-        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin0[0], vinv0)), vz0);
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin0[0], ctx->vinv[m + 0])),
+        ctx->vz[m + 0]);
       const HVX_Vector vq1 = Q6_Vw_vadd_VwVw(
-        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin1[0], vinv1)), vz1);
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin1[0], ctx->vinv[m + 1])),
+        ctx->vz[m + 1]);
       const HVX_Vector vq2 = Q6_Vw_vadd_VwVw(
-        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin2[0], vinv2)), vz2);
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin2[0], ctx->vinv[m + 2])),
+        ctx->vz[m + 2]);
       const HVX_Vector vq3 = Q6_Vw_vadd_VwVw(
-        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin3[0], vinv3)), vz3);
+        hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin3[0], ctx->vinv[m + 3])),
+        ctx->vz[m + 3]);
 
       // vpack(Vu, Vv):sat places Vv's (narrowed, saturated) elements in the
       // low half of the result and Vu's in the high half, in order --
@@ -182,11 +213,60 @@ void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
       const HVX_Vector vh23 = Q6_Vh_vpack_VwVw_sat(vq3, vq2);
       const HVX_Vector vb = Q6_Vub_vpack_VhVh_sat(vh23, vh01);
 
-      uint8_t *dst = out_ah +
-                    (size_t)(rb * n_ktiles + kt) * ACT_TILE_BYTES +
+      uint8_t *dst = ctx->out_ah +
+                    (size_t)(rb * ctx->n_ktiles + kt) * ACT_TILE_BYTES +
                     r0 * TILE_INNER;
       *(HVX_UVector *)dst = vb;
     }
+  }
+}
+
+int hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                        uint32_t k, const float *scale, const int32_t *zp,
+                        uint8_t *out_ah, hvx_worker_pool *pool) {
+  const uint32_t n_ktiles = k / TILE_INNER;
+
+  memset(out_ah, 0, (size_t)m_pad * k);
+
+  // Four rows at a time: TILE_ROW (64) is a multiple of 4, so a group of 4
+  // consecutive rows never straddles a row-block boundary, and the group's
+  // 4*32=128 destination bytes are exactly one HVX vector -- one store
+  // replaces the 32 scalar byte stores (per row, per k-tile) the row-at-a-
+  // time version needed, measured at 92% of hvx_quant_pack_u8_ah's own time
+  // relative to a full layer call (P2_QUANT_AND_WORKER_POOL.md §1).
+  //
+  // Q6_Vub_vpack_VhVh_sat's saturation to [0,255] is byte-identical to the
+  // Vw_vmax/Vw_vmin clamp it replaces for every input, not just the common
+  // case: [0,255] sits inside int16's range, so the first narrowing pack
+  // (int32->int16) never saturates a value this clamp would have kept, and
+  // any int32 value the clamp WOULD have clipped saturates the same way at
+  // the int16->uint8 stage (V79 HVX Programmer Reference Manual, "Pack").
+  const uint32_t m_vec_end = (m_valid / 4u) * 4u;
+  if (m_vec_end > 0) {
+    // Splitting the work below by k-tile means every k-tile's worker needs
+    // every row's vinv/vz -- computed here, once, instead of once per
+    // (k-tile, row) the way splitting by k-tile would otherwise force.
+    // HVX_UVector, not HVX_Vector: malloc gives no 128-byte alignment
+    // guarantee, and HVX_Vector's aligned load/store faults the moment it
+    // isn't (found on-device -- this crashed the DSP process the first
+    // time M was big enough to take this path).
+    HVX_UVector *vinv = (HVX_UVector *)malloc(sizeof(HVX_UVector) * m_vec_end);
+    HVX_UVector *vz = (HVX_UVector *)malloc(sizeof(HVX_UVector) * m_vec_end);
+    if (!vinv || !vz) {
+      free(vinv);
+      free(vz);
+      return AEE_ENOMEMORY;
+    }
+    for (uint32_t m = 0; m < m_vec_end; ++m) {
+      vinv[m] = hvx_splat_sf(1.0f / scale[m]);
+      vz[m] = Q6_V_vsplat_R(zp[m]);
+    }
+
+    quant_pack_ctx ctx = {x, m_vec_end, k, n_ktiles, vinv, vz, out_ah};
+    hvx_worker_pool_run(pool, quant_pack_worker, &ctx, n_ktiles);
+
+    free(vinv);
+    free(vz);
   }
 
   // Tail: 0-3 rows that didn't fit a group of 4 (e.g. every row when
@@ -200,4 +280,5 @@ void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
                           hvx_splat_sf(1.0f / scale[m]), Q6_V_vsplat_R(zp[m]),
                           dst_tile0, ACT_TILE_BYTES);
   }
+  return AEE_SUCCESS;
 }

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_quant_u8.c
+ * @date   03 Aug 2026
+ * @brief  Per-row asymmetric uint8 dynamic activation quantization
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <math.h>
+#include <string.h>
+
+#include <hexagon_types.h>
+#include <hvx_hexagon_protos.h>
+
+#include "hvx_convert.h"
+#include "hvx_quant_u8.h"
+
+/** @brief HMX activation tile geometry, mirrored from hexkl_micro.h. */
+#define TILE_ROW 64u
+#define TILE_INNER 32u
+#define ACT_TILE_BYTES 2048u
+/** @brief HVX vector width in bytes (128B mode). */
+#define VLEN 128u
+/** @brief f32 lanes per HVX vector. */
+#define FLANES (VLEN / 4u)
+
+void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
+                              uint32_t k, float *scale, int32_t *zp) {
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    scale[m] = 1.0f;
+    zp[m] = 0;
+  }
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float *row = x + (size_t)m * k;
+    const uint32_t n_vec = k / FLANES;
+    float min0 = row[0];
+    float max0 = row[0];
+
+    if (n_vec > 0) {
+      // FastRPC buffers carry no vector alignment guarantee, so the
+      // unaligned vector type is what keeps this from faulting.
+      const HVX_UVector *vrow = (const HVX_UVector *)row;
+      HVX_Vector vmin = vrow[0];
+      HVX_Vector vmax = vrow[0];
+      for (uint32_t i = 1; i < n_vec; ++i) {
+        vmin = Q6_Vsf_vmin_VsfVsf(vmin, vrow[i]);
+        vmax = Q6_Vsf_vmax_VsfVsf(vmax, vrow[i]);
+      }
+      // Fold 32 lanes down to 1 by rotating half the remaining width each
+      // step: 64, 32, 16, 8, 4 bytes.
+      for (uint32_t rot = VLEN / 2u; rot >= 4u; rot >>= 1) {
+        vmin = Q6_Vsf_vmin_VsfVsf(vmin, Q6_V_vror_VR(vmin, (int)rot));
+        vmax = Q6_Vsf_vmax_VsfVsf(vmax, Q6_V_vror_VR(vmax, (int)rot));
+      }
+      float lane_min[FLANES];
+      float lane_max[FLANES];
+      *(HVX_UVector *)lane_min = vmin;
+      *(HVX_UVector *)lane_max = vmax;
+      min0 = lane_min[0];
+      max0 = lane_max[0];
+    }
+
+    for (uint32_t i = n_vec * FLANES; i < k; ++i) {
+      if (row[i] < min0) {
+        min0 = row[i];
+      }
+      if (row[i] > max0) {
+        max0 = row[i];
+      }
+    }
+    const float rmin = min0 < 0.0f ? min0 : 0.0f;
+    const float rmax = max0 > 0.0f ? max0 : 0.0f;
+    if (rmin == rmax) {
+      continue; /* leaves scale 1, zp 0 */
+    }
+    const float s = (rmax - rmin) / 255.0f;
+    /* nearbyintf, not roundf: the vectorized path rounds to nearest even
+       and the host reference is written to match. */
+    int32_t z = (int32_t)nearbyintf(-rmin / s);
+    if (z < 0) {
+      z = 0;
+    }
+    if (z > 255) {
+      z = 255;
+    }
+    scale[m] = s;
+    zp[m] = z;
+  }
+}
+
+void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                          uint32_t k, const float *scale, const int32_t *zp,
+                          uint8_t *out_ah) {
+  const uint32_t n_ktiles = k / TILE_INNER;
+
+  memset(out_ah, 0, (size_t)m_pad * k);
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float *row = x + (size_t)m * k;
+    const float inv_s = 1.0f / scale[m];
+    const int32_t z = zp[m];
+    const uint32_t rb = m / TILE_ROW;
+    const uint32_t r = m % TILE_ROW;
+
+    const HVX_Vector vinv = hvx_splat_sf(inv_s);
+    const HVX_Vector vz = Q6_V_vsplat_R(z);
+    const HVX_Vector vlo = Q6_V_vzero();
+    const HVX_Vector vhi = Q6_V_vsplat_R(255);
+
+    for (uint32_t kt = 0; kt < n_ktiles; ++kt) {
+      const HVX_UVector *vin = (const HVX_UVector *)(row + kt * TILE_INNER);
+      // 32 f32 lanes is exactly one vector, and TILE_INNER is 32.
+      HVX_Vector vq = hvx_sf_to_w_rne(Q6_Vsf_vmpy_VsfVsf(vin[0], vinv));
+      vq = Q6_Vw_vadd_VwVw(vq, vz);
+      vq = Q6_Vw_vmax_VwVw(vq, vlo);
+      vq = Q6_Vw_vmin_VwVw(vq, vhi);
+
+      // Only the low 32 lanes carry data, so stage the vector and copy the
+      // 32 bytes we want. A packed store would need three quarters of the
+      // vector to be live.
+      int32_t lane[FLANES];
+      *(HVX_UVector *)lane = vq;
+      uint8_t *dst =
+        out_ah + (size_t)(rb * n_ktiles + kt) * ACT_TILE_BYTES + r * TILE_INNER;
+      for (uint32_t c = 0; c < TILE_INNER; ++c) {
+        dst[c] = (uint8_t)lane[c];
+      }
+    }
+  }
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.c
@@ -16,13 +16,17 @@
 #include <hexagon_types.h>
 #include <hvx_hexagon_protos.h>
 
+#include "hexkl_hmx_geom.h"
 #include "hvx_convert.h"
 #include "hvx_quant_u8.h"
 
-/** @brief HMX activation tile geometry, mirrored from hexkl_micro.h. */
-#define TILE_ROW 64u
-#define TILE_INNER 32u
-#define ACT_TILE_BYTES 2048u
+/** @brief HMX activation tile geometry. Taken from hexkl_hmx_geom.h rather
+ *         than restated here: this kernel writes the tiles that
+ *         hexkl_mm_u8i4_run then reads, and the two strides have to be the
+ *         same number or the matmul silently reads the wrong bytes. */
+#define TILE_ROW HEXKL_TILE_ROW
+#define TILE_INNER HEXKL_TILE_INNER
+#define ACT_TILE_BYTES HEXKL_ACT_TILE_BYTES
 /** @brief HVX vector width in bytes (128B mode). */
 #define VLEN 128u
 /** @brief f32 lanes per HVX vector. */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
@@ -15,6 +15,8 @@
 
 #include <stdint.h>
 
+#include "hvx_worker_pool.h"
+
 /**
  * @brief Computes the per-row scale and zero point (K1).
  *
@@ -28,9 +30,12 @@
  * @param[in]  m_pad    rows after padding up to a multiple of 64
  * @param[out] scale    m_pad entries
  * @param[out] zp       m_pad entries, each in [0, 255]
+ * @param[in]  pool     rows are independent, so this splits by row range.
+ *                      NULL runs single-threaded.
  */
 void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
-                              uint32_t k, float *scale, int32_t *zp);
+                              uint32_t k, float *scale, int32_t *zp,
+                              hvx_worker_pool *pool);
 
 /**
  * @brief Quantizes to uint8 and writes AH tiles (K2).
@@ -44,9 +49,16 @@ void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
  *
  * @param[in]  out_ah  destination, m_pad * k bytes. Usually VTCM, and then
  *                     it must be 2048-byte aligned.
+ * @param[in]  pool    splits the vectorized part by k-tile, not by row: a
+ *                     k-tile's destination bytes are its own, disjoint from
+ *                     every other k-tile's, so this preserves the 4-row
+ *                     vectorized store groups a row split would break.
+ *                     NULL runs single-threaded.
+ * @return AEE_SUCCESS, or AEE_ENOMEMORY if the small per-row vector cache
+ *         this needs to parallelize safely fails to allocate.
  */
-void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
-                          uint32_t k, const float *scale, const int32_t *zp,
-                          uint8_t *out_ah);
+int hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                        uint32_t k, const float *scale, const int32_t *zp,
+                        uint8_t *out_ah, hvx_worker_pool *pool);
 
 #endif /* __NNTRAINER_HVX_QUANT_U8_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
@@ -58,7 +58,7 @@ void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
  *         this needs to parallelize safely fails to allocate.
  */
 int hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
-                        uint32_t k, const float *scale, const int32_t *zp,
-                        uint8_t *out_ah, hvx_worker_pool *pool);
+                         uint32_t k, const float *scale, const int32_t *zp,
+                         uint8_t *out_ah, hvx_worker_pool *pool);
 
 #endif /* __NNTRAINER_HVX_QUANT_U8_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_quant_u8.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   hvx_quant_u8.h
+ * @date   03 Aug 2026
+ * @brief  Per-row asymmetric uint8 dynamic activation quantization
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_QUANT_U8_H__
+#define __NNTRAINER_HVX_QUANT_U8_H__
+
+#include <stdint.h>
+
+/**
+ * @brief Computes the per-row scale and zero point (K1).
+ *
+ * x[m][k] is recovered as scale[m] * (u[m][k] - zp[m]).
+ *
+ * Rows at or past @a m_valid are padding: they get scale 1 and zp 0 so a
+ * host reference can reproduce them without special cases.
+ *
+ * @param[in]  x        activation, m_valid rows by k columns, row-major f32
+ * @param[in]  m_valid  rows carrying real data
+ * @param[in]  m_pad    rows after padding up to a multiple of 64
+ * @param[out] scale    m_pad entries
+ * @param[out] zp       m_pad entries, each in [0, 255]
+ */
+void hvx_quant_rows_u8_params(const float *x, uint32_t m_valid, uint32_t m_pad,
+                              uint32_t k, float *scale, int32_t *zp);
+
+/**
+ * @brief Quantizes to uint8 and writes AH tiles (K2).
+ *
+ * Writes directly in the layout the HMX activation port expects: 64x32
+ * tiles, flat row-major inside a tile, tiles in (row_block, inner_tile)
+ * order at a 2048-byte stride. No separate layout pass is needed for
+ * 8-bit activations.
+ *
+ * Rounding is round-to-nearest-even, matching hvx_sf_to_w_rne.
+ *
+ * @param[in]  out_ah  destination, m_pad * k bytes. Usually VTCM, and then
+ *                     it must be 2048-byte aligned.
+ */
+void hvx_quant_pack_u8_ah(const float *x, uint32_t m_valid, uint32_t m_pad,
+                          uint32_t k, const float *scale, const int32_t *zp,
+                          uint8_t *out_ah);
+
+#endif /* __NNTRAINER_HVX_QUANT_U8_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.c
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hvx_worker_pool.c
+ * @date   06 Aug 2026
+ * @brief  Fixed-size QuRT thread pool for splitting HVX-bound work by index
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * The seqn/barrier/futex protocol below is not novel -- it is
+ * llama.cpp ggml-hexagon's htp/work-queue.c pattern (same QuRT primitives,
+ * same target), trimmed to a single-job-in-flight fork/join: this pool has
+ * no run_async and no multi-slot queue, since every caller here blocks
+ * until its job is done anyway. That is a smaller, already-proven surface
+ * for what is otherwise this codebase's first genuinely concurrent code
+ * path.
+ */
+
+#include "hvx_worker_pool.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <qurt.h>
+
+/** @brief Hexagon SMT pause hint for the calling thread's spin-wait below --
+ *         same instruction ggml-hexagon's work-queue.c uses while a job is
+ *         in flight. */
+static inline void hvx_worker_pool_pause(void) {
+  asm volatile(" pause(#255)\n");
+}
+
+/** @brief Per-worker stack, generous for the quant kernels this pool
+ *         currently runs (a handful of HVX vector locals, no recursion). */
+#define HVX_WORKER_POOL_STACK_SIZE (16u * 1024u)
+
+typedef struct hvx_worker_pool_s hvx_worker_pool;
+
+typedef struct {
+  hvx_worker_pool *pool;
+  uint32_t id; /**< 1..n_workers; 0 is reserved for the calling thread */
+} hvx_worker_ctx;
+
+struct hvx_worker_pool_s {
+  _Atomic uint32_t seqn;    /**< bumped once per hvx_worker_pool_run call */
+  _Atomic uint32_t barrier; /**< participating workers still running */
+  _Atomic int killed;
+  hvx_worker_pool_func func;
+  void *ctx;
+  uint32_t n_threads; /**< participants (main + workers) for the current run */
+  uint32_t n_workers;
+  qurt_thread_t *tids;
+  hvx_worker_ctx *worker_ctx;
+  unsigned char *stack_blob;
+};
+
+static void hvx_worker_pool_thread_entry(void *arg) {
+  hvx_worker_ctx *me = (hvx_worker_ctx *)arg;
+  hvx_worker_pool *pool = me->pool;
+  uint32_t prev_seqn = 0;
+
+  for (;;) {
+    if (atomic_load_explicit(&pool->killed, memory_order_relaxed)) {
+      qurt_thread_exit(0);
+    }
+
+    uint32_t seqn = atomic_load_explicit(&pool->seqn, memory_order_acquire);
+    if (seqn == prev_seqn) {
+      qurt_futex_wait(&pool->seqn, (int)prev_seqn);
+      continue;
+    }
+    prev_seqn = seqn;
+
+    if (me->id < pool->n_threads) {
+      pool->func(pool->n_threads, me->id, pool->ctx);
+      atomic_fetch_sub_explicit(&pool->barrier, 1, memory_order_release);
+    }
+    // me->id >= pool->n_threads: this run didn't need this worker; loop
+    // back and wait for the next one.
+  }
+}
+
+hvx_worker_pool *hvx_worker_pool_create(uint32_t n_workers) {
+  hvx_worker_pool *pool = (hvx_worker_pool *)calloc(1, sizeof(*pool));
+  if (!pool) {
+    return NULL;
+  }
+  atomic_init(&pool->seqn, 0);
+  atomic_init(&pool->barrier, 0);
+  atomic_init(&pool->killed, 0);
+  pool->n_workers = n_workers;
+
+  if (n_workers == 0) {
+    return pool;
+  }
+
+  pool->tids = (qurt_thread_t *)calloc(n_workers, sizeof(qurt_thread_t));
+  pool->worker_ctx = (hvx_worker_ctx *)calloc(n_workers, sizeof(hvx_worker_ctx));
+  pool->stack_blob =
+    (unsigned char *)malloc((size_t)n_workers * HVX_WORKER_POOL_STACK_SIZE);
+  if (!pool->tids || !pool->worker_ctx || !pool->stack_blob) {
+    hvx_worker_pool_destroy(pool);
+    return NULL;
+  }
+
+  qurt_thread_attr_t attr;
+  qurt_thread_attr_init(&attr);
+  qurt_thread_attr_set_stack_size(&attr, HVX_WORKER_POOL_STACK_SIZE);
+
+  // Match the creating thread's priority, same as ggml-hexagon's
+  // work_queue_init -- these workers only ever run while the FastRPC
+  // thread that owns this session is waiting on them, so there is no
+  // reason for them to run at a different priority.
+  int prio = qurt_thread_get_priority(qurt_thread_get_id());
+  if (prio < 1) {
+    prio = 1;
+  }
+  qurt_thread_attr_set_priority(&attr, (unsigned short)prio);
+
+  for (uint32_t i = 0; i < n_workers; ++i) {
+    pool->worker_ctx[i].pool = pool;
+    pool->worker_ctx[i].id = i + 1;
+    qurt_thread_attr_set_stack_addr(
+      &attr, pool->stack_blob + (size_t)i * HVX_WORKER_POOL_STACK_SIZE);
+
+    char name[16];
+    snprintf(name, sizeof(name), "hvxpool:%u", (unsigned)i);
+    qurt_thread_attr_set_name(&attr, name);
+
+    if (qurt_thread_create(&pool->tids[i], &attr, hvx_worker_pool_thread_entry,
+                          &pool->worker_ctx[i]) != 0) {
+      // Only i threads actually started; limit teardown's join loop to
+      // those.
+      pool->n_workers = i;
+      hvx_worker_pool_destroy(pool);
+      return NULL;
+    }
+  }
+
+  return pool;
+}
+
+void hvx_worker_pool_destroy(hvx_worker_pool *pool) {
+  if (!pool) {
+    return;
+  }
+  if (pool->n_workers > 0 && pool->tids) {
+    atomic_store_explicit(&pool->killed, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&pool->seqn, 1, memory_order_release);
+    qurt_futex_wake(&pool->seqn, (int)pool->n_workers);
+    for (uint32_t i = 0; i < pool->n_workers; ++i) {
+      int status;
+      qurt_thread_join(pool->tids[i], &status);
+    }
+  }
+  free(pool->tids);
+  free(pool->worker_ctx);
+  free(pool->stack_blob);
+  free(pool);
+}
+
+void hvx_worker_pool_run(hvx_worker_pool *pool, hvx_worker_pool_func func,
+                        void *ctx, uint32_t n_units) {
+  if (!pool || pool->n_workers == 0 || n_units <= 1) {
+    func(n_units == 0 ? 1u : n_units, 0, ctx);
+    return;
+  }
+
+  uint32_t n = n_units;
+  if (n > pool->n_workers + 1u) {
+    n = pool->n_workers + 1u;
+  }
+
+  pool->func = func;
+  pool->ctx = ctx;
+  pool->n_threads = n;
+  atomic_store_explicit(&pool->barrier, n - 1u, memory_order_relaxed);
+
+  // Publish the job, then wake every worker -- not just the n-1 that will
+  // participate. qurt_futex_wake(addr, k) wakes k ARBITRARY sleepers on
+  // addr, not k specific ones by id: waking only n-1 risked waking
+  // non-participants while the actual participants stayed asleep forever
+  // (found on-device: the very first call deadlocked here). A
+  // non-participant that wakes just rechecks its id against n_threads,
+  // finds it doesn't apply, and goes back to sleep -- harmless.
+  atomic_fetch_add_explicit(&pool->seqn, 1, memory_order_release);
+  qurt_futex_wake(&pool->seqn, (int)pool->n_workers);
+
+  func(n, 0, ctx); // the calling thread is worker 0
+
+  while (atomic_load_explicit(&pool->barrier, memory_order_relaxed) > 0) {
+    hvx_worker_pool_pause();
+  }
+  // Pairs with each worker's release store to barrier: makes every
+  // worker's writes to ctx visible to the calling thread from here on.
+  atomic_thread_fence(memory_order_acquire);
+}

--- a/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.c
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.c
@@ -98,7 +98,8 @@ hvx_worker_pool *hvx_worker_pool_create(uint32_t n_workers) {
   }
 
   pool->tids = (qurt_thread_t *)calloc(n_workers, sizeof(qurt_thread_t));
-  pool->worker_ctx = (hvx_worker_ctx *)calloc(n_workers, sizeof(hvx_worker_ctx));
+  pool->worker_ctx =
+    (hvx_worker_ctx *)calloc(n_workers, sizeof(hvx_worker_ctx));
   pool->stack_blob =
     (unsigned char *)malloc((size_t)n_workers * HVX_WORKER_POOL_STACK_SIZE);
   if (!pool->tids || !pool->worker_ctx || !pool->stack_blob) {
@@ -131,7 +132,7 @@ hvx_worker_pool *hvx_worker_pool_create(uint32_t n_workers) {
     qurt_thread_attr_set_name(&attr, name);
 
     if (qurt_thread_create(&pool->tids[i], &attr, hvx_worker_pool_thread_entry,
-                          &pool->worker_ctx[i]) != 0) {
+                           &pool->worker_ctx[i]) != 0) {
       // Only i threads actually started; limit teardown's join loop to
       // those.
       pool->n_workers = i;
@@ -163,7 +164,7 @@ void hvx_worker_pool_destroy(hvx_worker_pool *pool) {
 }
 
 void hvx_worker_pool_run(hvx_worker_pool *pool, hvx_worker_pool_func func,
-                        void *ctx, uint32_t n_units) {
+                         void *ctx, uint32_t n_units) {
   if (!pool || pool->n_workers == 0 || n_units <= 1) {
     func(n_units == 0 ? 1u : n_units, 0, ctx);
     return;

--- a/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.h
@@ -23,8 +23,7 @@
  *        by writing one more function with this signature, with nothing
  *        below it needing to change.
  */
-typedef void (*hvx_worker_pool_func)(uint32_t n_threads, uint32_t i,
-                                    void *ctx);
+typedef void (*hvx_worker_pool_func)(uint32_t n_threads, uint32_t i, void *ctx);
 
 typedef struct hvx_worker_pool_s hvx_worker_pool;
 
@@ -53,6 +52,6 @@ void hvx_worker_pool_destroy(hvx_worker_pool *pool);
  * single-owner assumption as the HMX lock this pool lives alongside.
  */
 void hvx_worker_pool_run(hvx_worker_pool *pool, hvx_worker_pool_func func,
-                        void *ctx, uint32_t n_units);
+                         void *ctx, uint32_t n_units);
 
 #endif /* __NNTRAINER_HVX_WORKER_POOL_H__ */

--- a/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.h
+++ b/nntrainer/tensor/htp_backend/hvx/hvx_worker_pool.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   hvx_worker_pool.h
+ * @date   06 Aug 2026
+ * @brief  Fixed-size QuRT thread pool for splitting HVX-bound work by index
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTRAINER_HVX_WORKER_POOL_H__
+#define __NNTRAINER_HVX_WORKER_POOL_H__
+
+#include <stdint.h>
+
+/**
+ * @brief One unit of parallel work: the callee sees which of @a n_threads
+ *        it is (@a i) and computes its own slice from that -- the same
+ *        shape as llama.cpp ggml-hexagon's work_queue_func_t, so a second
+ *        task type (e.g. a future dequant fusion) can share this pool later
+ *        by writing one more function with this signature, with nothing
+ *        below it needing to change.
+ */
+typedef void (*hvx_worker_pool_func)(uint32_t n_threads, uint32_t i,
+                                    void *ctx);
+
+typedef struct hvx_worker_pool_s hvx_worker_pool;
+
+/**
+ * @brief Starts @a n_workers QuRT threads, parked waiting for work.
+ *
+ * @param n_workers  worker thread count, NOT including the calling thread
+ *                    (pass hwinfo's n_hvx - 1: the caller's own thread uses
+ *                    one HVX context too). 0 is valid and makes every
+ *                    hvx_worker_pool_run() call run inline on the caller.
+ * @return NULL on allocation or thread-creation failure.
+ */
+hvx_worker_pool *hvx_worker_pool_create(uint32_t n_workers);
+
+/** @brief Signals every worker to exit and joins them. Safe to call on NULL. */
+void hvx_worker_pool_destroy(hvx_worker_pool *pool);
+
+/**
+ * @brief Runs func(n, i, ctx) for i in [0, n) and blocks until all n calls
+ *        finish -- i == 0 on the calling thread, the rest on pool workers.
+ *
+ * n = min(n_units, pool's worker count + 1). If @a pool is NULL or has no
+ * workers, or n_units <= 1, func runs once inline with no thread handoff.
+ *
+ * Not safe to call concurrently from two threads on the same pool -- same
+ * single-owner assumption as the HMX lock this pool lives alongside.
+ */
+void hvx_worker_pool_run(hvx_worker_pool *pool, hvx_worker_pool_func func,
+                        void *ctx, uint32_t n_units);
+
+#endif /* __NNTRAINER_HVX_WORKER_POOL_H__ */

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -16,14 +16,15 @@ set -eu
 
 HEX_ARCH="${HEX_ARCH:-v79}"
 HEXKL_ROOT="${HEXKL_ROOT:?set HEXKL_ROOT to your hexkl_addon path}"
-HEXKL_SDK_VER="${HEXKL_SDK_VER:-6.4.0.1}"
+HEXAGON_SDK_VER="${HEXAGON_SDK_VER:-$(basename "$HEXAGON_SDK_ROOT")}"
 HEXKL_TOOLS_VARIANT="${HEXKL_TOOLS_VARIANT:-toolv19}"
-HEXKL_LIB="$HEXKL_ROOT/lib/$HEXKL_SDK_VER/hexagon_${HEXKL_TOOLS_VARIANT}_${HEX_ARCH}/libhexkl_micro.a"
+HEXKL_LIB="$HEXKL_ROOT/lib/$HEXAGON_SDK_VER/hexagon_${HEXKL_TOOLS_VARIANT}_${HEX_ARCH}/libhexkl_micro.a"
 
 if [ ! -f "$HEXKL_LIB" ]; then
     echo "Error: HexKL static library not found:" >&2
     echo "  $HEXKL_LIB" >&2
-    echo "HexKL provides v79 only for lib/6.1.1.0 and newer." >&2
+    echo "Available under $HEXKL_ROOT/lib:" >&2
+    ls "$HEXKL_ROOT/lib" 2>/dev/null >&2 || echo "  (none)" >&2
     exit 1
 fi
 
@@ -59,4 +60,4 @@ SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
     "$HEXKL_LIB" \
     -o build/libnntr_hvx_skel.so
 
-echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH, hexkl $HEXKL_SDK_VER)"
+echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH, hexkl $HEXAGON_SDK_VER)"

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -7,7 +7,7 @@
 #   The SDK must be 6.1.1.0 or newer: HexKL ships libhexkl_micro.a for v79
 #   only from lib/6.1.1.0 up. 6.4.0.1 is the verified combination.
 # Override the target with: HEX_ARCH=v75 ./build.sh
-# Override HexKL with:      HEXKL_ROOT=/path/to/hexkl_addon ./build.sh
+# Set HexKL path:           HEXKL_ROOT=/path/to/hexkl_addon ./build.sh
 
 set -eu
 
@@ -15,7 +15,7 @@ set -eu
 : "${DEFAULT_HEXAGON_TOOLS_ROOT:?source setup_sdk_env.source first}"
 
 HEX_ARCH="${HEX_ARCH:-v79}"
-HEXKL_ROOT="${HEXKL_ROOT:-$HOME/Downloads/hexkl_addon}"
+HEXKL_ROOT="${HEXKL_ROOT:?set HEXKL_ROOT to your hexkl_addon path}"
 HEXKL_SDK_VER="${HEXKL_SDK_VER:-6.4.0.1}"
 HEXKL_TOOLS_VARIANT="${HEXKL_TOOLS_VARIANT:-toolv19}"
 HEXKL_LIB="$HEXKL_ROOT/lib/$HEXKL_SDK_VER/hexagon_${HEXKL_TOOLS_VARIANT}_${HEX_ARCH}/libhexkl_micro.a"

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -41,6 +41,7 @@ mkdir -p generated build
 
 SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -4,7 +4,10 @@
 # Generates the FastRPC stub/skel from nntr_hvx.idl and builds the DSP skel.
 #
 # Prerequisite: source $HEXAGON_SDK_ROOT/setup_sdk_env.source
+#   The SDK must be 6.1.1.0 or newer: HexKL ships libhexkl_micro.a for v79
+#   only from lib/6.1.1.0 up. 6.4.0.1 is the verified combination.
 # Override the target with: HEX_ARCH=v75 ./build.sh
+# Override HexKL with:      HEXKL_ROOT=/path/to/hexkl_addon ./build.sh
 
 set -eu
 
@@ -12,7 +15,21 @@ set -eu
 : "${DEFAULT_HEXAGON_TOOLS_ROOT:?source setup_sdk_env.source first}"
 
 HEX_ARCH="${HEX_ARCH:-v79}"
+HEXKL_ROOT="${HEXKL_ROOT:-$HOME/Downloads/hexkl_addon}"
+HEXKL_SDK_VER="${HEXKL_SDK_VER:-6.4.0.1}"
+HEXKL_TOOLS_VARIANT="${HEXKL_TOOLS_VARIANT:-toolv19}"
+HEXKL_LIB="$HEXKL_ROOT/lib/$HEXKL_SDK_VER/hexagon_${HEXKL_TOOLS_VARIANT}_${HEX_ARCH}/libhexkl_micro.a"
+
+if [ ! -f "$HEXKL_LIB" ]; then
+    echo "Error: HexKL static library not found:" >&2
+    echo "  $HEXKL_LIB" >&2
+    echo "HexKL provides v79 only for lib/6.1.1.0 and newer." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BACKEND="$REPO_ROOT/nntrainer/tensor/htp_backend"
 cd "$SCRIPT_DIR"
 
 mkdir -p generated build
@@ -22,16 +39,23 @@ mkdir -p generated build
     -I "$HEXAGON_SDK_ROOT/incs/stddef" \
     -mdll -o generated nntr_hvx.idl
 
+SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \
     -Wall -Werror \
     -I generated \
+    -I "$HEXKL_ROOT/include" \
+    -I "$BACKEND/hvx" \
+    -I "$BACKEND/hmx" \
     -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/qurt" \
     -I "$HEXAGON_SDK_ROOT/rtos/qurt/compute${HEX_ARCH}/include/posix" \
     -isystem "$HEXAGON_SDK_ROOT/incs" \
     -isystem "$HEXAGON_SDK_ROOT/incs/stddef" \
     -isystem "$HEXAGON_SDK_ROOT/ipc/fastrpc/incs" \
-    hvx_add_f32.c generated/nntr_hvx_skel.c \
+    $SRCS \
+    "$HEXKL_LIB" \
     -o build/libnntr_hvx_skel.so
 
-echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH)"
+echo "built: $SCRIPT_DIR/build/libnntr_hvx_skel.so ($HEX_ARCH, hexkl $HEXKL_SDK_VER)"

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -40,8 +40,9 @@ mkdir -p generated build
     -I "$HEXAGON_SDK_ROOT/incs/stddef" \
     -mdll -o generated nntr_hvx.idl
 
-SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
+SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c nntr_hvx_mm_u8i8.c generated/nntr_hvx_skel.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c $BACKEND/hmx/hexkl_mm_u8i4_dma.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i8_dma.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_dma_ring.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -45,6 +45,7 @@ SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c $BACKEND/hmx/hexkl_mm_u8i4_dma.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i8_dma.c"
 SRCS="$SRCS $BACKEND/hmx/hexkl_dma_ring.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
+SRCS="$SRCS $BACKEND/hvx/hvx_worker_pool.c"
 
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \
     -m"$HEX_ARCH" -mhvx -mhvx-length=128B -G0 -O3 -fPIC -shared \

--- a/test/htp/build.sh
+++ b/test/htp/build.sh
@@ -41,7 +41,8 @@ mkdir -p generated build
     -mdll -o generated nntr_hvx.idl
 
 SRCS="hvx_add_f32.c nntr_hvx_mm_u8i4.c generated/nntr_hvx_skel.c"
-SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_mm_u8i4.c $BACKEND/hmx/hexkl_mm_u8i4_dma.c"
+SRCS="$SRCS $BACKEND/hmx/hexkl_dma_ring.c"
 SRCS="$SRCS $BACKEND/hvx/hvx_quant_u8.c $BACKEND/hvx/hvx_dequant_i32.c"
 
 "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-clang" \

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -22,6 +22,7 @@
 #include <qurt.h>
 
 #include "hexkl_micro.h"
+#include "hvx_worker_pool.h"
 #include "nntr_hvx.h"
 #include "nntr_hvx_session.h"
 
@@ -75,6 +76,19 @@ int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
     return res;
   }
 
+  // Sized from the real HVX context count (bits 15:8, same decode
+  // nntr_hvx_add_f32 uses to check HVX is present at all) minus one, since
+  // this session's own FastRPC thread uses an HVX context too when it runs
+  // quant's own share of the work.
+  const uint32_t n_hvx = (qurt_hvx_get_units() >> 8) & 0xFFu;
+  s->quant_pool = hvx_worker_pool_create(n_hvx > 1 ? n_hvx - 1 : 0);
+  if (!s->quant_pool) {
+    FARF(ERROR, "nntr_hvx_open: hvx_worker_pool_create failed");
+    hexkl_micro_hmx_unlock();
+    free(s);
+    return AEE_ENOMEMORY;
+  }
+
   *handle = (remote_handle64)s;
   return AEE_SUCCESS;
 }
@@ -94,6 +108,7 @@ int nntr_hvx_close(remote_handle64 handle) {
       hexkl_weight_u8i8_release(&s->weights_u8i8, i);
     }
   }
+  hvx_worker_pool_destroy(s->quant_pool);
   int res = AEE_SUCCESS;
   if (s->hmx_locked) {
     res = hexkl_micro_hmx_unlock();

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -11,15 +11,19 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <AEEStdErr.h>
+#include <HAP_farf.h>
 #include <remote.h>
 
 #include <hexagon_types.h>
 #include <hvx_hexagon_protos.h>
 #include <qurt.h>
 
+#include "hexkl_micro.h"
 #include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
 
 /** @brief HVX vector width in bytes (128B mode). */
 #define VLEN 128
@@ -28,18 +32,72 @@
 
 int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
   (void)uri;
-  /* No per-session state; a unique non-NULL handle is all FastRPC needs. */
-  void *ctx = malloc(1);
-  if (!ctx) {
+
+  nntr_hvx_session *s = (nntr_hvx_session *)calloc(1, sizeof(nntr_hvx_session));
+  if (!s) {
     return AEE_ENOMEMORY;
   }
-  *handle = (remote_handle64)ctx;
+
+  // hw_init and the HMX lock happen once here, for the session's whole
+  // lifetime, instead of per call (doc15 §3/§4) -- every other entry point
+  // in this skel reaches vtcm_base/vtcm_size/config_off through the
+  // session rather than re-acquiring either.
+  uint32_t hmx_fp16_rate = 0;
+  int res = hexkl_micro_hw_init(&s->vtcm_base, &s->vtcm_size, &hmx_fp16_rate);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: hexkl_micro_hw_init failed: 0x%08x", res);
+    free(s);
+    return res;
+  }
+  // config_off depends only on vtcm_size (see hexkl_mm_u8i4_plan), so it is
+  // computed once here rather than at every mm_u8i4_layer call.
+  const uint32_t config_size = hexkl_micro_hmx_config_size();
+  if (s->vtcm_size < config_size) {
+    free(s);
+    return AEE_ENOMEMORY;
+  }
+  s->config_off =
+    (s->vtcm_size - config_size) & ~(HEXKL_HMX_CONFIG_ALIGNMENT - 1u);
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: hexkl_micro_hmx_lock failed: 0x%08x", res);
+    free(s);
+    return res;
+  }
+  s->hmx_locked = 1;
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(s->vtcm_base, s->config_off);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "nntr_hvx_open: setup_acc_read_int32 failed: 0x%08x", res);
+    hexkl_micro_hmx_unlock();
+    free(s);
+    return res;
+  }
+
+  *handle = (remote_handle64)s;
   return AEE_SUCCESS;
 }
 
 int nntr_hvx_close(remote_handle64 handle) {
-  free((void *)handle);
-  return AEE_SUCCESS;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_SUCCESS;
+  }
+  for (uint32_t i = 0; i < HEXKL_MM_U8I4_MAX_WEIGHTS; ++i) {
+    if (s->weights.slots[i].in_use) {
+      hexkl_weight_u8i4_release(&s->weights, i);
+    }
+  }
+  int res = AEE_SUCCESS;
+  if (s->hmx_locked) {
+    res = hexkl_micro_hmx_unlock();
+    if (res != AEE_SUCCESS) {
+      FARF(ERROR, "nntr_hvx_close: hexkl_micro_hmx_unlock failed: 0x%08x", res);
+    }
+  }
+  free(s);
+  return res;
 }
 
 int nntr_hvx_add_f32(remote_handle64 handle, const float *a, int aLen,

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -39,7 +39,7 @@ int nntr_hvx_open(const char *uri, remote_handle64 *handle) {
   }
 
   // hw_init and the HMX lock happen once here, for the session's whole
-  // lifetime, instead of per call (doc15 §3/§4) -- every other entry point
+  // lifetime, instead of per call -- every other entry point
   // in this skel reaches vtcm_base/vtcm_size/config_off through the
   // session rather than re-acquiring either.
   uint32_t hmx_fp16_rate = 0;

--- a/test/htp/hvx_add_f32.c
+++ b/test/htp/hvx_add_f32.c
@@ -85,8 +85,13 @@ int nntr_hvx_close(remote_handle64 handle) {
     return AEE_SUCCESS;
   }
   for (uint32_t i = 0; i < HEXKL_MM_U8I4_MAX_WEIGHTS; ++i) {
-    if (s->weights.slots[i].in_use) {
-      hexkl_weight_u8i4_release(&s->weights, i);
+    if (s->weights_u8i4.slots[i].in_use) {
+      hexkl_weight_u8i4_release(&s->weights_u8i4, i);
+    }
+  }
+  for (uint32_t i = 0; i < HEXKL_MM_U8I8_MAX_WEIGHTS; ++i) {
+    if (s->weights_u8i8.slots[i].in_use) {
+      hexkl_weight_u8i8_release(&s->weights_u8i8, i);
     }
   }
   int res = AEE_SUCCESS;

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -52,4 +52,22 @@ interface nntr_hvx : remote_handle64 {
                            in sequence<uint32> w_handles,
                            in sequence<float> act_f32,
                            rout sequence<float> out_cat);
+
+   // Same three ops, at the wider weight width. u8i8 keeps the activation
+   // at uint8 (HMX's activation port is always 8-bit) and widens only the
+   // weight, so the accuracy risk relative to u8i4 is narrower -- this is
+   // why it is worth having alongside u8i4 rather than instead of it.
+   AEEResult weight_register_u8i8(in uint32 K, in uint32 N,
+                                  in sequence<int8> w_i8_rm,
+                                  in sequence<float> w_scale,
+                                  in sequence<int32> colsum_w,
+                                  in sequence<float> bias,
+                                  rout uint32 w_handle);
+
+   AEEResult weight_release_u8i8(in uint32 w_handle);
+
+   AEEResult mm_u8i8_layer(in uint32 M, in uint32 K,
+                           in sequence<uint32> w_handles,
+                           in sequence<float> act_f32,
+                           rout sequence<float> out_cat);
 };

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -11,14 +11,6 @@ interface nntr_hvx : remote_handle64 {
    AEEResult add_f32(in sequence<float> a, in sequence<float> b,
                      rout sequence<float> c);
 
-   // Accuracy harness: activation already quantized on the host, so this
-   // isolates the weight bake, the WH layout and the HMX matmul.
-   AEEResult mm_u8i4_from_u8(in uint32 M, in uint32 K, in uint32 N,
-                             in sequence<uint8> act_u8_ah,
-                             in sequence<int8> w_i4_rm,
-                             rout sequence<int32> acc_i32,
-                             rout sequence<uint8> w_wh_dump);
-
    // Accuracy harness: the whole flow, quantization and dequantization on
    // the DSP. Intermediate buffers come back so each stage is checkable.
    AEEResult mm_u8i4_from_f32(in uint32 M, in uint32 K, in uint32 N,

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -25,7 +25,7 @@ interface nntr_hvx : remote_handle64 {
                               rout sequence<int32> acc_i32,
                               rout sequence<float> out_f32);
 
-   // --- Performance path (doc15 §8 item 3) ---
+   // --- Performance path ---
    //
    // Bakes a K x N int4 weight (int4 values in int8 containers, row-major)
    // to WH layout once and keeps it DSP-resident, along with its dequant
@@ -44,8 +44,8 @@ interface nntr_hvx : remote_handle64 {
    // quantized activation -- e.g. a Q/K/V or gate/up projection set. Every
    // handle must have been registered with the same K. Quantizes act_f32
    // once, double-buffers each handle's weight into VTCM with the next
-   // handle prefetched while the current one computes (doc13 §3a
-   // cross-matmul prefetch: 1.7-2x over SDKL on V79), and returns
+   // handle prefetched while the current one computes (cross-matmul
+   // prefetch, measured at 1.7-2x over SDKL on V79), and returns
    // dequantized f32 -- one contiguous M x handle[i].N block per handle in
    // call order.
    AEEResult mm_u8i4_layer(in uint32 M, in uint32 K,

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -24,4 +24,32 @@ interface nntr_hvx : remote_handle64 {
                               rout sequence<int32> act_zp,
                               rout sequence<int32> acc_i32,
                               rout sequence<float> out_f32);
+
+   // --- Performance path (doc15 §8 item 3) ---
+   //
+   // Bakes a K x N int4 weight (int4 values in int8 containers, row-major)
+   // to WH layout once and keeps it DSP-resident, along with its dequant
+   // constants, until weight_release_u8i4. hw_init and the HMX lock happen
+   // once in nntr_hvx_open, not per call -- see nntr_hvx_session.h.
+   AEEResult weight_register_u8i4(in uint32 K, in uint32 N,
+                                  in sequence<int8> w_i4_rm,
+                                  in sequence<float> w_scale,
+                                  in sequence<int32> colsum_w,
+                                  in sequence<float> bias,
+                                  rout uint32 w_handle);
+
+   AEEResult weight_release_u8i4(in uint32 w_handle);
+
+   // Runs matmuls against several registered weights that share ONE
+   // quantized activation -- e.g. a Q/K/V or gate/up projection set. Every
+   // handle must have been registered with the same K. Quantizes act_f32
+   // once, double-buffers each handle's weight into VTCM with the next
+   // handle prefetched while the current one computes (doc13 §3a
+   // cross-matmul prefetch: 1.7-2x over SDKL on V79), and returns
+   // dequantized f32 -- one contiguous M x handle[i].N block per handle in
+   // call order.
+   AEEResult mm_u8i4_layer(in uint32 M, in uint32 K,
+                           in sequence<uint32> w_handles,
+                           in sequence<float> act_f32,
+                           rout sequence<float> out_cat);
 };

--- a/test/htp/nntr_hvx.idl
+++ b/test/htp/nntr_hvx.idl
@@ -10,4 +10,26 @@
 interface nntr_hvx : remote_handle64 {
    AEEResult add_f32(in sequence<float> a, in sequence<float> b,
                      rout sequence<float> c);
+
+   // Accuracy harness: activation already quantized on the host, so this
+   // isolates the weight bake, the WH layout and the HMX matmul.
+   AEEResult mm_u8i4_from_u8(in uint32 M, in uint32 K, in uint32 N,
+                             in sequence<uint8> act_u8_ah,
+                             in sequence<int8> w_i4_rm,
+                             rout sequence<int32> acc_i32,
+                             rout sequence<uint8> w_wh_dump);
+
+   // Accuracy harness: the whole flow, quantization and dequantization on
+   // the DSP. Intermediate buffers come back so each stage is checkable.
+   AEEResult mm_u8i4_from_f32(in uint32 M, in uint32 K, in uint32 N,
+                              in sequence<float> act_f32,
+                              in sequence<int8> w_i4_rm,
+                              in sequence<float> w_scale,
+                              in sequence<int32> colsum_w,
+                              in sequence<float> bias,
+                              rout sequence<uint8> act_u8_ah,
+                              rout sequence<float> act_scale,
+                              rout sequence<int32> act_zp,
+                              rout sequence<int32> acc_i32,
+                              rout sequence<float> out_f32);
 };

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -71,9 +71,9 @@ int nntr_hvx_mm_u8i4_from_f32(
 
   // K1 then K2, writing the AH tiles straight into VTCM.
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp,
-                          s->quant_pool);
+                           s->quant_pool);
   res = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                            s->vtcm_base + L.act_base, s->quant_pool);
+                             s->vtcm_base + L.act_base, s->quant_pool);
   if (res != AEE_SUCCESS) {
     return res;
   }
@@ -159,8 +159,7 @@ int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
          (unsigned)n_total);
     return AEE_EBADPARM;
   }
-  return hexkl_mm_u8i4_layer_run(&s->weights_u8i4, s->vtcm_base, s->vtcm_size,
-                                 s->config_off, M, K, w_handles,
-                                 (uint32_t)w_handlesLen, act_f32, out_cat,
-                                 s->quant_pool);
+  return hexkl_mm_u8i4_layer_run(
+    &s->weights_u8i4, s->vtcm_base, s->vtcm_size, s->config_off, M, K,
+    w_handles, (uint32_t)w_handlesLen, act_f32, out_cat, s->quant_pool);
 }

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -33,8 +33,8 @@
  *        is checkable. Used by unittest_hvx_mm_u8i4's fixed shapes.
  *
  * hw_init and the HMX lock are session-scoped (nntr_hvx_open), not per
- * call, since doc15 §8 item 3 turned this from a call that stood alone into
- * one of several entry points sharing one session. The weight is still
+ * call, since the layer endpoint below turned this from a call that stood
+ * alone into one of several entry points sharing one session. The weight is still
  * baked fresh every call -- that is the point of this harness, checking the
  * bake -- unlike the resident-weight path in mm_u8i4_layer below.
  */
@@ -126,8 +126,8 @@ int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
 /**
  * @brief Runs a layer's worth of matmuls (Q/K/V, or gate/up) against one
  *        shared activation -- see hexkl_mm_u8i4_dma.h. This is the entry
- *        point PR③'s ComputeOps seam will call; nntr_hvx_mm_u8i4_from_f32
- *        above stays the accuracy harness.
+ *        point nntrainer's ComputeOps seam will call once it is wired up;
+ *        nntr_hvx_mm_u8i4_from_f32 above stays the accuracy harness.
  */
 int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
                            const uint32 *w_handles, int w_handlesLen,

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -22,8 +22,8 @@
 #include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
 
-/** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
-#define ROUND_UP(v, a) (((v) + ((a)-1)) & ~((a)-1))
+/** @brief Rounds @a v up to a multiple of @a a. */
+#define ROUND_UP(v, a) ((((v) + ((a)-1)) / (a)) * (a))
 
 /**
  * @brief Brings up HMX and reports the VTCM budget.

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -110,9 +110,9 @@ int nntr_hvx_weight_register_u8i4(remote_handle64 handle, uint32 K, uint32 N,
          (unsigned)N);
     return AEE_EBADPARM;
   }
-  return hexkl_weight_u8i4_register(&s->weights, s->vtcm_base, s->vtcm_size, K,
-                                    N, w_i4_rm, w_scale, colsum_w, bias,
-                                    w_handle);
+  return hexkl_weight_u8i4_register(&s->weights_u8i4, s->vtcm_base,
+                                    s->vtcm_size, K, N, w_i4_rm, w_scale,
+                                    colsum_w, bias, w_handle);
 }
 
 int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
@@ -120,7 +120,7 @@ int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
   if (!s) {
     return AEE_EBADPARM;
   }
-  return hexkl_weight_u8i4_release(&s->weights, w_handle);
+  return hexkl_weight_u8i4_release(&s->weights_u8i4, w_handle);
 }
 
 /**
@@ -145,17 +145,17 @@ int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
   uint32_t n_total = 0;
   for (int i = 0; i < w_handlesLen; ++i) {
     if (w_handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
-        !s->weights.slots[w_handles[i]].in_use) {
+        !s->weights_u8i4.slots[w_handles[i]].in_use) {
       return AEE_EBADPARM;
     }
-    n_total += s->weights.slots[w_handles[i]].N;
+    n_total += s->weights_u8i4.slots[w_handles[i]].N;
   }
   if ((uint32_t)out_catLen != M * n_total) {
     FARF(ERROR, "mm_u8i4_layer: bad out_catLen (M=%u n_total=%u)", (unsigned)M,
          (unsigned)n_total);
     return AEE_EBADPARM;
   }
-  return hexkl_mm_u8i4_layer_run(&s->weights, s->vtcm_base, s->vtcm_size,
+  return hexkl_mm_u8i4_layer_run(&s->weights_u8i4, s->vtcm_base, s->vtcm_size,
                                  s->config_off, M, K, w_handles,
                                  (uint32_t)w_handlesLen, act_f32, out_cat);
 }

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -16,6 +16,7 @@
 #include <HAP_farf.h>
 #include <remote.h>
 
+#include "hexkl_hmx_geom.h"
 #include "hexkl_micro.h"
 #include "hexkl_mm_u8i4.h"
 #include "hexkl_mm_u8i4_dma.h"
@@ -24,8 +25,7 @@
 #include "nntr_hvx.h"
 #include "nntr_hvx_session.h"
 
-/** @brief Rounds @a v up to a multiple of @a a. */
-#define ROUND_UP(v, a) ((((v) + ((a)-1)) / (a)) * (a))
+#define ROUND_UP(v, a) HEXKL_ROUND_UP_U32(v, a)
 
 /**
  * @brief Accuracy harness: the whole flow, quantization and dequantization

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   nntr_hvx_mm_u8i4.c
+ * @date   03 Aug 2026
+ * @brief  FastRPC entry points for the HMX u8i4 accuracy harness
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <string.h>
+
+#include <AEEStdErr.h>
+#include <HAP_farf.h>
+#include <remote.h>
+
+#include "hexkl_micro.h"
+#include "hexkl_mm_u8i4.h"
+#include "nntr_hvx.h"
+
+/** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
+#define ROUND_UP(v, a) (((v) + ((a)-1)) & ~((a)-1))
+
+/**
+ * @brief Brings up HMX and reports the VTCM budget.
+ *
+ * Split out because both entry points need the same preamble, and because
+ * the VTCM size it reports is itself a measurement we do not have yet.
+ */
+static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
+  uint32_t hmx_fp16_rate = 0;
+  int res = hexkl_micro_hw_init(vtcm_base, vtcm_size, &hmx_fp16_rate);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hw_init failed: 0x%08x", res);
+    return res;
+  }
+  FARF(ALWAYS, "vtcm_base=%p vtcm_size=%u config_size=%u hmx_fp16_rate=%u",
+       (void *)*vtcm_base, (unsigned)*vtcm_size,
+       (unsigned)hexkl_micro_hmx_config_size(), (unsigned)hmx_fp16_rate);
+  return AEE_SUCCESS;
+}
+
+int nntr_hvx_mm_u8i4_from_u8(remote_handle64 handle, uint32 M, uint32 K,
+                             uint32 N, const uint8 *act_u8_ah, int act_u8_ahLen,
+                             const int8 *w_i4_rm, int w_i4_rmLen,
+                             int32 *acc_i32, int acc_i32Len, uint8 *w_wh_dump,
+                             int w_wh_dumpLen) {
+  (void)handle;
+
+  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+
+  if ((uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)w_i4_rmLen != K * N ||
+      (uint32_t)acc_i32Len != m_pad * N) {
+    FARF(ERROR, "bad lengths: act=%d w=%d acc=%d (M=%u K=%u N=%u m_pad=%u)",
+         act_u8_ahLen, w_i4_rmLen, acc_i32Len, (unsigned)M, (unsigned)K,
+         (unsigned)N, (unsigned)m_pad);
+    return AEE_EBADPARM;
+  }
+
+  uint8_t *vtcm_base = NULL;
+  uint32_t vtcm_size = 0;
+  int res = hmx_bringup(&vtcm_base, &vtcm_size);
+  if (res != AEE_SUCCESS) {
+    return res;
+  }
+
+  hexkl_mm_u8i4_layout L;
+  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "plan failed: 0x%08x (need w=%u act=%u, vtcm=%u)", res,
+         (unsigned)L.w_size, (unsigned)L.act_size, (unsigned)vtcm_size);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
+  }
+  if (res == AEE_SUCCESS) {
+    // Activation arrives already in AH layout, so a flat copy places it.
+    memcpy(vtcm_base + L.act_base, act_u8_ah, (size_t)m_pad * K);
+    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
+  }
+  if (res == AEE_SUCCESS && w_wh_dumpLen > 0) {
+    const uint32_t n_copy =
+      (uint32_t)w_wh_dumpLen < L.w_size ? (uint32_t)w_wh_dumpLen : L.w_size;
+    memcpy(w_wh_dump, vtcm_base + L.w_base, n_copy);
+  }
+
+  int res2 = hexkl_micro_hmx_unlock();
+  if (res2 != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
+    if (res == AEE_SUCCESS) {
+      res = res2;
+    }
+  }
+  return res;
+}
+
+int nntr_hvx_mm_u8i4_from_f32(
+  remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
+  int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,
+  int w_scaleLen, const int32 *colsum_w, int colsum_wLen, const float *bias,
+  int biasLen, uint8 *act_u8_ah, int act_u8_ahLen, float *act_scale,
+  int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
+  int acc_i32Len, float *out_f32, int out_f32Len) {
+  (void)handle;
+  (void)M;
+  (void)K;
+  (void)N;
+  (void)act_f32;
+  (void)act_f32Len;
+  (void)w_i4_rm;
+  (void)w_i4_rmLen;
+  (void)w_scale;
+  (void)w_scaleLen;
+  (void)colsum_w;
+  (void)colsum_wLen;
+  (void)bias;
+  (void)biasLen;
+  (void)act_u8_ah;
+  (void)act_u8_ahLen;
+  (void)act_scale;
+  (void)act_scaleLen;
+  (void)act_zp;
+  (void)act_zpLen;
+  (void)acc_i32;
+  (void)acc_i32Len;
+  (void)out_f32;
+  (void)out_f32Len;
+  return AEE_EUNSUPPORTED;
+}

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -34,9 +34,9 @@
  *
  * hw_init and the HMX lock are session-scoped (nntr_hvx_open), not per
  * call, since the layer endpoint below turned this from a call that stood
- * alone into one of several entry points sharing one session. The weight is still
- * baked fresh every call -- that is the point of this harness, checking the
- * bake -- unlike the resident-weight path in mm_u8i4_layer below.
+ * alone into one of several entry points sharing one session. The weight is
+ * still baked fresh every call -- that is the point of this harness, checking
+ * the bake -- unlike the resident-weight path in mm_u8i4_layer below.
  */
 int nntr_hvx_mm_u8i4_from_f32(
   remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -18,6 +18,8 @@
 
 #include "hexkl_micro.h"
 #include "hexkl_mm_u8i4.h"
+#include "hvx_dequant_i32.h"
+#include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
 
 /** @brief Rounds @a v up to a multiple of @a a (a must be a power of two). */
@@ -113,28 +115,64 @@ int nntr_hvx_mm_u8i4_from_f32(
   int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
   int acc_i32Len, float *out_f32, int out_f32Len) {
   (void)handle;
-  (void)M;
-  (void)K;
-  (void)N;
-  (void)act_f32;
-  (void)act_f32Len;
-  (void)w_i4_rm;
-  (void)w_i4_rmLen;
-  (void)w_scale;
-  (void)w_scaleLen;
-  (void)colsum_w;
-  (void)colsum_wLen;
-  (void)bias;
-  (void)biasLen;
-  (void)act_u8_ah;
-  (void)act_u8_ahLen;
-  (void)act_scale;
-  (void)act_scaleLen;
-  (void)act_zp;
-  (void)act_zpLen;
-  (void)acc_i32;
-  (void)acc_i32Len;
-  (void)out_f32;
-  (void)out_f32Len;
-  return AEE_EUNSUPPORTED;
+
+  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
+
+  if ((uint32_t)act_f32Len != M * K || (uint32_t)w_i4_rmLen != K * N ||
+      (uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)act_scaleLen != m_pad ||
+      (uint32_t)act_zpLen != m_pad || (uint32_t)acc_i32Len != m_pad * N ||
+      (uint32_t)w_scaleLen != N || (uint32_t)colsum_wLen != N ||
+      (uint32_t)biasLen != N || (uint32_t)out_f32Len != M * N) {
+    FARF(ERROR, "bad lengths (M=%u K=%u N=%u m_pad=%u)", (unsigned)M,
+         (unsigned)K, (unsigned)N, (unsigned)m_pad);
+    return AEE_EBADPARM;
+  }
+
+  uint8_t *vtcm_base = NULL;
+  uint32_t vtcm_size = 0;
+  int res = hmx_bringup(&vtcm_base, &vtcm_size);
+  if (res != AEE_SUCCESS) {
+    return res;
+  }
+
+  hexkl_mm_u8i4_layout L;
+  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "plan failed: 0x%08x", res);
+    return res;
+  }
+
+  // K1 then K2, writing the AH tiles straight into VTCM.
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
+  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                       vtcm_base + L.act_base);
+  memcpy(act_u8_ah, vtcm_base + L.act_base, (size_t)m_pad * K);
+
+  res = hexkl_micro_hmx_lock();
+  if (res != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
+    return res;
+  }
+
+  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
+  }
+  if (res == AEE_SUCCESS) {
+    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
+  }
+
+  if (res == AEE_SUCCESS) {
+    hvx_dequant_i32_to_f32(acc_i32, M, m_pad, N, act_scale, act_zp, colsum_w,
+                           w_scale, bias, out_f32);
+  }
+
+  int res2 = hexkl_micro_hmx_unlock();
+  if (res2 != AEE_SUCCESS) {
+    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
+    if (res == AEE_SUCCESS) {
+      res = res2;
+    }
+  }
+  return res;
 }

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -44,69 +44,6 @@ static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
   return AEE_SUCCESS;
 }
 
-int nntr_hvx_mm_u8i4_from_u8(remote_handle64 handle, uint32 M, uint32 K,
-                             uint32 N, const uint8 *act_u8_ah, int act_u8_ahLen,
-                             const int8 *w_i4_rm, int w_i4_rmLen,
-                             int32 *acc_i32, int acc_i32Len, uint8 *w_wh_dump,
-                             int w_wh_dumpLen) {
-  (void)handle;
-
-  const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
-
-  if ((uint32_t)act_u8_ahLen != m_pad * K || (uint32_t)w_i4_rmLen != K * N ||
-      (uint32_t)acc_i32Len != m_pad * N) {
-    FARF(ERROR, "bad lengths: act=%d w=%d acc=%d (M=%u K=%u N=%u m_pad=%u)",
-         act_u8_ahLen, w_i4_rmLen, acc_i32Len, (unsigned)M, (unsigned)K,
-         (unsigned)N, (unsigned)m_pad);
-    return AEE_EBADPARM;
-  }
-
-  uint8_t *vtcm_base = NULL;
-  uint32_t vtcm_size = 0;
-  int res = hmx_bringup(&vtcm_base, &vtcm_size);
-  if (res != AEE_SUCCESS) {
-    return res;
-  }
-
-  hexkl_mm_u8i4_layout L;
-  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "plan failed: 0x%08x (need w=%u act=%u, vtcm=%u)", res,
-         (unsigned)L.w_size, (unsigned)L.act_size, (unsigned)vtcm_size);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_lock();
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
-  if (res == AEE_SUCCESS) {
-    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
-  }
-  if (res == AEE_SUCCESS) {
-    // Activation arrives already in AH layout, so a flat copy places it.
-    memcpy(vtcm_base + L.act_base, act_u8_ah, (size_t)m_pad * K);
-    res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
-  }
-  if (res == AEE_SUCCESS && w_wh_dumpLen > 0) {
-    const uint32_t n_copy =
-      (uint32_t)w_wh_dumpLen < L.w_size ? (uint32_t)w_wh_dumpLen : L.w_size;
-    memcpy(w_wh_dump, vtcm_base + L.w_base, n_copy);
-  }
-
-  int res2 = hexkl_micro_hmx_unlock();
-  if (res2 != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
-    if (res == AEE_SUCCESS) {
-      res = res2;
-    }
-  }
-  return res;
-}
-
 int nntr_hvx_mm_u8i4_from_f32(
   remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
   int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -18,32 +18,26 @@
 
 #include "hexkl_micro.h"
 #include "hexkl_mm_u8i4.h"
+#include "hexkl_mm_u8i4_dma.h"
 #include "hvx_dequant_i32.h"
 #include "hvx_quant_u8.h"
 #include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
 
 /** @brief Rounds @a v up to a multiple of @a a. */
 #define ROUND_UP(v, a) ((((v) + ((a)-1)) / (a)) * (a))
 
 /**
- * @brief Brings up HMX and reports the VTCM budget.
+ * @brief Accuracy harness: the whole flow, quantization and dequantization
+ *        on the DSP, with every intermediate buffer returned so each stage
+ *        is checkable. Used by unittest_hvx_mm_u8i4's fixed shapes.
  *
- * Split out because both entry points need the same preamble, and because
- * the VTCM size it reports is itself a measurement we do not have yet.
+ * hw_init and the HMX lock are session-scoped (nntr_hvx_open), not per
+ * call, since doc15 §8 item 3 turned this from a call that stood alone into
+ * one of several entry points sharing one session. The weight is still
+ * baked fresh every call -- that is the point of this harness, checking the
+ * bake -- unlike the resident-weight path in mm_u8i4_layer below.
  */
-static int hmx_bringup(uint8_t **vtcm_base, uint32_t *vtcm_size) {
-  uint32_t hmx_fp16_rate = 0;
-  int res = hexkl_micro_hw_init(vtcm_base, vtcm_size, &hmx_fp16_rate);
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hw_init failed: 0x%08x", res);
-    return res;
-  }
-  FARF(ALWAYS, "vtcm_base=%p vtcm_size=%u config_size=%u hmx_fp16_rate=%u",
-       (void *)*vtcm_base, (unsigned)*vtcm_size,
-       (unsigned)hexkl_micro_hmx_config_size(), (unsigned)hmx_fp16_rate);
-  return AEE_SUCCESS;
-}
-
 int nntr_hvx_mm_u8i4_from_f32(
   remote_handle64 handle, uint32 M, uint32 K, uint32 N, const float *act_f32,
   int act_f32Len, const int8 *w_i4_rm, int w_i4_rmLen, const float *w_scale,
@@ -51,7 +45,10 @@ int nntr_hvx_mm_u8i4_from_f32(
   int biasLen, uint8 *act_u8_ah, int act_u8_ahLen, float *act_scale,
   int act_scaleLen, int32 *act_zp, int act_zpLen, int32 *acc_i32,
   int acc_i32Len, float *out_f32, int out_f32Len) {
-  (void)handle;
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
 
   const uint32_t m_pad = ROUND_UP(M, HEXKL_HMX_INT8_BLOCK_N_ROW);
 
@@ -65,15 +62,8 @@ int nntr_hvx_mm_u8i4_from_f32(
     return AEE_EBADPARM;
   }
 
-  uint8_t *vtcm_base = NULL;
-  uint32_t vtcm_size = 0;
-  int res = hmx_bringup(&vtcm_base, &vtcm_size);
-  if (res != AEE_SUCCESS) {
-    return res;
-  }
-
   hexkl_mm_u8i4_layout L;
-  res = hexkl_mm_u8i4_plan(vtcm_base, vtcm_size, m_pad, K, N, &L);
+  int res = hexkl_mm_u8i4_plan(s->vtcm_base, s->vtcm_size, m_pad, K, N, &L);
   if (res != AEE_SUCCESS) {
     FARF(ERROR, "plan failed: 0x%08x", res);
     return res;
@@ -82,19 +72,13 @@ int nntr_hvx_mm_u8i4_from_f32(
   // K1 then K2, writing the AH tiles straight into VTCM.
   hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
   hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                       vtcm_base + L.act_base);
-  memcpy(act_u8_ah, vtcm_base + L.act_base, (size_t)m_pad * K);
+                       s->vtcm_base + L.act_base);
+  memcpy(act_u8_ah, s->vtcm_base + L.act_base, (size_t)m_pad * K);
 
-  res = hexkl_micro_hmx_lock();
-  if (res != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_lock failed: 0x%08x", res);
-    return res;
-  }
-
-  res = hexkl_micro_hmx_setup_acc_read_int32(vtcm_base, L.config_off);
-  if (res == AEE_SUCCESS) {
-    res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
-  }
+  // setup_acc_read_int32 already ran once in nntr_hvx_open for
+  // s->config_off, which hexkl_mm_u8i4_plan recomputes identically here
+  // (it is a pure function of vtcm_size) -- no need to call it again.
+  res = hexkl_mm_u8i4_bake_weights(&L, w_i4_rm, K, N);
   if (res == AEE_SUCCESS) {
     res = hexkl_mm_u8i4_run(&L, m_pad, K, N, acc_i32);
   }
@@ -103,13 +87,75 @@ int nntr_hvx_mm_u8i4_from_f32(
     hvx_dequant_i32_to_f32(acc_i32, M, m_pad, N, act_scale, act_zp, colsum_w,
                            w_scale, bias, out_f32);
   }
-
-  int res2 = hexkl_micro_hmx_unlock();
-  if (res2 != AEE_SUCCESS) {
-    FARF(ERROR, "hexkl_micro_hmx_unlock failed: 0x%08x", res2);
-    if (res == AEE_SUCCESS) {
-      res = res2;
-    }
-  }
   return res;
+}
+
+/**
+ * @brief Bakes a K x N int4 weight once and keeps it resident until
+ *        weight_release_u8i4 -- see hexkl_mm_u8i4_dma.h.
+ */
+int nntr_hvx_weight_register_u8i4(remote_handle64 handle, uint32 K, uint32 N,
+                                  const int8 *w_i4_rm, int w_i4_rmLen,
+                                  const float *w_scale, int w_scaleLen,
+                                  const int32 *colsum_w, int colsum_wLen,
+                                  const float *bias, int biasLen,
+                                  uint32 *w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)w_i4_rmLen != K * N || (uint32_t)w_scaleLen != N ||
+      (uint32_t)colsum_wLen != N || (uint32_t)biasLen != N) {
+    FARF(ERROR, "weight_register_u8i4: bad lengths (K=%u N=%u)", (unsigned)K,
+         (unsigned)N);
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i4_register(&s->weights, s->vtcm_base, s->vtcm_size,
+                                    K, N, w_i4_rm, w_scale, colsum_w, bias,
+                                    w_handle);
+}
+
+int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i4_release(&s->weights, w_handle);
+}
+
+/**
+ * @brief Runs a layer's worth of matmuls (Q/K/V, or gate/up) against one
+ *        shared activation -- see hexkl_mm_u8i4_dma.h. This is the entry
+ *        point PR③'s ComputeOps seam will call; nntr_hvx_mm_u8i4_from_f32
+ *        above stays the accuracy harness.
+ */
+int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
+                           const uint32 *w_handles, int w_handlesLen,
+                           const float *act_f32, int act_f32Len,
+                           float *out_cat, int out_catLen) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s || w_handlesLen <= 0) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)act_f32Len != M * K) {
+    FARF(ERROR, "mm_u8i4_layer: bad act_f32Len (M=%u K=%u)", (unsigned)M,
+         (unsigned)K);
+    return AEE_EBADPARM;
+  }
+  uint32_t n_total = 0;
+  for (int i = 0; i < w_handlesLen; ++i) {
+    if (w_handles[i] >= HEXKL_MM_U8I4_MAX_WEIGHTS ||
+        !s->weights.slots[w_handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    n_total += s->weights.slots[w_handles[i]].N;
+  }
+  if ((uint32_t)out_catLen != M * n_total) {
+    FARF(ERROR, "mm_u8i4_layer: bad out_catLen (M=%u n_total=%u)",
+         (unsigned)M, (unsigned)n_total);
+    return AEE_EBADPARM;
+  }
+  return hexkl_mm_u8i4_layer_run(&s->weights, s->vtcm_base, s->vtcm_size,
+                                 s->config_off, M, K, w_handles,
+                                 (uint32_t)w_handlesLen, act_f32, out_cat);
 }

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -110,8 +110,8 @@ int nntr_hvx_weight_register_u8i4(remote_handle64 handle, uint32 K, uint32 N,
          (unsigned)N);
     return AEE_EBADPARM;
   }
-  return hexkl_weight_u8i4_register(&s->weights, s->vtcm_base, s->vtcm_size,
-                                    K, N, w_i4_rm, w_scale, colsum_w, bias,
+  return hexkl_weight_u8i4_register(&s->weights, s->vtcm_base, s->vtcm_size, K,
+                                    N, w_i4_rm, w_scale, colsum_w, bias,
                                     w_handle);
 }
 
@@ -131,8 +131,8 @@ int nntr_hvx_weight_release_u8i4(remote_handle64 handle, uint32 w_handle) {
  */
 int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
                            const uint32 *w_handles, int w_handlesLen,
-                           const float *act_f32, int act_f32Len,
-                           float *out_cat, int out_catLen) {
+                           const float *act_f32, int act_f32Len, float *out_cat,
+                           int out_catLen) {
   nntr_hvx_session *s = (nntr_hvx_session *)handle;
   if (!s || w_handlesLen <= 0) {
     return AEE_EBADPARM;
@@ -151,8 +151,8 @@ int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
     n_total += s->weights.slots[w_handles[i]].N;
   }
   if ((uint32_t)out_catLen != M * n_total) {
-    FARF(ERROR, "mm_u8i4_layer: bad out_catLen (M=%u n_total=%u)",
-         (unsigned)M, (unsigned)n_total);
+    FARF(ERROR, "mm_u8i4_layer: bad out_catLen (M=%u n_total=%u)", (unsigned)M,
+         (unsigned)n_total);
     return AEE_EBADPARM;
   }
   return hexkl_mm_u8i4_layer_run(&s->weights, s->vtcm_base, s->vtcm_size,

--- a/test/htp/nntr_hvx_mm_u8i4.c
+++ b/test/htp/nntr_hvx_mm_u8i4.c
@@ -70,9 +70,13 @@ int nntr_hvx_mm_u8i4_from_f32(
   }
 
   // K1 then K2, writing the AH tiles straight into VTCM.
-  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp);
-  hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
-                       s->vtcm_base + L.act_base);
+  hvx_quant_rows_u8_params(act_f32, M, m_pad, K, act_scale, act_zp,
+                          s->quant_pool);
+  res = hvx_quant_pack_u8_ah(act_f32, M, m_pad, K, act_scale, act_zp,
+                            s->vtcm_base + L.act_base, s->quant_pool);
+  if (res != AEE_SUCCESS) {
+    return res;
+  }
   memcpy(act_u8_ah, s->vtcm_base + L.act_base, (size_t)m_pad * K);
 
   // setup_acc_read_int32 already ran once in nntr_hvx_open for
@@ -157,5 +161,6 @@ int nntr_hvx_mm_u8i4_layer(remote_handle64 handle, uint32 M, uint32 K,
   }
   return hexkl_mm_u8i4_layer_run(&s->weights_u8i4, s->vtcm_base, s->vtcm_size,
                                  s->config_off, M, K, w_handles,
-                                 (uint32_t)w_handlesLen, act_f32, out_cat);
+                                 (uint32_t)w_handlesLen, act_f32, out_cat,
+                                 s->quant_pool);
 }

--- a/test/htp/nntr_hvx_mm_u8i8.c
+++ b/test/htp/nntr_hvx_mm_u8i8.c
@@ -82,5 +82,6 @@ int nntr_hvx_mm_u8i8_layer(remote_handle64 handle, uint32 M, uint32 K,
   }
   return hexkl_mm_u8i8_layer_run(&s->weights_u8i8, s->vtcm_base, s->vtcm_size,
                                  s->config_off, M, K, w_handles,
-                                 (uint32_t)w_handlesLen, act_f32, out_cat);
+                                 (uint32_t)w_handlesLen, act_f32, out_cat,
+                                 s->quant_pool);
 }

--- a/test/htp/nntr_hvx_mm_u8i8.c
+++ b/test/htp/nntr_hvx_mm_u8i8.c
@@ -80,8 +80,7 @@ int nntr_hvx_mm_u8i8_layer(remote_handle64 handle, uint32 M, uint32 K,
          (unsigned)n_total);
     return AEE_EBADPARM;
   }
-  return hexkl_mm_u8i8_layer_run(&s->weights_u8i8, s->vtcm_base, s->vtcm_size,
-                                 s->config_off, M, K, w_handles,
-                                 (uint32_t)w_handlesLen, act_f32, out_cat,
-                                 s->quant_pool);
+  return hexkl_mm_u8i8_layer_run(
+    &s->weights_u8i8, s->vtcm_base, s->vtcm_size, s->config_off, M, K,
+    w_handles, (uint32_t)w_handlesLen, act_f32, out_cat, s->quant_pool);
 }

--- a/test/htp/nntr_hvx_mm_u8i8.c
+++ b/test/htp/nntr_hvx_mm_u8i8.c
@@ -56,8 +56,8 @@ int nntr_hvx_weight_release_u8i8(remote_handle64 handle, uint32 w_handle) {
 
 int nntr_hvx_mm_u8i8_layer(remote_handle64 handle, uint32 M, uint32 K,
                            const uint32 *w_handles, int w_handlesLen,
-                           const float *act_f32, int act_f32Len,
-                           float *out_cat, int out_catLen) {
+                           const float *act_f32, int act_f32Len, float *out_cat,
+                           int out_catLen) {
   nntr_hvx_session *s = (nntr_hvx_session *)handle;
   if (!s || w_handlesLen <= 0) {
     return AEE_EBADPARM;
@@ -76,12 +76,11 @@ int nntr_hvx_mm_u8i8_layer(remote_handle64 handle, uint32 M, uint32 K,
     n_total += s->weights_u8i8.slots[w_handles[i]].N;
   }
   if ((uint32_t)out_catLen != M * n_total) {
-    FARF(ERROR, "mm_u8i8_layer: bad out_catLen (M=%u n_total=%u)",
-         (unsigned)M, (unsigned)n_total);
+    FARF(ERROR, "mm_u8i8_layer: bad out_catLen (M=%u n_total=%u)", (unsigned)M,
+         (unsigned)n_total);
     return AEE_EBADPARM;
   }
-  return hexkl_mm_u8i8_layer_run(&s->weights_u8i8, s->vtcm_base,
-                                 s->vtcm_size, s->config_off, M, K,
-                                 w_handles, (uint32_t)w_handlesLen, act_f32,
-                                 out_cat);
+  return hexkl_mm_u8i8_layer_run(&s->weights_u8i8, s->vtcm_base, s->vtcm_size,
+                                 s->config_off, M, K, w_handles,
+                                 (uint32_t)w_handlesLen, act_f32, out_cat);
 }

--- a/test/htp/nntr_hvx_mm_u8i8.c
+++ b/test/htp/nntr_hvx_mm_u8i8.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   nntr_hvx_mm_u8i8.c
+ * @date   06 Aug 2026
+ * @brief  FastRPC entry points for the u8i8 performance path
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Mirrors nntr_hvx_mm_u8i4.c's weight_register_u8i4/weight_release_u8i4/
+ * mm_u8i4_layer trio, at the wider weight width. There is no u8i8
+ * accuracy-harness endpoint to mirror nntr_hvx_mm_u8i4_from_f32: u8i8 was
+ * never given one in #4236, and none is added here -- the layer endpoint
+ * is checked directly against the same per-weight integer reference the
+ * u8i4 tests use (unittest_hvx_mm_u8i4.cpp's HmxMmU8I8Layer fixture).
+ */
+
+#include <AEEStdErr.h>
+#include <HAP_farf.h>
+#include <remote.h>
+
+#include "hexkl_mm_u8i8_dma.h"
+#include "nntr_hvx.h"
+#include "nntr_hvx_session.h"
+
+int nntr_hvx_weight_register_u8i8(remote_handle64 handle, uint32 K, uint32 N,
+                                  const int8 *w_i8_rm, int w_i8_rmLen,
+                                  const float *w_scale, int w_scaleLen,
+                                  const int32 *colsum_w, int colsum_wLen,
+                                  const float *bias, int biasLen,
+                                  uint32 *w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)w_i8_rmLen != K * N || (uint32_t)w_scaleLen != N ||
+      (uint32_t)colsum_wLen != N || (uint32_t)biasLen != N) {
+    FARF(ERROR, "weight_register_u8i8: bad lengths (K=%u N=%u)", (unsigned)K,
+         (unsigned)N);
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i8_register(&s->weights_u8i8, s->vtcm_base,
+                                    s->vtcm_size, K, N, w_i8_rm, w_scale,
+                                    colsum_w, bias, w_handle);
+}
+
+int nntr_hvx_weight_release_u8i8(remote_handle64 handle, uint32 w_handle) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s) {
+    return AEE_EBADPARM;
+  }
+  return hexkl_weight_u8i8_release(&s->weights_u8i8, w_handle);
+}
+
+int nntr_hvx_mm_u8i8_layer(remote_handle64 handle, uint32 M, uint32 K,
+                           const uint32 *w_handles, int w_handlesLen,
+                           const float *act_f32, int act_f32Len,
+                           float *out_cat, int out_catLen) {
+  nntr_hvx_session *s = (nntr_hvx_session *)handle;
+  if (!s || w_handlesLen <= 0) {
+    return AEE_EBADPARM;
+  }
+  if ((uint32_t)act_f32Len != M * K) {
+    FARF(ERROR, "mm_u8i8_layer: bad act_f32Len (M=%u K=%u)", (unsigned)M,
+         (unsigned)K);
+    return AEE_EBADPARM;
+  }
+  uint32_t n_total = 0;
+  for (int i = 0; i < w_handlesLen; ++i) {
+    if (w_handles[i] >= HEXKL_MM_U8I8_MAX_WEIGHTS ||
+        !s->weights_u8i8.slots[w_handles[i]].in_use) {
+      return AEE_EBADPARM;
+    }
+    n_total += s->weights_u8i8.slots[w_handles[i]].N;
+  }
+  if ((uint32_t)out_catLen != M * n_total) {
+    FARF(ERROR, "mm_u8i8_layer: bad out_catLen (M=%u n_total=%u)",
+         (unsigned)M, (unsigned)n_total);
+    return AEE_EBADPARM;
+  }
+  return hexkl_mm_u8i8_layer_run(&s->weights_u8i8, s->vtcm_base,
+                                 s->vtcm_size, s->config_off, M, K,
+                                 w_handles, (uint32_t)w_handlesLen, act_f32,
+                                 out_cat);
+}

--- a/test/htp/nntr_hvx_session.h
+++ b/test/htp/nntr_hvx_session.h
@@ -20,9 +20,9 @@
 /**
  * @brief State held for the lifetime of one nntr_hvx_open()/close() pair.
  *
- * hw_init and the HMX lock happen once in open() rather than per call (doc15
- * §3/§4): every FastRPC entry point in this file reaches its VTCM arena and
- * weight table through the session instead of re-acquiring either. This
+ * hw_init and the HMX lock happen once in open() rather than per call:
+ * every FastRPC entry point in this skel reaches its VTCM arena and weight
+ * table through the session instead of re-acquiring either. This
  * assumes one open session at a time -- hexkl_micro_hw_init is a singleton
  * DSP resource, so a second concurrent open would contend for the same VTCM
  * arena and HMX lock. nntrainer opens exactly one HTP session per process,

--- a/test/htp/nntr_hvx_session.h
+++ b/test/htp/nntr_hvx_session.h
@@ -16,6 +16,7 @@
 #include <stdint.h>
 
 #include "hexkl_mm_u8i4_dma.h"
+#include "hexkl_mm_u8i8_dma.h"
 
 /**
  * @brief State held for the lifetime of one nntr_hvx_open()/close() pair.
@@ -34,7 +35,8 @@ typedef struct {
   uint32_t vtcm_size;
   uint32_t config_off; /**< session-constant: depends only on vtcm_size */
   int hmx_locked;      /**< close() only unlocks/finalizes what open() set up */
-  hexkl_weight_u8i4_table weights;
+  hexkl_weight_u8i4_table weights_u8i4;
+  hexkl_weight_u8i8_table weights_u8i8;
 } nntr_hvx_session;
 
 #endif /* __NNTR_HVX_SESSION_H__ */

--- a/test/htp/nntr_hvx_session.h
+++ b/test/htp/nntr_hvx_session.h
@@ -17,6 +17,7 @@
 
 #include "hexkl_mm_u8i4_dma.h"
 #include "hexkl_mm_u8i8_dma.h"
+#include "hvx_worker_pool.h"
 
 /**
  * @brief State held for the lifetime of one nntr_hvx_open()/close() pair.
@@ -37,6 +38,7 @@ typedef struct {
   int hmx_locked;      /**< close() only unlocks/finalizes what open() set up */
   hexkl_weight_u8i4_table weights_u8i4;
   hexkl_weight_u8i8_table weights_u8i8;
+  hvx_worker_pool *quant_pool; /**< sized from the HVX unit count in open() */
 } nntr_hvx_session;
 
 #endif /* __NNTR_HVX_SESSION_H__ */

--- a/test/htp/nntr_hvx_session.h
+++ b/test/htp/nntr_hvx_session.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 SeungHui Lee <shsh1004.lee@samsung.com>
+ *
+ * @file   nntr_hvx_session.h
+ * @date   06 Aug 2026
+ * @brief  Per-session HMX/VTCM state and the u8i4 weight registry
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author SeungHui Lee <shsh1004.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
+ */
+
+#ifndef __NNTR_HVX_SESSION_H__
+#define __NNTR_HVX_SESSION_H__
+
+#include <stdint.h>
+
+#include "hexkl_mm_u8i4_dma.h"
+
+/**
+ * @brief State held for the lifetime of one nntr_hvx_open()/close() pair.
+ *
+ * hw_init and the HMX lock happen once in open() rather than per call (doc15
+ * §3/§4): every FastRPC entry point in this file reaches its VTCM arena and
+ * weight table through the session instead of re-acquiring either. This
+ * assumes one open session at a time -- hexkl_micro_hw_init is a singleton
+ * DSP resource, so a second concurrent open would contend for the same VTCM
+ * arena and HMX lock. nntrainer opens exactly one HTP session per process,
+ * so that is not a real constraint today; it would need addressing before
+ * this skel served more than one client process at once.
+ */
+typedef struct {
+  uint8_t *vtcm_base;
+  uint32_t vtcm_size;
+  uint32_t config_off; /**< session-constant: depends only on vtcm_size */
+  int hmx_locked;      /**< close() only unlocks/finalizes what open() set up */
+  hexkl_weight_u8i4_table weights;
+} nntr_hvx_session;
+
+#endif /* __NNTR_HVX_SESSION_H__ */

--- a/test/htp/run_u8i4_layer_on_device.sh
+++ b/test/htp/run_u8i4_layer_on_device.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Builds the DSP skel + the ARM gtest for the u8i4 layer endpoint and runs
-# them on a connected device.
+# Builds the DSP skel + the ARM gtest for the u8i4 AND u8i8 layer endpoints
+# and runs them on a connected device. Both live in one gtest binary
+# (unittest_hvx_mm_u8i4 despite the name -- it predates the u8i8 fixture),
+# so one run covers both.
 #
 # What this checks, in order:
 #   1. DSP skel compiles clean against HexKL (-Wall -Werror)
 #   2. libnntrainer.so + the ARM gtest binary build for arm64-v8a
-#   3. unittest_hvx_mm_u8i4 passes on-device -- both the original accuracy
-#      harness (Shape1-4) and the layer-endpoint tests
-#   4. the reported layer_x4/harness speedup lands near the 1.7-2x the
-#      cross-matmul prefetch was measured at (printed, not asserted -- see
-#      ReportPerCallCost's comment)
+#   3. unittest_hvx_mm_u8i4 passes on-device -- the original u8i4 accuracy
+#      harness (Shape1-4), the u8i4 layer-endpoint tests, and the u8i8
+#      layer-endpoint tests
+#   4. the reported layer_x4/harness speedup (u8i4) lands near the 1.7-2x
+#      the cross-matmul prefetch was measured at, and the u8i8-vs-u8i4 ratio
+#      is sane (both printed, not asserted -- see the ReportPerCallCost*
+#      tests' comments)
 #
 # Required, with no default -- these are per-machine install paths, and a
 # guessed one fails later and less clearly than an unset one does here:
@@ -159,7 +163,7 @@ adb shell "cd $DEVICE_TMP && \
 
 echo
 log "Summary"
-grep -E "^\[  (PASSED|FAILED)|U8I4_FIELD" "$RUN_LOG" || true
+grep -E "^\[  (PASSED|FAILED)|U8I[48]_FIELD" "$RUN_LOG" || true
 echo
 echo "Full log: $RUN_LOG"
 echo "Gate to clear before building on top of this: all PASSED, and the"

--- a/test/htp/run_u8i4_layer_on_device.sh
+++ b/test/htp/run_u8i4_layer_on_device.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds the DSP skel + the ARM gtest for the u8i4 layer endpoint
+# (HTP_PR_PLAN.md PR① / doc15 §8 item 3) and runs it on a connected device.
+#
+# What this checks, in order:
+#   1. DSP skel compiles clean against HexKL beta2 (-Wall -Werror)
+#   2. libnntrainer.so + the ARM gtest binary build for arm64-v8a
+#   3. unittest_hvx_mm_u8i4 passes on-device -- both the original accuracy
+#      harness (Shape1-4) and the new layer-endpoint tests
+#   4. the reported layer_x4/harness speedup lands near doc13 §3a's
+#      1.7-2x (printed, not asserted -- see ReportPerCallCost's comment)
+#
+# Override any of these if your paths differ:
+: "${HEXAGON_SDK_ROOT:=$HOME/workspace/Hexagon_SDK/6.4.0.2}"
+: "${HEXKL_ROOT:=$HOME/workspace/hxkl-beta2/hexkl_addon}"   # beta2, NOT the
+                                                            # one under
+                                                            # Hexagon_SDK/*/addons/
+: "${HEXKL_SDK_VER:=6.4.0.2}"
+: "${ANDROID_NDK:=$HOME/workspace/android-ndk-r26d}"
+: "${DEVICE_TMP:=/data/local/tmp/htp_u8i4_layer_test}"
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+log()  { echo -e "\n\033[1;36m==> $*\033[0m"; }
+fail() { echo -e "\033[1;31mFAILED: $*\033[0m" >&2; exit 1; }
+
+for v in HEXAGON_SDK_ROOT HEXKL_ROOT ANDROID_NDK; do
+  [ -d "${!v}" ] || fail "$v does not exist: ${!v}"
+done
+
+export HEXAGON_SDK_ROOT
+export DEFAULT_HEXAGON_TOOLS_ROOT="$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/19.0.04"
+[ -d "$DEFAULT_HEXAGON_TOOLS_ROOT" ] ||
+  fail "Hexagon tools not at $DEFAULT_HEXAGON_TOOLS_ROOT -- check the toolchain version dir name"
+
+if ! adb get-state >/dev/null 2>&1; then
+  fail "no device visible to adb -- check 'adb devices'"
+fi
+DEVICE="$(adb get-serialno)"
+echo "device: $DEVICE"
+
+# --- 1. DSP skel -----------------------------------------------------------
+log "1/4  Building the DSP skel (test/htp/build.sh, HexKL $HEXKL_SDK_VER)"
+(
+  cd "$REPO_ROOT/test/htp"
+  HEXKL_ROOT="$HEXKL_ROOT" HEXKL_SDK_VER="$HEXKL_SDK_VER" bash build.sh
+)
+SKEL="$REPO_ROOT/test/htp/build/libnntr_hvx_skel.so"
+[ -f "$SKEL" ] || fail "skel did not build: $SKEL"
+
+# --- 2. libnntrainer.so for arm64-v8a --------------------------------------
+# unittest_hvx_mm_u8i4 does not itself call into nntrainer, but Android.mk's
+# PREBUILT_SHARED_LIBRARY entries for it are parsed unconditionally, so the
+# .so must exist on disk before ndk-build will process ANY target in this
+# file. -Denable-htp is not required for this test (it never goes through
+# nntrainer's HtpComputeOps seam), but matches what PR③ will eventually need
+# from the same builddir, so building it now saves a second full rebuild.
+LIBNNTRAINER="$REPO_ROOT/builddir/jni/arm64-v8a/libnntrainer.so"
+if [ -f "$LIBNNTRAINER" ]; then
+  log "2/4  libnntrainer.so already built, skipping (rm -rf builddir to force)"
+else
+  log "2/4  Building libnntrainer.so for arm64-v8a (tools/package_android.sh)"
+  # subprojects/iniparser (and occasionally others) can be an unfetched
+  # wrap-git placeholder in a fresh worktree -- same class of gotcha as the
+  # googletest one below, just tripped by the android build instead of the
+  # host one.
+  if [ ! -f "$REPO_ROOT/subprojects/iniparser/src/iniparser.c" ]; then
+    echo "  subprojects/iniparser looks unfetched -- running git submodule update"
+    git -C "$REPO_ROOT" submodule update --init subprojects/iniparser
+  fi
+  (
+    cd "$REPO_ROOT"
+    ANDROID_NDK="$ANDROID_NDK" PATH="$ANDROID_NDK:$PATH" \
+      ./tools/package_android.sh --arm-arch=armv8.2-a -Dwerror=false
+  )
+fi
+[ -f "$LIBNNTRAINER" ] || fail "libnntrainer.so did not build: $LIBNNTRAINER"
+
+# --- 3. ARM gtest -----------------------------------------------------------
+log "3/4  Building unittest_hvx_mm_u8i4 (ndk-build, arm64-v8a)"
+GTEST_SUBMODULE="$REPO_ROOT/subprojects/googletest"
+if [ ! -f "$GTEST_SUBMODULE/googletest/include/gtest/gtest.h" ]; then
+  echo "  googletest submodule looks unfetched -- running git submodule update"
+  git -C "$REPO_ROOT" submodule update --init subprojects/googletest
+fi
+# test/jni/Android.mk's googletest_main module expects ./googletest/{src,include}
+# relative to test/jni/ -- there is no setup script that creates this, so do
+# it here rather than committing a real copy into the tree.
+if [ ! -e "$REPO_ROOT/test/jni/googletest" ]; then
+  ln -sfn "$GTEST_SUBMODULE/googletest" "$REPO_ROOT/test/jni/googletest"
+fi
+(
+  cd "$REPO_ROOT/test/jni"
+  export ANDROID_NDK
+  # Override, do not rely on the default: this shell's profile may already
+  # export NNTRAINER_ROOT pointing at a different checkout (it does on at
+  # least one dev machine this was verified on), which Android.mk's
+  # ifndef-guarded default silently defers to.
+  "$ANDROID_NDK/ndk-build" \
+    NDK_PROJECT_PATH=. NDK_APPLICATION_MK=./Application.mk \
+    APP_BUILD_SCRIPT=./Android.mk \
+    NNTRAINER_ROOT="$REPO_ROOT" \
+    HEXAGON_SDK_ROOT="$HEXAGON_SDK_ROOT" \
+    unittest_hvx_mm_u8i4
+)
+TEST_BIN="$REPO_ROOT/test/jni/obj/local/arm64-v8a/unittest_hvx_mm_u8i4"
+[ -f "$TEST_BIN" ] || fail "test binary did not build: $TEST_BIN"
+
+# --- 4. push + run -----------------------------------------------------------
+log "4/4  Pushing to $DEVICE:$DEVICE_TMP and running"
+adb shell "mkdir -p $DEVICE_TMP"
+adb push "$SKEL" "$DEVICE_TMP/" >/dev/null
+adb push "$TEST_BIN" "$DEVICE_TMP/" >/dev/null
+# c++_shared runtime the test binary links against (APP_STL in Application.mk)
+CXX_SHARED="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so"
+[ -f "$CXX_SHARED" ] && adb push "$CXX_SHARED" "$DEVICE_TMP/" >/dev/null
+
+echo "  (unsigned-PD enable happens inside the test itself via remote_session_control)"
+adb shell "cd $DEVICE_TMP && \
+  chmod +x unittest_hvx_mm_u8i4 && \
+  LD_LIBRARY_PATH=$DEVICE_TMP ADSP_LIBRARY_PATH=$DEVICE_TMP \
+  ./unittest_hvx_mm_u8i4" 2>&1 | tee /tmp/hvx_mm_u8i4_device_run.log
+
+echo
+log "Summary"
+grep -E "^\[  (PASSED|FAILED)|U8I4_FIELD" /tmp/hvx_mm_u8i4_device_run.log || true
+echo
+echo "Full log: /tmp/hvx_mm_u8i4_device_run.log"
+echo "Gate to clear before starting PR②/③: all PASSED, and the printed"
+echo "U8I4_FIELD path=layer_x4 field=speedup_vs_harness value=... should be"
+echo "in the neighbourhood of 1.7-2 (doc13 §3a). If it is not, stop and find"
+echo "out why before building anything on top of this."

--- a/test/htp/run_u8i4_layer_on_device.sh
+++ b/test/htp/run_u8i4_layer_on_device.sh
@@ -1,30 +1,42 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Builds the DSP skel + the ARM gtest for the u8i4 layer endpoint
-# (HTP_PR_PLAN.md PR① / doc15 §8 item 3) and runs it on a connected device.
+# Builds the DSP skel + the ARM gtest for the u8i4 layer endpoint and runs
+# them on a connected device.
 #
 # What this checks, in order:
-#   1. DSP skel compiles clean against HexKL beta2 (-Wall -Werror)
+#   1. DSP skel compiles clean against HexKL (-Wall -Werror)
 #   2. libnntrainer.so + the ARM gtest binary build for arm64-v8a
 #   3. unittest_hvx_mm_u8i4 passes on-device -- both the original accuracy
-#      harness (Shape1-4) and the new layer-endpoint tests
-#   4. the reported layer_x4/harness speedup lands near doc13 §3a's
-#      1.7-2x (printed, not asserted -- see ReportPerCallCost's comment)
+#      harness (Shape1-4) and the layer-endpoint tests
+#   4. the reported layer_x4/harness speedup lands near the 1.7-2x the
+#      cross-matmul prefetch was measured at (printed, not asserted -- see
+#      ReportPerCallCost's comment)
 #
-# Override any of these if your paths differ:
-: "${HEXAGON_SDK_ROOT:=$HOME/workspace/Hexagon_SDK/6.4.0.2}"
-: "${HEXKL_ROOT:=$HOME/workspace/hxkl-beta2/hexkl_addon}"   # beta2, NOT the
-                                                            # one under
-                                                            # Hexagon_SDK/*/addons/
-: "${HEXKL_SDK_VER:=6.4.0.2}"
-: "${ANDROID_NDK:=$HOME/workspace/android-ndk-r26d}"
-: "${DEVICE_TMP:=/data/local/tmp/htp_u8i4_layer_test}"
+# Required, with no default -- these are per-machine install paths, and a
+# guessed one fails later and less clearly than an unset one does here:
+#   HEXAGON_SDK_ROOT  Hexagon SDK install (its directory name is the version
+#                     test/htp/build.sh looks for under HEXKL_ROOT/lib)
+#   HEXKL_ROOT        hexkl_addon install. NOT the copy under
+#                     Hexagon_SDK/*/addons/ -- that one has no v79 micro lib
+#   ANDROID_NDK       NDK install used for the arm64-v8a build
+#
+# Optional:
+#   DEVICE_TMP        on-device scratch dir (default below)
+#   HEXAGON_TOOLS_VER Hexagon toolchain dir name under tools/HEXAGON_Tools;
+#                     auto-detected when exactly one is installed
 
 set -eu
 
+: "${HEXAGON_SDK_ROOT:?set HEXAGON_SDK_ROOT to your Hexagon SDK install}"
+: "${HEXKL_ROOT:?set HEXKL_ROOT to your hexkl_addon path}"
+: "${ANDROID_NDK:?set ANDROID_NDK to your NDK install}"
+: "${DEVICE_TMP:=/data/local/tmp/htp_u8i4_layer_test}"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RUN_LOG="${RUN_LOG:-$(mktemp -t hvx_mm_u8i4_device_run.XXXXXX.log)}"
 
 log()  { echo -e "\n\033[1;36m==> $*\033[0m"; }
 fail() { echo -e "\033[1;31mFAILED: $*\033[0m" >&2; exit 1; }
@@ -34,9 +46,19 @@ for v in HEXAGON_SDK_ROOT HEXKL_ROOT ANDROID_NDK; do
 done
 
 export HEXAGON_SDK_ROOT
-export DEFAULT_HEXAGON_TOOLS_ROOT="$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/19.0.04"
+# The toolchain directory carries a version in its name that moves with the
+# SDK, so pin it only when there is a choice to make.
+TOOLS_DIR="$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools"
+if [ -n "${HEXAGON_TOOLS_VER:-}" ]; then
+  export DEFAULT_HEXAGON_TOOLS_ROOT="$TOOLS_DIR/$HEXAGON_TOOLS_VER"
+else
+  n_tools=$(find "$TOOLS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
+  [ "$n_tools" -eq 1 ] ||
+    fail "found $n_tools toolchains under $TOOLS_DIR -- set HEXAGON_TOOLS_VER to the one to use"
+  export DEFAULT_HEXAGON_TOOLS_ROOT="$(find "$TOOLS_DIR" -mindepth 1 -maxdepth 1 -type d)"
+fi
 [ -d "$DEFAULT_HEXAGON_TOOLS_ROOT" ] ||
-  fail "Hexagon tools not at $DEFAULT_HEXAGON_TOOLS_ROOT -- check the toolchain version dir name"
+  fail "Hexagon tools not at $DEFAULT_HEXAGON_TOOLS_ROOT"
 
 if ! adb get-state >/dev/null 2>&1; then
   fail "no device visible to adb -- check 'adb devices'"
@@ -45,10 +67,10 @@ DEVICE="$(adb get-serialno)"
 echo "device: $DEVICE"
 
 # --- 1. DSP skel -----------------------------------------------------------
-log "1/4  Building the DSP skel (test/htp/build.sh, HexKL $HEXKL_SDK_VER)"
+log "1/4  Building the DSP skel (test/htp/build.sh)"
 (
   cd "$REPO_ROOT/test/htp"
-  HEXKL_ROOT="$HEXKL_ROOT" HEXKL_SDK_VER="$HEXKL_SDK_VER" bash build.sh
+  HEXKL_ROOT="$HEXKL_ROOT" bash build.sh
 )
 SKEL="$REPO_ROOT/test/htp/build/libnntr_hvx_skel.so"
 [ -f "$SKEL" ] || fail "skel did not build: $SKEL"
@@ -58,8 +80,9 @@ SKEL="$REPO_ROOT/test/htp/build/libnntr_hvx_skel.so"
 # PREBUILT_SHARED_LIBRARY entries for it are parsed unconditionally, so the
 # .so must exist on disk before ndk-build will process ANY target in this
 # file. -Denable-htp is not required for this test (it never goes through
-# nntrainer's HtpComputeOps seam), but matches what PR③ will eventually need
-# from the same builddir, so building it now saves a second full rebuild.
+# nntrainer's HtpComputeOps seam), but matches what the CausalLM-side work
+# will eventually need from the same builddir, so building it now saves a
+# second full rebuild.
 LIBNNTRAINER="$REPO_ROOT/builddir/jni/arm64-v8a/libnntrainer.so"
 if [ -f "$LIBNNTRAINER" ]; then
   log "2/4  libnntrainer.so already built, skipping (rm -rf builddir to force)"
@@ -116,22 +139,29 @@ log "4/4  Pushing to $DEVICE:$DEVICE_TMP and running"
 adb shell "mkdir -p $DEVICE_TMP"
 adb push "$SKEL" "$DEVICE_TMP/" >/dev/null
 adb push "$TEST_BIN" "$DEVICE_TMP/" >/dev/null
-# c++_shared runtime the test binary links against (APP_STL in Application.mk)
-CXX_SHARED="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so"
-[ -f "$CXX_SHARED" ] && adb push "$CXX_SHARED" "$DEVICE_TMP/" >/dev/null
+# c++_shared runtime the test binary links against (APP_STL in Application.mk).
+# The prebuilt directory is named after the build host, so glob it rather
+# than assuming linux-x86_64.
+CXX_SHARED=$(find "$ANDROID_NDK/toolchains/llvm/prebuilt" \
+  -path "*/aarch64-linux-android/libc++_shared.so" -print -quit 2>/dev/null || true)
+if [ -n "$CXX_SHARED" ]; then
+  adb push "$CXX_SHARED" "$DEVICE_TMP/" >/dev/null
+else
+  echo "  warning: libc++_shared.so not found under $ANDROID_NDK -- the test"
+  echo "  will fail to load unless the device already has a copy"
+fi
 
 echo "  (unsigned-PD enable happens inside the test itself via remote_session_control)"
 adb shell "cd $DEVICE_TMP && \
   chmod +x unittest_hvx_mm_u8i4 && \
   LD_LIBRARY_PATH=$DEVICE_TMP ADSP_LIBRARY_PATH=$DEVICE_TMP \
-  ./unittest_hvx_mm_u8i4" 2>&1 | tee /tmp/hvx_mm_u8i4_device_run.log
+  ./unittest_hvx_mm_u8i4" 2>&1 | tee "$RUN_LOG"
 
 echo
 log "Summary"
-grep -E "^\[  (PASSED|FAILED)|U8I4_FIELD" /tmp/hvx_mm_u8i4_device_run.log || true
+grep -E "^\[  (PASSED|FAILED)|U8I4_FIELD" "$RUN_LOG" || true
 echo
-echo "Full log: /tmp/hvx_mm_u8i4_device_run.log"
-echo "Gate to clear before starting PR②/③: all PASSED, and the printed"
-echo "U8I4_FIELD path=layer_x4 field=speedup_vs_harness value=... should be"
-echo "in the neighbourhood of 1.7-2 (doc13 §3a). If it is not, stop and find"
-echo "out why before building anything on top of this."
+echo "Full log: $RUN_LOG"
+echo "Gate to clear before building on top of this: all PASSED, and the"
+echo "printed U8I4_FIELD path=layer_x4 field=speedup_vs_harness value=..."
+echo "in the neighbourhood of 1.7-2. If it is not, stop and find out why."

--- a/test/jni/Android.mk
+++ b/test/jni/Android.mk
@@ -924,4 +924,27 @@ LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
 LOCAL_STATIC_LIBRARIES := googletest_main
 
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := unittest_hvx_mm_u8i4
+LOCAL_CFLAGS := -Igoogletest/include -pthread -fexceptions -O3 -DNDK_BUILD=1
+LOCAL_CXXFLAGS += -std=c++17 -frtti -fexceptions
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := \
+	 ../unittest/unittest_hvx_mm_u8i4.cpp \
+	 ../htp/generated/nntr_hvx_stub.c
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/../htp/generated \
+	 $(HEXAGON_SDK_ROOT)/incs \
+	 $(HEXAGON_SDK_ROOT)/incs/stddef \
+	 $(HEXAGON_SDK_ROOT)/ipc/fastrpc/incs
+
+LOCAL_LDLIBS += -L$(HEXAGON_SDK_ROOT)/ipc/fastrpc/remote/ship/android_aarch64 \
+	 -lcdsprpc
+
+LOCAL_STATIC_LIBRARIES := googletest_main
+
+include $(BUILD_EXECUTABLE)
 endif

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -138,9 +138,8 @@ void quantize_weights_qs4cx(const std::vector<float> &w_f32, uint32_t K,
  *        parametrizing qs4cx over the range: that function's name and
  *        callers are already tied to QS4CX specifically.
  */
-void quantize_weights_symmetric_i8(const std::vector<float> &w_f32,
-                                   uint32_t K, uint32_t N,
-                                   std::vector<int8_t> &q_w,
+void quantize_weights_symmetric_i8(const std::vector<float> &w_f32, uint32_t K,
+                                   uint32_t N, std::vector<int8_t> &q_w,
                                    std::vector<float> &d,
                                    std::vector<int32_t> &colsum) {
   q_w.assign(static_cast<size_t>(K) * N, 0);
@@ -782,8 +781,8 @@ protected:
 
     w.handle = 0xFFFFFFFFu;
     int err = nntr_hvx_weight_register_u8i8(
-      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()),
-      w.d.data(), static_cast<int>(w.d.size()), w.colsum.data(),
+      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()), w.d.data(),
+      static_cast<int>(w.d.size()), w.colsum.data(),
       static_cast<int>(w.colsum.size()), w.bias.data(),
       static_cast<int>(w.bias.size()), &w.handle);
     ASSERT_EQ(err, AEE_SUCCESS) << "weight_register_u8i8 failed: " << hex(err);
@@ -940,10 +939,9 @@ TEST_F(HmxMmU8I8Layer, ReportPerCallCostVsU8I4) {
   }
   std::vector<float> out8(static_cast<size_t>(M) * n_total8, 0.0f);
   const double u8i8_x4_us = time_us([&] {
-    nntr_hvx_mm_u8i8_layer(handle_, M, K, hs8.data(),
-                           static_cast<int>(hs8.size()), x.data(),
-                           static_cast<int>(x.size()), out8.data(),
-                           static_cast<int>(out8.size()));
+    nntr_hvx_mm_u8i8_layer(
+      handle_, M, K, hs8.data(), static_cast<int>(hs8.size()), x.data(),
+      static_cast<int>(x.size()), out8.data(), static_cast<int>(out8.size()));
   });
 
   std::vector<int8_t> q_w4;

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -154,6 +154,40 @@ void ref_int_matmul(const std::vector<uint8_t> &u_rm,
   }
 }
 
+/**
+ * @brief Dequantization reference.
+ *
+ * out[m][n] = (acc[m][n] - zp[m]*colsum[n]) * scale[m] * d[n] + bias[n]
+ *
+ * The correction term comes from feeding HMX unsigned activations:
+ *   sum_k x*w = sum_k s*(u - zp) * d*q_w
+ *             = s*d * (sum_k u*q_w  -  zp * sum_k q_w)
+ * and sum_k q_w is colsum, which the weights alone determine.
+ *
+ * |acc| <= 255*8*K and |zp*colsum| <= 255*8*K, so the difference stays
+ * inside int32 and both operands are exactly representable in f32 (below
+ * 2^24), which is why the DSP may do the correction in either domain.
+ *
+ * @param[in] acc m_pad by n, row-major
+ * @param[out] out m_valid by n, row-major
+ */
+void ref_dequant(const std::vector<int32_t> &acc, uint32_t m_valid, uint32_t N,
+                 const std::vector<float> &act_scale,
+                 const std::vector<int32_t> &act_zp,
+                 const std::vector<int32_t> &colsum,
+                 const std::vector<float> &d, const std::vector<float> &bias,
+                 std::vector<float> &out) {
+  out.assign(static_cast<size_t>(m_valid) * N, 0.0f);
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      const int32_t corrected =
+        acc[static_cast<size_t>(m) * N + n] - act_zp[m] * colsum[n];
+      out[static_cast<size_t>(m) * N + n] =
+        static_cast<float>(corrected) * act_scale[m] * d[n] + bias[n];
+    }
+  }
+}
+
 /** @brief Deterministic pseudo-random fill in [-1, 1). */
 void fill_deterministic(std::vector<float> &v, uint32_t seed) {
   uint32_t s = seed;
@@ -162,6 +196,74 @@ void fill_deterministic(std::vector<float> &v, uint32_t seed) {
     v[i] = static_cast<float>(static_cast<int32_t>(s >> 8)) /
              static_cast<float>(1 << 23) -
            1.0f;
+  }
+}
+
+/**
+ * @brief Per-row asymmetric uint8 activation quantization: scale and zp.
+ *
+ * x[m][k] is recovered as scale[m] * (u[m][k] - zp[m]).
+ *
+ * Padded rows (m >= m_valid) get scale 1 and zp 0. Their uint8 values are
+ * zero, which does not decode to zero -- s*(0-zp) is nonzero whenever zp
+ * is -- so their outputs are meaningless. Rows are independent in a
+ * matmul so valid rows are unaffected; fixing scale and zp for pad rows
+ * just makes the host reference easy to keep identical to the DSP.
+ */
+void quantize_act_rows(const std::vector<float> &x, uint32_t m_valid,
+                       uint32_t m_pad, uint32_t K, std::vector<float> &scale,
+                       std::vector<int32_t> &zp) {
+  scale.assign(m_pad, 1.0f);
+  zp.assign(m_pad, 0);
+
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    float min0 = x[static_cast<size_t>(m) * K];
+    float max0 = min0;
+    for (uint32_t k = 0; k < K; ++k) {
+      const float v = x[static_cast<size_t>(m) * K + k];
+      min0 = std::min(min0, v);
+      max0 = std::max(max0, v);
+    }
+    const float rmin = std::min(0.0f, min0);
+    const float rmax = std::max(0.0f, max0);
+    if (rmin == rmax) {
+      scale[m] = 1.0f;
+      zp[m] = 0;
+      continue;
+    }
+    scale[m] = (rmax - rmin) / 255.0f;
+    int32_t z = static_cast<int32_t>(std::nearbyint(-rmin / scale[m]));
+    zp[m] = std::max(0, std::min(255, z));
+  }
+}
+
+/**
+ * @brief Per-row asymmetric uint8 activation quantization: the values.
+ *
+ * std::nearbyint, not std::round: this value is computed independently on
+ * the DSP and compared byte for byte, and HVX's float add rounds to
+ * nearest-even. std::round (half away from zero) would disagree at exact
+ * .5. Weight quantization uses std::round because it runs on the host
+ * only -- see quantize_weights_qs4cx.
+ *
+ * @param[out] u_rm row-major uint8, m_pad by K
+ */
+void quantize_act_values(const std::vector<float> &x, uint32_t m_valid,
+                         uint32_t m_pad, uint32_t K,
+                         const std::vector<float> &scale,
+                         const std::vector<int32_t> &zp,
+                         std::vector<uint8_t> &u_rm) {
+  u_rm.assign(static_cast<size_t>(m_pad) * K, 0);
+  for (uint32_t m = 0; m < m_valid; ++m) {
+    const float inv_s = 1.0f / scale[m];
+    for (uint32_t k = 0; k < K; ++k) {
+      // Reciprocal multiply, matching the DSP kernel: f32 a/b and a*(1/b)
+      // can differ by 1 ULP, which breaks the S1 byte-exact check.
+      const float q = std::nearbyint(x[static_cast<size_t>(m) * K + k] * inv_s);
+      int32_t v = static_cast<int32_t>(q) + zp[m];
+      v = std::max(0, std::min(255, v));
+      u_rm[static_cast<size_t>(m) * K + k] = static_cast<uint8_t>(v);
+    }
   }
 }
 
@@ -268,6 +370,124 @@ TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
               << ((i % 32 == 31) ? "\n" : " ");
   }
   std::cout << std::dec << std::flush;
+}
+
+TEST_F(HmxMmU8I4, S1_ActivationQuantMatchesHost) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  std::vector<float> bias(N);
+  fill_deterministic(bias, 0x5EED0003u);
+
+  std::vector<float> exp_scale;
+  std::vector<int32_t> exp_zp;
+  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+  std::vector<uint8_t> exp_u_rm;
+  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+  std::vector<uint8_t> exp_ah;
+  pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
+  std::vector<int32_t> exp_acc;
+  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+
+  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> got_scale(m_pad, 0.0f);
+  std::vector<int32_t> got_zp(m_pad, -1);
+  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_from_f32(
+    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+    static_cast<int>(bias.size()), got_ah.data(),
+    static_cast<int>(got_ah.size()), got_scale.data(),
+    static_cast<int>(got_scale.size()), got_zp.data(),
+    static_cast<int>(got_zp.size()), got_acc.data(),
+    static_cast<int>(got_acc.size()), got_out.data(),
+    static_cast<int>(got_out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
+      << "scale[" << m << "]";
+    EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
+  }
+  EXPECT_EQ(got_ah, exp_ah);
+
+  // The activation the HMX actually consumed now comes from the HVX
+  // kernel, so this re-checks S2 end to end rather than with a fixed
+  // pattern.
+  EXPECT_EQ(got_acc, exp_acc);
+}
+
+TEST_F(HmxMmU8I4, S3_DequantMatchesHost) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  std::vector<float> bias(N);
+  fill_deterministic(bias, 0x5EED0003u);
+
+  std::vector<float> exp_scale;
+  std::vector<int32_t> exp_zp;
+  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+  std::vector<uint8_t> exp_u_rm;
+  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+  std::vector<int32_t> exp_acc;
+  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+  std::vector<float> exp_out;
+  ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
+
+  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> got_scale(m_pad, 0.0f);
+  std::vector<int32_t> got_zp(m_pad, -1);
+  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_from_f32(
+    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+    static_cast<int>(bias.size()), got_ah.data(),
+    static_cast<int>(got_ah.size()), got_scale.data(),
+    static_cast<int>(got_scale.size()), got_zp.data(),
+    static_cast<int>(got_zp.size()), got_acc.data(),
+    static_cast<int>(got_acc.size()), got_out.data(),
+    static_cast<int>(got_out.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+  ASSERT_EQ(got_acc, exp_acc) << "accumulator diverged; S3 is meaningless";
+
+  size_t reported = 0;
+  for (uint32_t m = 0; m < M; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      const size_t i = static_cast<size_t>(m) * N + n;
+      const float tol = std::abs(exp_out[i]) * 1e-5f + 1e-6f;
+      if (std::abs(got_out[i] - exp_out[i]) > tol && reported < 10) {
+        ++reported;
+        ADD_FAILURE() << "out[" << m << "][" << n << "] = " << got_out[i]
+                      << ", expected " << exp_out[i];
+      }
+      EXPECT_NEAR(got_out[i], exp_out[i], tol);
+    }
+  }
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -624,10 +624,10 @@ TEST_F(HmxMmU8I4Layer, MismatchedKIsRejected) {
 /**
  * @brief Per-call cost of the harness endpoint against the layer endpoint.
  *
- * Printed, never asserted. doc13 §3a measured 1.7-2x for cross-matmul
- * prefetch on a V79, but that was inside a standalone DSP program with no
- * FastRPC in the timed region, and thermal state moves these numbers
- * between runs -- a threshold here would encode the lab conditions rather
+ * Printed, never asserted. Cross-matmul prefetch measured 1.7-2x on a
+ * V79, but that was inside a standalone DSP program with no FastRPC in the
+ * timed region, and thermal state moves these numbers between runs -- a
+ * threshold here would encode the lab conditions rather
  * than a property of the code. Read the ratio, do not gate on it.
  */
 TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
@@ -682,8 +682,8 @@ TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
             << std::endl;
 
   // Several weights per call is where the prefetch has something to hide
-  // behind; x1 above cannot show it by construction (doc13 §3a: a single
-  // matmul is parity).
+  // behind; x1 above cannot show it by construction -- with a single
+  // matmul there is nothing to overlap the transfer with, so it is parity.
   std::vector<Weight> ws(4);
   std::vector<uint32_t> hs;
   uint32_t n_total = 0;

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -132,6 +132,47 @@ void quantize_weights_qs4cx(const std::vector<float> &w_f32, uint32_t K,
 }
 
 /**
+ * @brief Per-channel symmetric int8 weight quantization -- same shape as
+ *        quantize_weights_qs4cx, at the full int8 range [-128, 127]
+ *        instead of int4's [-8, 7]. Kept separate rather than
+ *        parametrizing qs4cx over the range: that function's name and
+ *        callers are already tied to QS4CX specifically.
+ */
+void quantize_weights_symmetric_i8(const std::vector<float> &w_f32,
+                                   uint32_t K, uint32_t N,
+                                   std::vector<int8_t> &q_w,
+                                   std::vector<float> &d,
+                                   std::vector<int32_t> &colsum) {
+  q_w.assign(static_cast<size_t>(K) * N, 0);
+  d.assign(N, 0.0f);
+  colsum.assign(N, 0);
+
+  for (uint32_t n = 0; n < N; ++n) {
+    float min0 = w_f32[n];
+    float max0 = min0;
+    for (uint32_t k = 0; k < K; ++k) {
+      const float v = w_f32[static_cast<size_t>(k) * N + n];
+      min0 = std::min(min0, v);
+      max0 = std::max(max0, v);
+    }
+    const float rmin = std::min(0.0f, min0);
+    const float rmax = std::max(0.0f, max0);
+    const float scale = (rmin == rmax) ? 1.0f : 255.0f / (rmax - rmin);
+
+    int32_t sum = 0;
+    for (uint32_t k = 0; k < K; ++k) {
+      int32_t q = static_cast<int32_t>(
+        std::round(w_f32[static_cast<size_t>(k) * N + n] * scale));
+      q = std::max(-128, std::min(127, q));
+      q_w[static_cast<size_t>(k) * N + n] = static_cast<int8_t>(q);
+      sum += q;
+    }
+    d[n] = 1.0f / scale;
+    colsum[n] = sum;
+  }
+}
+
+/**
  * @brief Integer reference matmul: uint8 activation by int4 weight.
  *
  * Deterministic integer arithmetic, so the HMX result must match this bit
@@ -707,6 +748,235 @@ TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
   EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
   for (const auto &ww : ws) {
     EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, ww.handle), AEE_SUCCESS);
+  }
+}
+
+/**
+ * @brief u8i8's counterpart to HmxMmU8I4Layer. Same tests, same shapes,
+ *        the wider weight quantizer, and the _u8i8 entry points --
+ *        mirrored rather than templated on width for the same reason
+ *        hexkl_mm_u8i8_dma.c mirrors hexkl_mm_u8i4_dma.c: the u8i4 side
+ *        is proven, and a shared test fixture parametrised on width would
+ *        need re-verifying that it still exercises u8i4 correctly to
+ *        trust either.
+ */
+class HmxMmU8I8Layer : public HmxMmU8I4 {
+protected:
+  struct Weight {
+    uint32_t handle;
+    uint32_t N;
+    std::vector<int8_t> q_w;
+    std::vector<float> d;
+    std::vector<int32_t> colsum;
+    std::vector<float> bias;
+    std::vector<float> w_f32;
+  };
+
+  void MakeAndRegister(uint32_t K, uint32_t N, uint32_t seed, Weight &w) {
+    w.N = N;
+    w.w_f32.resize(static_cast<size_t>(K) * N);
+    fill_deterministic(w.w_f32, seed);
+    quantize_weights_symmetric_i8(w.w_f32, K, N, w.q_w, w.d, w.colsum);
+    w.bias.resize(N);
+    fill_deterministic(w.bias, seed ^ 0xA5A5A5A5u);
+
+    w.handle = 0xFFFFFFFFu;
+    int err = nntr_hvx_weight_register_u8i8(
+      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()),
+      w.d.data(), static_cast<int>(w.d.size()), w.colsum.data(),
+      static_cast<int>(w.colsum.size()), w.bias.data(),
+      static_cast<int>(w.bias.size()), &w.handle);
+    ASSERT_EQ(err, AEE_SUCCESS) << "weight_register_u8i8 failed: " << hex(err);
+    ASSERT_NE(w.handle, 0xFFFFFFFFu) << "handle not written";
+  }
+
+  void ExpectedFor(const Weight &w, const std::vector<float> &x, uint32_t M,
+                   uint32_t K, std::vector<float> &out) {
+    const uint32_t m_pad = round_up(M, kTileRow);
+    std::vector<float> scale;
+    std::vector<int32_t> zp;
+    quantize_act_rows(x, M, m_pad, K, scale, zp);
+    std::vector<uint8_t> u_rm;
+    quantize_act_values(x, M, m_pad, K, scale, zp, u_rm);
+    std::vector<int32_t> acc;
+    ref_int_matmul(u_rm, w.q_w, m_pad, K, w.N, acc);
+    ref_dequant(acc, M, w.N, scale, zp, w.colsum, w.d, w.bias, out);
+  }
+};
+
+TEST_F(HmxMmU8I8Layer, ThreeWeightsMatchPerWeightReference) {
+  const uint32_t M = 64, K = 256;
+  const uint32_t Ns[3] = {128, 256, 64};
+
+  std::vector<Weight> ws(3);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, Ns[i], 0xB0B08001u + i * 0x1000u, ws[i]));
+  }
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  uint32_t n_total = 0;
+  std::vector<uint32_t> handles;
+  for (const auto &w : ws) {
+    handles.push_back(w.handle);
+    n_total += w.N;
+  }
+  std::vector<float> got(static_cast<size_t>(M) * n_total, 0.0f);
+
+  int err = nntr_hvx_mm_u8i8_layer(
+    handle_, M, K, handles.data(), static_cast<int>(handles.size()), x.data(),
+    static_cast<int>(x.size()), got.data(), static_cast<int>(got.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i8_layer failed: " << hex(err);
+
+  size_t off = 0;
+  for (int i = 0; i < 3; ++i) {
+    SCOPED_TRACE("weight " + std::to_string(i) + " N=" + std::to_string(Ns[i]));
+    std::vector<float> want;
+    ExpectedFor(ws[i], x, M, K, want);
+    for (size_t j = 0; j < want.size(); ++j) {
+      EXPECT_NEAR(got[off + j], want[j], std::abs(want[j]) * 1e-5f + 1e-6f)
+        << "element " << j;
+    }
+    off += want.size();
+  }
+
+  for (const auto &w : ws) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i8(handle_, w.handle), AEE_SUCCESS);
+  }
+}
+
+TEST_F(HmxMmU8I8Layer, RegisteredWeightSurvivesRepeatedCalls) {
+  const uint32_t M = 1, K = 512, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xC0FFEE81u, w));
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  const uint32_t handles[1] = {w.handle};
+
+  std::vector<float> first(static_cast<size_t>(M) * N, 0.0f);
+  std::vector<float> second(static_cast<size_t>(M) * N, 1.0f);
+  for (int pass = 0; pass < 2; ++pass) {
+    std::vector<float> &dst = pass == 0 ? first : second;
+    int err = nntr_hvx_mm_u8i8_layer(handle_, M, K, handles, 1, x.data(),
+                                     static_cast<int>(x.size()), dst.data(),
+                                     static_cast<int>(dst.size()));
+    ASSERT_EQ(err, AEE_SUCCESS) << "pass " << pass << ": " << hex(err);
+  }
+  EXPECT_EQ(first, second);
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i8(handle_, w.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I8Layer, ReleasedHandleIsRejectedAndSlotIsReused) {
+  const uint32_t K = 128, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D8001u, w));
+  const uint32_t released = w.handle;
+  ASSERT_EQ(nntr_hvx_weight_release_u8i8(handle_, released), AEE_SUCCESS);
+
+  std::vector<float> x(K, 0.0f);
+  std::vector<float> out(N, 0.0f);
+  const uint32_t handles[1] = {released};
+  EXPECT_NE(nntr_hvx_mm_u8i8_layer(handle_, 1, K, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_NE(nntr_hvx_weight_release_u8i8(handle_, released), AEE_SUCCESS)
+    << "double release accepted";
+
+  Weight w2;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D8002u, w2));
+  EXPECT_EQ(w2.handle, released);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i8(handle_, w2.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I8Layer, MismatchedKIsRejected) {
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(256, 128, 0xE0E08001u, w));
+  const uint32_t handles[1] = {w.handle};
+  std::vector<float> x(128, 0.0f);
+  std::vector<float> out(128, 0.0f);
+  EXPECT_NE(nntr_hvx_mm_u8i8_layer(handle_, 1, 128, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i8(handle_, w.handle), AEE_SUCCESS);
+}
+
+/**
+ * @brief Per-call cost, u8i4 vs u8i8, both through the layer endpoint --
+ *        not against the (u8i4-only) accuracy harness this time, since
+ *        there is no u8i8 harness to compare against. Printed, not
+ *        asserted, for the same reason as HmxMmU8I4Layer.ReportPerCallCost.
+ */
+TEST_F(HmxMmU8I8Layer, ReportPerCallCostVsU8I4) {
+  const uint32_t M = 64, K = 1024, N = 1024;
+  const int kReps = 20;
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  auto time_us = [&](const std::function<void()> &fn) {
+    fn();
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kReps; ++i) {
+      fn();
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::micro>(t1 - t0).count() / kReps;
+  };
+
+  std::vector<Weight> ws8(4);
+  std::vector<uint32_t> hs8;
+  uint32_t n_total8 = 0;
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, N, 0xF00D9000u + i * 0x100u, ws8[i]));
+    hs8.push_back(ws8[i].handle);
+    n_total8 += ws8[i].N;
+  }
+  std::vector<float> out8(static_cast<size_t>(M) * n_total8, 0.0f);
+  const double u8i8_x4_us = time_us([&] {
+    nntr_hvx_mm_u8i8_layer(handle_, M, K, hs8.data(),
+                           static_cast<int>(hs8.size()), x.data(),
+                           static_cast<int>(x.size()), out8.data(),
+                           static_cast<int>(out8.size()));
+  });
+
+  std::vector<int8_t> q_w4;
+  std::vector<float> d4;
+  std::vector<int32_t> colsum4;
+  std::vector<float> w4_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w4_f32, 0xF00D9101u);
+  quantize_weights_qs4cx(w4_f32, K, N, q_w4, d4, colsum4);
+  std::vector<float> bias4(N);
+  fill_deterministic(bias4, 0xF00D9102u);
+  uint32_t handle4 = 0;
+  ASSERT_EQ(nntr_hvx_weight_register_u8i4(
+              handle_, K, N, q_w4.data(), static_cast<int>(q_w4.size()),
+              d4.data(), static_cast<int>(d4.size()), colsum4.data(),
+              static_cast<int>(colsum4.size()), bias4.data(),
+              static_cast<int>(bias4.size()), &handle4),
+            AEE_SUCCESS);
+  const uint32_t handles4[1] = {handle4};
+  std::vector<float> out4(static_cast<size_t>(M) * N, 0.0f);
+  const double u8i4_x1_us = time_us([&] {
+    nntr_hvx_mm_u8i4_layer(handle_, M, K, handles4, 1, x.data(),
+                           static_cast<int>(x.size()), out4.data(),
+                           static_cast<int>(out4.size()));
+  });
+
+  std::cout << "U8I8_FIELD path=layer_x4 field=us_per_matmul value="
+            << (u8i8_x4_us / 4.0) << std::endl;
+  std::cout << "U8I8_FIELD path=layer_x4_vs_u8i4_x1 field=ratio value="
+            << (u8i4_x1_us / (u8i8_x4_us / 4.0)) << std::endl;
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, handle4), AEE_SUCCESS);
+  for (const auto &w : ws8) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i8(handle_, w.handle), AEE_SUCCESS);
   }
 }
 

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -485,8 +485,8 @@ protected:
 
     w.handle = 0xFFFFFFFFu;
     int err = nntr_hvx_weight_register_u8i4(
-      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()),
-      w.d.data(), static_cast<int>(w.d.size()), w.colsum.data(),
+      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()), w.d.data(),
+      static_cast<int>(w.d.size()), w.colsum.data(),
       static_cast<int>(w.colsum.size()), w.bias.data(),
       static_cast<int>(w.bias.size()), &w.handle);
     ASSERT_EQ(err, AEE_SUCCESS) << "weight_register_u8i4 failed: " << hex(err);
@@ -678,8 +678,8 @@ TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
 
   std::cout << "U8I4_FIELD path=harness  field=us_per_matmul value="
             << harness_us << std::endl;
-  std::cout << "U8I4_FIELD path=layer_x1 field=us_per_matmul value="
-            << layer_us << std::endl;
+  std::cout << "U8I4_FIELD path=layer_x1 field=us_per_matmul value=" << layer_us
+            << std::endl;
 
   // Several weights per call is where the prefetch has something to hide
   // behind; x1 above cannot show it by construction (doc13 §3a: a single
@@ -695,10 +695,9 @@ TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
   }
   std::vector<float> out4(static_cast<size_t>(M) * n_total, 0.0f);
   const double layer4_us = time_us([&] {
-    nntr_hvx_mm_u8i4_layer(handle_, M, K, hs.data(),
-                           static_cast<int>(hs.size()), x.data(),
-                           static_cast<int>(x.size()), out4.data(),
-                           static_cast<int>(out4.size()));
+    nntr_hvx_mm_u8i4_layer(
+      handle_, M, K, hs.data(), static_cast<int>(hs.size()), x.data(),
+      static_cast<int>(x.size()), out4.data(), static_cast<int>(out4.size()));
   });
   std::cout << "U8I4_FIELD path=layer_x4 field=us_per_matmul value="
             << (layer4_us / 4.0) << std::endl;

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 dlwlzzero <dlwlzzero@gmail.com>
+ *
+ * @file   unittest_hvx_mm_u8i4.cpp
+ * @date   03 Aug 2026
+ * @brief  Device test: A8W4 matmul on HMX matches the CPU reference
+ * @see    https://github.com/nntrainer/nntrainer
+ * @author dlwlzzero <dlwlzzero@gmail.com>
+ * @bug    No known bugs except for NYI items
+ *
+ * Runs on an Android device only. Requires libnntr_hvx_skel.so on
+ * ADSP_LIBRARY_PATH. See test/htp/build.sh.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <AEEStdErr.h>
+#include <remote.h>
+
+#include "nntr_hvx.h"
+
+namespace {
+
+/** @brief Render a FastRPC error as hex so the code is searchable. */
+std::string hex(int err) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(8) << std::setfill('0')
+     << static_cast<unsigned>(err);
+  return os.str();
+}
+
+/** @brief Rounds @a v up to a multiple of @a a. */
+constexpr uint32_t round_up(uint32_t v, uint32_t a) {
+  return ((v + a - 1) / a) * a;
+}
+
+/** @brief HMX int8 tile geometry, mirrored from hexkl_micro.h. */
+constexpr uint32_t kTileRow = 64;   // HEXKL_HMX_INT8_BLOCK_N_ROW
+constexpr uint32_t kTileInner = 32; // HEXKL_HMX_INT8_BLOCK_N_INNER
+constexpr uint32_t kTileCol = 32;   // HEXKL_HMX_INT8_BLOCK_N_COL
+constexpr uint32_t kActTileBytes = 2048;
+
+/**
+ * @brief Byte offset of activation element (m, k) in AH layout.
+ *
+ * AH is a tiling, not a shuffle: each 64x32 tile is flat row-major, and
+ * the tiles run in (row_block, inner_tile) order at a 2048-byte stride.
+ */
+inline size_t ah_offset(uint32_t m, uint32_t k, uint32_t K) {
+  const uint32_t n_ktiles = K / kTileInner;
+  const uint32_t rb = m / kTileRow;
+  const uint32_t r = m % kTileRow;
+  const uint32_t kt = k / kTileInner;
+  const uint32_t c = k % kTileInner;
+  return static_cast<size_t>(rb * n_ktiles + kt) * kActTileBytes +
+         r * kTileInner + c;
+}
+
+/** @brief Scatters a row-major uint8 activation into AH layout. */
+void pack_ah_from_rowmajor(const std::vector<uint8_t> &u_rm, uint32_t m_pad,
+                           uint32_t K, std::vector<uint8_t> &out_ah) {
+  out_ah.assign(static_cast<size_t>(m_pad) * K, 0);
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    for (uint32_t k = 0; k < K; ++k) {
+      out_ah[ah_offset(m, k, K)] = u_rm[static_cast<size_t>(m) * K + k];
+    }
+  }
+}
+
+/**
+ * @brief Per-channel symmetric int4 weight quantization.
+ *
+ * Deliberately replicates __fallback_quant_nxk_qs4cx_f32 in
+ * nntrainer/tensor/cpu_backend/fallback/fallback_internal.cpp:713 so a
+ * later cross-check against nntrainer's CPU QS4CX path does not need a
+ * second quantizer. Note it derives the scale from the min/max span but
+ * quantizes symmetrically with no zero point, so skewed channels clamp.
+ *
+ * std::round (half away from zero) is correct here: this runs on the host
+ * only and the DSP consumes the result, so no rounding mismatch is
+ * possible. Activation quantization uses RNE instead -- see quantize_act.
+ *
+ * @param[in]  w_f32 weight matrix, K rows by N columns, row-major
+ * @param[out] q_w   quantized values in [-8, 7], K by N, row-major
+ * @param[out] d     per-channel dequantization multiplier, N entries
+ * @param[out] colsum per-channel sum of q_w over K, N entries
+ */
+void quantize_weights_qs4cx(const std::vector<float> &w_f32, uint32_t K,
+                            uint32_t N, std::vector<int8_t> &q_w,
+                            std::vector<float> &d,
+                            std::vector<int32_t> &colsum) {
+  q_w.assign(static_cast<size_t>(K) * N, 0);
+  d.assign(N, 0.0f);
+  colsum.assign(N, 0);
+
+  for (uint32_t n = 0; n < N; ++n) {
+    float min0 = w_f32[n];
+    float max0 = min0;
+    for (uint32_t k = 0; k < K; ++k) {
+      const float v = w_f32[static_cast<size_t>(k) * N + n];
+      min0 = std::min(min0, v);
+      max0 = std::max(max0, v);
+    }
+    const float rmin = std::min(0.0f, min0);
+    const float rmax = std::max(0.0f, max0);
+    const float scale = (rmin == rmax) ? 1.0f : 15.0f / (rmax - rmin);
+
+    int32_t sum = 0;
+    for (uint32_t k = 0; k < K; ++k) {
+      int32_t q = static_cast<int32_t>(
+        std::round(w_f32[static_cast<size_t>(k) * N + n] * scale));
+      q = std::max(-8, std::min(7, q));
+      q_w[static_cast<size_t>(k) * N + n] = static_cast<int8_t>(q);
+      sum += q;
+    }
+    d[n] = 1.0f / scale;
+    colsum[n] = sum;
+  }
+}
+
+/**
+ * @brief Integer reference matmul: uint8 activation by int4 weight.
+ *
+ * Deterministic integer arithmetic, so the HMX result must match this bit
+ * for bit. |acc| <= 255 * 8 * K, which is 2,088,960 at K=1024 -- three
+ * orders of magnitude inside int32.
+ *
+ * @param[in] u_rm activation, m_pad by K, row-major (NOT AH)
+ * @param[in] q_w  weights, K by N, row-major
+ */
+void ref_int_matmul(const std::vector<uint8_t> &u_rm,
+                    const std::vector<int8_t> &q_w, uint32_t m_pad, uint32_t K,
+                    uint32_t N, std::vector<int32_t> &acc) {
+  acc.assign(static_cast<size_t>(m_pad) * N, 0);
+  for (uint32_t m = 0; m < m_pad; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      int32_t sum = 0;
+      for (uint32_t k = 0; k < K; ++k) {
+        sum += static_cast<int32_t>(u_rm[static_cast<size_t>(m) * K + k]) *
+               static_cast<int32_t>(q_w[static_cast<size_t>(k) * N + n]);
+      }
+      acc[static_cast<size_t>(m) * N + n] = sum;
+    }
+  }
+}
+
+/** @brief Deterministic pseudo-random fill in [-1, 1). */
+void fill_deterministic(std::vector<float> &v, uint32_t seed) {
+  uint32_t s = seed;
+  for (size_t i = 0; i < v.size(); ++i) {
+    s = s * 1664525u + 1013904223u;
+    v[i] = static_cast<float>(static_cast<int32_t>(s >> 8)) /
+             static_cast<float>(1 << 23) -
+           1.0f;
+  }
+}
+
+/**
+ * @brief Opens one unsigned-PD CDSP session for the whole test case.
+ *
+ * A failure here is a hard FAIL rather than a skip: proving the DSP comes
+ * up on the device is the point of this test, so a quiet skip would
+ * report success for the thing being measured.
+ */
+class HmxMmU8I4 : public ::testing::Test {
+protected:
+  void SetUp() override {
+    remote_rpc_control_unsigned_module unsigned_pd = {CDSP_DOMAIN_ID, 1};
+    int err = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE,
+                                     &unsigned_pd, sizeof(unsigned_pd));
+    ASSERT_EQ(err, AEE_SUCCESS) << "enabling unsigned PD failed: " << hex(err);
+
+    const std::string uri = std::string(nntr_hvx_URI) + "&_dom=cdsp";
+    err = nntr_hvx_open(uri.c_str(), &handle_);
+    ASSERT_EQ(err, AEE_SUCCESS)
+      << "nntr_hvx_open failed: " << hex(err)
+      << " -- is libnntr_hvx_skel.so on ADSP_LIBRARY_PATH?";
+  }
+
+  void TearDown() override {
+    if (handle_) {
+      nntr_hvx_close(handle_);
+    }
+  }
+
+  remote_handle64 handle_ = 0;
+};
+
+TEST_F(HmxMmU8I4, HmxBringsUp) {
+  // Task 1 gate: the entry point links against libhexkl_micro.a, hw_init
+  // succeeds and the HMX lock round-trips. Buffers are unused here.
+  std::vector<uint8_t> act(64 * 128, 0);
+  std::vector<int8_t> w(128 * 128, 0);
+  std::vector<int32_t> acc(64 * 128, 0);
+  std::vector<uint8_t> dump(0);
+
+  int err = nntr_hvx_mm_u8i4_from_u8(
+    handle_, 64, 128, 128, act.data(), static_cast<int>(act.size()), w.data(),
+    static_cast<int>(w.size()), acc.data(), static_cast<int>(acc.size()),
+    dump.data(), 0);
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+}
+
+TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
+  const uint32_t M = 64, K = 128, N = 128;
+  const uint32_t m_pad = round_up(M, kTileRow);
+
+  // Host-side weight quantization: fp32 -> per-channel int4.
+  std::vector<float> w_f32(static_cast<size_t>(K) * N);
+  fill_deterministic(w_f32, 0x5EED0001u);
+  std::vector<int8_t> q_w;
+  std::vector<float> d;
+  std::vector<int32_t> colsum;
+  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+  // Host-side activation: an arbitrary but deterministic uint8 pattern.
+  // Activation quantization from fp32 is Task 3; this task isolates the
+  // weight bake, the WH layout and the HMX matmul.
+  std::vector<uint8_t> u_rm(static_cast<size_t>(m_pad) * K);
+  for (size_t i = 0; i < u_rm.size(); ++i) {
+    u_rm[i] = static_cast<uint8_t>((i * 37u + 11u) & 0xFFu);
+  }
+  std::vector<uint8_t> act_ah;
+  pack_ah_from_rowmajor(u_rm, m_pad, K, act_ah);
+
+  std::vector<int32_t> expected;
+  ref_int_matmul(u_rm, q_w, m_pad, K, N, expected);
+
+  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<uint8_t> dump(static_cast<size_t>(K / kTileInner) *
+                            (N / kTileCol) * 512);
+
+  int err = nntr_hvx_mm_u8i4_from_u8(
+    handle_, M, K, N, act_ah.data(), static_cast<int>(act_ah.size()),
+    q_w.data(), static_cast<int>(q_w.size()), acc.data(),
+    static_cast<int>(acc.size()), dump.data(), static_cast<int>(dump.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+
+  size_t mismatches = 0;
+  for (uint32_t m = 0; m < m_pad && mismatches < 10; ++m) {
+    for (uint32_t n = 0; n < N && mismatches < 10; ++n) {
+      const size_t i = static_cast<size_t>(m) * N + n;
+      if (acc[i] != expected[i]) {
+        ++mismatches;
+        ADD_FAILURE() << "acc[" << m << "][" << n << "] = " << acc[i]
+                      << ", expected " << expected[i];
+      }
+    }
+  }
+  EXPECT_EQ(acc, expected);
+
+  // The baked buffer is the WH i4 layout, which HexKL does not document.
+  // Print the first tile so the offline converter has a reference.
+  std::cout << "WH tile 0 (512B, hex):" << std::endl;
+  for (size_t i = 0; i < 512; ++i) {
+    std::cout << std::hex << std::setw(2) << std::setfill('0')
+              << static_cast<unsigned>(dump[i])
+              << ((i % 32 == 31) ? "\n" : " ");
+  }
+  std::cout << std::dec << std::flush;
+}
+
+} // namespace
+
+/**
+ * @brief Main gtest
+ */
+int main(int argc, char **argv) {
+  int result = -1;
+
+  try {
+    testing::InitGoogleTest(&argc, argv);
+  } catch (...) {
+    std::cerr << "Error during IniGoogleTest" << std::endl;
+    return 0;
+  }
+
+  try {
+    result = RUN_ALL_TESTS();
+  } catch (...) {
+    std::cerr << "Error during RUN_ALL_TESTS()" << std::endl;
+  }
+
+  return result;
+}

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -347,7 +347,7 @@ protected:
    * being absorbed into a tolerance. S3 allows f32 ordering slack. S4 is
    * reported, not gated.
    */
-  void CheckShape(uint32_t M, uint32_t K, uint32_t N, bool want_wh_dump) {
+  void CheckShape(uint32_t M, uint32_t K, uint32_t N) {
     SCOPED_TRACE("M=" + std::to_string(M) + " K=" + std::to_string(K) +
                  " N=" + std::to_string(N));
     const uint32_t m_pad = round_up(M, kTileRow);
@@ -431,24 +431,24 @@ protected:
 
 TEST_F(HmxMmU8I4, Shape1_Minimal) {
   // Same dimensions as HexKL's own example, so a failure here is ours.
-  CheckShape(64, 128, 128, /*want_wh_dump=*/true);
+  CheckShape(64, 128, 128);
 }
 
 TEST_F(HmxMmU8I4, Shape2_DecodeSingleToken) {
   // One token padded out to a 64-row tile: the decode case, and the one
   // that exercises the zero-pad path for 63 of 64 rows.
-  CheckShape(1, 1024, 1024, /*want_wh_dump=*/false);
+  CheckShape(1, 1024, 1024);
 }
 
 TEST_F(HmxMmU8I4, Shape3_PrefillQwen3Scale) {
   // Weights alone need (1024/32)*(1024/32)*512 = 512 KiB of VTCM here.
-  CheckShape(64, 1024, 1024, /*want_wh_dump=*/false);
+  CheckShape(64, 1024, 1024);
 }
 
 TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
   // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
   // ever runs with rb=0. This is the one that runs it twice.
-  CheckShape(128, 128, 128, /*want_wh_dump=*/false);
+  CheckShape(128, 128, 128);
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -16,8 +16,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -449,6 +451,264 @@ TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
   // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
   // ever runs with rb=0. This is the one that runs it twice.
   CheckShape(128, 128, 128);
+}
+
+/**
+ * @brief The performance path: weights registered once, several matmuls
+ *        per call sharing one activation.
+ *
+ * Shares HmxMmU8I4's helpers rather than duplicating a reference: the
+ * layer endpoint must produce exactly what calling the accuracy endpoint
+ * once per weight would, so that is what these compare against.
+ */
+class HmxMmU8I4Layer : public HmxMmU8I4 {
+protected:
+  /** @brief One weight plus everything needed to check its output. */
+  struct Weight {
+    uint32_t handle;
+    uint32_t N;
+    std::vector<int8_t> q_w;
+    std::vector<float> d;
+    std::vector<int32_t> colsum;
+    std::vector<float> bias;
+    std::vector<float> w_f32;
+  };
+
+  /** @brief Quantizes a deterministic K x N weight and registers it. */
+  void MakeAndRegister(uint32_t K, uint32_t N, uint32_t seed, Weight &w) {
+    w.N = N;
+    w.w_f32.resize(static_cast<size_t>(K) * N);
+    fill_deterministic(w.w_f32, seed);
+    quantize_weights_qs4cx(w.w_f32, K, N, w.q_w, w.d, w.colsum);
+    w.bias.resize(N);
+    fill_deterministic(w.bias, seed ^ 0xA5A5A5A5u);
+
+    w.handle = 0xFFFFFFFFu;
+    int err = nntr_hvx_weight_register_u8i4(
+      handle_, K, N, w.q_w.data(), static_cast<int>(w.q_w.size()),
+      w.d.data(), static_cast<int>(w.d.size()), w.colsum.data(),
+      static_cast<int>(w.colsum.size()), w.bias.data(),
+      static_cast<int>(w.bias.size()), &w.handle);
+    ASSERT_EQ(err, AEE_SUCCESS) << "weight_register_u8i4 failed: " << hex(err);
+    ASSERT_NE(w.handle, 0xFFFFFFFFu) << "handle not written";
+  }
+
+  /** @brief Host reference for one weight's slice of the concatenated
+   *         output, via the same path the accuracy harness checks. */
+  void ExpectedFor(const Weight &w, const std::vector<float> &x, uint32_t M,
+                   uint32_t K, std::vector<float> &out) {
+    const uint32_t m_pad = round_up(M, kTileRow);
+    std::vector<float> scale;
+    std::vector<int32_t> zp;
+    quantize_act_rows(x, M, m_pad, K, scale, zp);
+    std::vector<uint8_t> u_rm;
+    quantize_act_values(x, M, m_pad, K, scale, zp, u_rm);
+    std::vector<int32_t> acc;
+    ref_int_matmul(u_rm, w.q_w, m_pad, K, w.N, acc);
+    ref_dequant(acc, M, w.N, scale, zp, w.colsum, w.d, w.bias, out);
+  }
+};
+
+TEST_F(HmxMmU8I4Layer, ThreeWeightsMatchPerWeightReference) {
+  // A Q/K/V set: three weights, one shared activation, one call. The
+  // shapes differ in N so a bug that assumes a uniform stride into
+  // out_cat shows up as a mismatch rather than passing by luck.
+  const uint32_t M = 64, K = 256;
+  const uint32_t Ns[3] = {128, 256, 64};
+
+  std::vector<Weight> ws(3);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, Ns[i], 0xB0B00001u + i * 0x1000u, ws[i]));
+  }
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  uint32_t n_total = 0;
+  std::vector<uint32_t> handles;
+  for (const auto &w : ws) {
+    handles.push_back(w.handle);
+    n_total += w.N;
+  }
+  std::vector<float> got(static_cast<size_t>(M) * n_total, 0.0f);
+
+  int err = nntr_hvx_mm_u8i4_layer(
+    handle_, M, K, handles.data(), static_cast<int>(handles.size()), x.data(),
+    static_cast<int>(x.size()), got.data(), static_cast<int>(got.size()));
+  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_layer failed: " << hex(err);
+
+  size_t off = 0;
+  for (int i = 0; i < 3; ++i) {
+    SCOPED_TRACE("weight " + std::to_string(i) + " N=" + std::to_string(Ns[i]));
+    std::vector<float> want;
+    ExpectedFor(ws[i], x, M, K, want);
+    for (size_t j = 0; j < want.size(); ++j) {
+      EXPECT_NEAR(got[off + j], want[j], std::abs(want[j]) * 1e-5f + 1e-6f)
+        << "element " << j;
+    }
+    off += want.size();
+  }
+
+  for (const auto &w : ws) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+  }
+}
+
+TEST_F(HmxMmU8I4Layer, RegisteredWeightSurvivesRepeatedCalls) {
+  // The whole point of registering is that the bake is not repaid per
+  // call, so the second call must return exactly what the first did --
+  // bitwise, since nothing between them is supposed to differ.
+  const uint32_t M = 1, K = 512, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xC0FFEE01u, w));
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+  const uint32_t handles[1] = {w.handle};
+
+  std::vector<float> first(static_cast<size_t>(M) * N, 0.0f);
+  std::vector<float> second(static_cast<size_t>(M) * N, 1.0f);
+  for (int pass = 0; pass < 2; ++pass) {
+    std::vector<float> &dst = pass == 0 ? first : second;
+    int err = nntr_hvx_mm_u8i4_layer(handle_, M, K, handles, 1, x.data(),
+                                     static_cast<int>(x.size()), dst.data(),
+                                     static_cast<int>(dst.size()));
+    ASSERT_EQ(err, AEE_SUCCESS) << "pass " << pass << ": " << hex(err);
+  }
+  EXPECT_EQ(first, second);
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I4Layer, ReleasedHandleIsRejectedAndSlotIsReused) {
+  const uint32_t K = 128, N = 128;
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D0001u, w));
+  const uint32_t released = w.handle;
+  ASSERT_EQ(nntr_hvx_weight_release_u8i4(handle_, released), AEE_SUCCESS);
+
+  // Using a released handle must fail rather than read freed memory.
+  std::vector<float> x(K, 0.0f);
+  std::vector<float> out(N, 0.0f);
+  const uint32_t handles[1] = {released};
+  EXPECT_NE(nntr_hvx_mm_u8i4_layer(handle_, 1, K, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_NE(nntr_hvx_weight_release_u8i4(handle_, released), AEE_SUCCESS)
+    << "double release accepted";
+
+  // The freed slot must come back, or a long-running process leaks handles.
+  Weight w2;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xD00D0002u, w2));
+  EXPECT_EQ(w2.handle, released);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w2.handle), AEE_SUCCESS);
+}
+
+TEST_F(HmxMmU8I4Layer, MismatchedKIsRejected) {
+  // Every handle in one call shares the activation, so a handle baked for
+  // a different K is a caller bug that must not read out of bounds.
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(256, 128, 0xE0E00001u, w));
+  const uint32_t handles[1] = {w.handle};
+  std::vector<float> x(128, 0.0f); // K=128, but the weight was baked at 256
+  std::vector<float> out(128, 0.0f);
+  EXPECT_NE(nntr_hvx_mm_u8i4_layer(handle_, 1, 128, handles, 1, x.data(),
+                                   static_cast<int>(x.size()), out.data(),
+                                   static_cast<int>(out.size())),
+            AEE_SUCCESS);
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+}
+
+/**
+ * @brief Per-call cost of the harness endpoint against the layer endpoint.
+ *
+ * Printed, never asserted. doc13 §3a measured 1.7-2x for cross-matmul
+ * prefetch on a V79, but that was inside a standalone DSP program with no
+ * FastRPC in the timed region, and thermal state moves these numbers
+ * between runs -- a threshold here would encode the lab conditions rather
+ * than a property of the code. Read the ratio, do not gate on it.
+ */
+TEST_F(HmxMmU8I4Layer, ReportPerCallCost) {
+  const uint32_t M = 64, K = 1024, N = 1024;
+  const int kReps = 20;
+
+  std::vector<float> x(static_cast<size_t>(M) * K);
+  fill_deterministic(x, 0x5EED0002u);
+
+  Weight w;
+  ASSERT_NO_FATAL_FAILURE(MakeAndRegister(K, N, 0xF00D0001u, w));
+  const uint32_t handles[1] = {w.handle};
+
+  std::vector<float> out(static_cast<size_t>(M) * N, 0.0f);
+  auto time_us = [&](const std::function<void()> &fn) {
+    fn(); // warm-up, discarded
+    const auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kReps; ++i) {
+      fn();
+    }
+    const auto t1 = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::micro>(t1 - t0).count() / kReps;
+  };
+
+  const uint32_t m_pad = round_up(M, kTileRow);
+  std::vector<uint8_t> ah(static_cast<size_t>(m_pad) * K, 0);
+  std::vector<float> sc(m_pad, 0.0f);
+  std::vector<int32_t> zp(m_pad, 0);
+  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
+  std::vector<float> harness_out(static_cast<size_t>(M) * N, 0.0f);
+
+  const double harness_us = time_us([&] {
+    nntr_hvx_mm_u8i4_from_f32(
+      handle_, M, K, N, x.data(), static_cast<int>(x.size()), w.q_w.data(),
+      static_cast<int>(w.q_w.size()), w.d.data(), static_cast<int>(w.d.size()),
+      w.colsum.data(), static_cast<int>(w.colsum.size()), w.bias.data(),
+      static_cast<int>(w.bias.size()), ah.data(), static_cast<int>(ah.size()),
+      sc.data(), static_cast<int>(sc.size()), zp.data(),
+      static_cast<int>(zp.size()), acc.data(), static_cast<int>(acc.size()),
+      harness_out.data(), static_cast<int>(harness_out.size()));
+  });
+
+  const double layer_us = time_us([&] {
+    nntr_hvx_mm_u8i4_layer(handle_, M, K, handles, 1, x.data(),
+                           static_cast<int>(x.size()), out.data(),
+                           static_cast<int>(out.size()));
+  });
+
+  std::cout << "U8I4_FIELD path=harness  field=us_per_matmul value="
+            << harness_us << std::endl;
+  std::cout << "U8I4_FIELD path=layer_x1 field=us_per_matmul value="
+            << layer_us << std::endl;
+
+  // Several weights per call is where the prefetch has something to hide
+  // behind; x1 above cannot show it by construction (doc13 §3a: a single
+  // matmul is parity).
+  std::vector<Weight> ws(4);
+  std::vector<uint32_t> hs;
+  uint32_t n_total = 0;
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_NO_FATAL_FAILURE(
+      MakeAndRegister(K, N, 0xF00D1000u + i * 0x100u, ws[i]));
+    hs.push_back(ws[i].handle);
+    n_total += ws[i].N;
+  }
+  std::vector<float> out4(static_cast<size_t>(M) * n_total, 0.0f);
+  const double layer4_us = time_us([&] {
+    nntr_hvx_mm_u8i4_layer(handle_, M, K, hs.data(),
+                           static_cast<int>(hs.size()), x.data(),
+                           static_cast<int>(x.size()), out4.data(),
+                           static_cast<int>(out4.size()));
+  });
+  std::cout << "U8I4_FIELD path=layer_x4 field=us_per_matmul value="
+            << (layer4_us / 4.0) << std::endl;
+  std::cout << "U8I4_FIELD path=layer_x4 field=speedup_vs_harness value="
+            << (harness_us / (layer4_us / 4.0)) << std::endl;
+
+  EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, w.handle), AEE_SUCCESS);
+  for (const auto &ww : ws) {
+    EXPECT_EQ(nntr_hvx_weight_release_u8i4(handle_, ww.handle), AEE_SUCCESS);
+  }
 }
 
 } // namespace

--- a/test/unittest/unittest_hvx_mm_u8i4.cpp
+++ b/test/unittest/unittest_hvx_mm_u8i4.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -188,6 +189,47 @@ void ref_dequant(const std::vector<int32_t> &acc, uint32_t m_valid, uint32_t N,
   }
 }
 
+/**
+ * @brief Unquantized fp32 matmul. The yardstick S4 measures against.
+ */
+void ref_fp32_matmul(const std::vector<float> &x, const std::vector<float> &w,
+                     uint32_t M, uint32_t K, uint32_t N,
+                     const std::vector<float> &bias, std::vector<float> &out) {
+  out.assign(static_cast<size_t>(M) * N, 0.0f);
+  for (uint32_t m = 0; m < M; ++m) {
+    for (uint32_t n = 0; n < N; ++n) {
+      float sum = 0.0f;
+      for (uint32_t k = 0; k < K; ++k) {
+        sum +=
+          x[static_cast<size_t>(m) * K + k] * w[static_cast<size_t>(k) * N + n];
+      }
+      out[static_cast<size_t>(m) * N + n] = sum + bias[n];
+    }
+  }
+}
+
+/**
+ * @brief Signal-to-noise ratio in dB between a reference and a result.
+ *
+ * Reported rather than asserted tightly: no measurement exists yet for
+ * what per-channel int4 costs on this workload, and inventing a threshold
+ * before measuring would just encode a guess.
+ */
+double snr_db(const std::vector<float> &ref, const std::vector<float> &got) {
+  double sig = 0.0;
+  double noise = 0.0;
+  for (size_t i = 0; i < ref.size(); ++i) {
+    const double r = ref[i];
+    const double e = static_cast<double>(got[i]) - r;
+    sig += r * r;
+    noise += e * e;
+  }
+  if (noise == 0.0) {
+    return std::numeric_limits<double>::infinity();
+  }
+  return 10.0 * std::log10(sig / noise);
+}
+
 /** @brief Deterministic pseudo-random fill in [-1, 1). */
 void fill_deterministic(std::vector<float> &v, uint32_t seed) {
   uint32_t s = seed;
@@ -296,198 +338,117 @@ protected:
   }
 
   remote_handle64 handle_ = 0;
+
+  /**
+   * @brief Runs S1 through S4 for one shape.
+   *
+   * S1 and S2 are bit-exact: integer arithmetic is deterministic, so any
+   * layout or wiring error shows up as an exact mismatch rather than
+   * being absorbed into a tolerance. S3 allows f32 ordering slack. S4 is
+   * reported, not gated.
+   */
+  void CheckShape(uint32_t M, uint32_t K, uint32_t N, bool want_wh_dump) {
+    SCOPED_TRACE("M=" + std::to_string(M) + " K=" + std::to_string(K) +
+                 " N=" + std::to_string(N));
+    const uint32_t m_pad = round_up(M, kTileRow);
+
+    std::vector<float> w_f32(static_cast<size_t>(K) * N);
+    fill_deterministic(w_f32, 0x5EED0001u);
+    std::vector<int8_t> q_w;
+    std::vector<float> d;
+    std::vector<int32_t> colsum;
+    quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
+
+    std::vector<float> x(static_cast<size_t>(M) * K);
+    fill_deterministic(x, 0x5EED0002u);
+    std::vector<float> bias(N);
+    fill_deterministic(bias, 0x5EED0003u);
+
+    std::vector<float> exp_scale;
+    std::vector<int32_t> exp_zp;
+    quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
+    std::vector<uint8_t> exp_u_rm;
+    quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
+    std::vector<uint8_t> exp_ah;
+    pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
+    std::vector<int32_t> exp_acc;
+    ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
+    std::vector<float> exp_out;
+    ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
+
+    std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
+    std::vector<float> got_scale(m_pad, 0.0f);
+    std::vector<int32_t> got_zp(m_pad, -1);
+    std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
+    std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
+
+    int err = nntr_hvx_mm_u8i4_from_f32(
+      handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
+      static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
+      colsum.data(), static_cast<int>(colsum.size()), bias.data(),
+      static_cast<int>(bias.size()), got_ah.data(),
+      static_cast<int>(got_ah.size()), got_scale.data(),
+      static_cast<int>(got_scale.size()), got_zp.data(),
+      static_cast<int>(got_zp.size()), got_acc.data(),
+      static_cast<int>(got_acc.size()), got_out.data(),
+      static_cast<int>(got_out.size()));
+    ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
+
+    // S1
+    for (uint32_t m = 0; m < m_pad; ++m) {
+      EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
+        << "scale[" << m << "]";
+      EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
+    }
+    EXPECT_EQ(got_ah, exp_ah);
+
+    // S2
+    EXPECT_EQ(got_acc, exp_acc);
+
+    // S3
+    for (size_t i = 0; i < exp_out.size(); ++i) {
+      EXPECT_NEAR(got_out[i], exp_out[i], std::abs(exp_out[i]) * 1e-5f + 1e-6f);
+    }
+
+    // S4 -- measured and printed, deliberately not gated tightly.
+    std::vector<float> fp32_ref;
+    ref_fp32_matmul(x, w_f32, M, K, N, bias, fp32_ref);
+    double max_rel = 0.0;
+    for (size_t i = 0; i < fp32_ref.size(); ++i) {
+      const double denom = std::abs(static_cast<double>(fp32_ref[i]));
+      if (denom > 1e-6) {
+        max_rel = std::max(
+          max_rel,
+          std::abs(static_cast<double>(got_out[i]) - fp32_ref[i]) / denom);
+      }
+    }
+    const double snr = snr_db(fp32_ref, got_out);
+    std::cout << "[S4] M=" << M << " K=" << K << " N=" << N << " SNR=" << snr
+              << " dB  max_rel=" << max_rel << std::endl;
+    EXPECT_GT(snr, 0.0) << "quantized output carries no signal at all";
+  }
 };
 
-TEST_F(HmxMmU8I4, HmxBringsUp) {
-  // Task 1 gate: the entry point links against libhexkl_micro.a, hw_init
-  // succeeds and the HMX lock round-trips. Buffers are unused here.
-  std::vector<uint8_t> act(64 * 128, 0);
-  std::vector<int8_t> w(128 * 128, 0);
-  std::vector<int32_t> acc(64 * 128, 0);
-  std::vector<uint8_t> dump(0);
-
-  int err = nntr_hvx_mm_u8i4_from_u8(
-    handle_, 64, 128, 128, act.data(), static_cast<int>(act.size()), w.data(),
-    static_cast<int>(w.size()), acc.data(), static_cast<int>(acc.size()),
-    dump.data(), 0);
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
+TEST_F(HmxMmU8I4, Shape1_Minimal) {
+  // Same dimensions as HexKL's own example, so a failure here is ours.
+  CheckShape(64, 128, 128, /*want_wh_dump=*/true);
 }
 
-TEST_F(HmxMmU8I4, S2_IntegerAccumulatorIsBitExact) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  // Host-side weight quantization: fp32 -> per-channel int4.
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  // Host-side activation: an arbitrary but deterministic uint8 pattern.
-  // Activation quantization from fp32 is Task 3; this task isolates the
-  // weight bake, the WH layout and the HMX matmul.
-  std::vector<uint8_t> u_rm(static_cast<size_t>(m_pad) * K);
-  for (size_t i = 0; i < u_rm.size(); ++i) {
-    u_rm[i] = static_cast<uint8_t>((i * 37u + 11u) & 0xFFu);
-  }
-  std::vector<uint8_t> act_ah;
-  pack_ah_from_rowmajor(u_rm, m_pad, K, act_ah);
-
-  std::vector<int32_t> expected;
-  ref_int_matmul(u_rm, q_w, m_pad, K, N, expected);
-
-  std::vector<int32_t> acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<uint8_t> dump(static_cast<size_t>(K / kTileInner) *
-                            (N / kTileCol) * 512);
-
-  int err = nntr_hvx_mm_u8i4_from_u8(
-    handle_, M, K, N, act_ah.data(), static_cast<int>(act_ah.size()),
-    q_w.data(), static_cast<int>(q_w.size()), acc.data(),
-    static_cast<int>(acc.size()), dump.data(), static_cast<int>(dump.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_u8 failed: " << hex(err);
-
-  size_t mismatches = 0;
-  for (uint32_t m = 0; m < m_pad && mismatches < 10; ++m) {
-    for (uint32_t n = 0; n < N && mismatches < 10; ++n) {
-      const size_t i = static_cast<size_t>(m) * N + n;
-      if (acc[i] != expected[i]) {
-        ++mismatches;
-        ADD_FAILURE() << "acc[" << m << "][" << n << "] = " << acc[i]
-                      << ", expected " << expected[i];
-      }
-    }
-  }
-  EXPECT_EQ(acc, expected);
-
-  // The baked buffer is the WH i4 layout, which HexKL does not document.
-  // Print the first tile so the offline converter has a reference.
-  std::cout << "WH tile 0 (512B, hex):" << std::endl;
-  for (size_t i = 0; i < 512; ++i) {
-    std::cout << std::hex << std::setw(2) << std::setfill('0')
-              << static_cast<unsigned>(dump[i])
-              << ((i % 32 == 31) ? "\n" : " ");
-  }
-  std::cout << std::dec << std::flush;
+TEST_F(HmxMmU8I4, Shape2_DecodeSingleToken) {
+  // One token padded out to a 64-row tile: the decode case, and the one
+  // that exercises the zero-pad path for 63 of 64 rows.
+  CheckShape(1, 1024, 1024, /*want_wh_dump=*/false);
 }
 
-TEST_F(HmxMmU8I4, S1_ActivationQuantMatchesHost) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  std::vector<float> x(static_cast<size_t>(M) * K);
-  fill_deterministic(x, 0x5EED0002u);
-  std::vector<float> bias(N);
-  fill_deterministic(bias, 0x5EED0003u);
-
-  std::vector<float> exp_scale;
-  std::vector<int32_t> exp_zp;
-  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
-  std::vector<uint8_t> exp_u_rm;
-  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
-  std::vector<uint8_t> exp_ah;
-  pack_ah_from_rowmajor(exp_u_rm, m_pad, K, exp_ah);
-  std::vector<int32_t> exp_acc;
-  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
-
-  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
-  std::vector<float> got_scale(m_pad, 0.0f);
-  std::vector<int32_t> got_zp(m_pad, -1);
-  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
-
-  int err = nntr_hvx_mm_u8i4_from_f32(
-    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
-    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
-    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
-    static_cast<int>(bias.size()), got_ah.data(),
-    static_cast<int>(got_ah.size()), got_scale.data(),
-    static_cast<int>(got_scale.size()), got_zp.data(),
-    static_cast<int>(got_zp.size()), got_acc.data(),
-    static_cast<int>(got_acc.size()), got_out.data(),
-    static_cast<int>(got_out.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
-
-  for (uint32_t m = 0; m < m_pad; ++m) {
-    EXPECT_NEAR(got_scale[m], exp_scale[m], std::abs(exp_scale[m]) * 1e-6f)
-      << "scale[" << m << "]";
-    EXPECT_EQ(got_zp[m], exp_zp[m]) << "zp[" << m << "]";
-  }
-  EXPECT_EQ(got_ah, exp_ah);
-
-  // The activation the HMX actually consumed now comes from the HVX
-  // kernel, so this re-checks S2 end to end rather than with a fixed
-  // pattern.
-  EXPECT_EQ(got_acc, exp_acc);
+TEST_F(HmxMmU8I4, Shape3_PrefillQwen3Scale) {
+  // Weights alone need (1024/32)*(1024/32)*512 = 512 KiB of VTCM here.
+  CheckShape(64, 1024, 1024, /*want_wh_dump=*/false);
 }
 
-TEST_F(HmxMmU8I4, S3_DequantMatchesHost) {
-  const uint32_t M = 64, K = 128, N = 128;
-  const uint32_t m_pad = round_up(M, kTileRow);
-
-  std::vector<float> w_f32(static_cast<size_t>(K) * N);
-  fill_deterministic(w_f32, 0x5EED0001u);
-  std::vector<int8_t> q_w;
-  std::vector<float> d;
-  std::vector<int32_t> colsum;
-  quantize_weights_qs4cx(w_f32, K, N, q_w, d, colsum);
-
-  std::vector<float> x(static_cast<size_t>(M) * K);
-  fill_deterministic(x, 0x5EED0002u);
-  std::vector<float> bias(N);
-  fill_deterministic(bias, 0x5EED0003u);
-
-  std::vector<float> exp_scale;
-  std::vector<int32_t> exp_zp;
-  quantize_act_rows(x, M, m_pad, K, exp_scale, exp_zp);
-  std::vector<uint8_t> exp_u_rm;
-  quantize_act_values(x, M, m_pad, K, exp_scale, exp_zp, exp_u_rm);
-  std::vector<int32_t> exp_acc;
-  ref_int_matmul(exp_u_rm, q_w, m_pad, K, N, exp_acc);
-  std::vector<float> exp_out;
-  ref_dequant(exp_acc, M, N, exp_scale, exp_zp, colsum, d, bias, exp_out);
-
-  std::vector<uint8_t> got_ah(static_cast<size_t>(m_pad) * K, 0);
-  std::vector<float> got_scale(m_pad, 0.0f);
-  std::vector<int32_t> got_zp(m_pad, -1);
-  std::vector<int32_t> got_acc(static_cast<size_t>(m_pad) * N, 0);
-  std::vector<float> got_out(static_cast<size_t>(M) * N, 0.0f);
-
-  int err = nntr_hvx_mm_u8i4_from_f32(
-    handle_, M, K, N, x.data(), static_cast<int>(x.size()), q_w.data(),
-    static_cast<int>(q_w.size()), d.data(), static_cast<int>(d.size()),
-    colsum.data(), static_cast<int>(colsum.size()), bias.data(),
-    static_cast<int>(bias.size()), got_ah.data(),
-    static_cast<int>(got_ah.size()), got_scale.data(),
-    static_cast<int>(got_scale.size()), got_zp.data(),
-    static_cast<int>(got_zp.size()), got_acc.data(),
-    static_cast<int>(got_acc.size()), got_out.data(),
-    static_cast<int>(got_out.size()));
-  ASSERT_EQ(err, AEE_SUCCESS) << "mm_u8i4_from_f32 failed: " << hex(err);
-
-  ASSERT_EQ(got_acc, exp_acc) << "accumulator diverged; S3 is meaningless";
-
-  size_t reported = 0;
-  for (uint32_t m = 0; m < M; ++m) {
-    for (uint32_t n = 0; n < N; ++n) {
-      const size_t i = static_cast<size_t>(m) * N + n;
-      const float tol = std::abs(exp_out[i]) * 1e-5f + 1e-6f;
-      if (std::abs(got_out[i] - exp_out[i]) > tol && reported < 10) {
-        ++reported;
-        ADD_FAILURE() << "out[" << m << "][" << n << "] = " << got_out[i]
-                      << ", expected " << exp_out[i];
-      }
-      EXPECT_NEAR(got_out[i], exp_out[i], tol);
-    }
-  }
+TEST_F(HmxMmU8I4, Shape4_MultipleRowBlocks) {
+  // Shapes 1 through 3 all pad to 64 rows, so the row-block loop only
+  // ever runs with rb=0. This is the one that runs it twice.
+  CheckShape(128, 128, 128, /*want_wh_dump=*/false);
 }
 
 } // namespace


### PR DESCRIPTION
## Dependency of the PR

  #4236

  ## Commits to be reviewed in this PR

  <details><summary>11854b5a [HTP] Replace the scalar accumulator copy-out with async DMA</summary><br />

  [HTP] Replace the scalar accumulator copy-out with async DMA

  hexkl_micro_hmx_copy_32b_to_submatrix's strided scalar copy dominated
  the layer path's DSP-internal time. Give each (row-band, output-tile)
  its own VTCM result slot instead of reusing one, so its copy-out can be
  queued on the DMA ring right after acc_read and overlap the next 
  tile's HMX matmul + acc_read instead of blocking on it -- the same
  dmlink-chained ring already used for cross-matmul weight prefetch.

  Verified on device (R3CY10WM83Y, V79): 14/14 tests pass,
  speedup_vs_harness 25.8x (up from ~3.4x on the un-fixed layer path).

  **Self evaluation:**
  1. Build test: [X]Passed [ ]Failed [ ]Skipped
  2. Run test: [X]Passed [ ]Failed [ ]Skipped

  Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
  Co-authored-by: Claude <noreply@anthropic.com>

  </details>

  <details><summary>b99e79c2 [HTP] Vectorize hvx_quant_pack_u8_ah's per-tile store</summary><br />

  [HTP] Vectorize hvx_quant_pack_u8_ah's per-tile store

  The row-at-a-time path wrote 32 scalar bytes per (row, k-tile) after
  computing a full HVX vector -- one lane used out of the vector width.
  Process 4 rows at a time instead: TILE_ROW (64) is a multiple of 4, so
  a group of 4 consecutive rows never straddles a row-block boundary,
  and its 4*32=128 destination bytes are exactly one HVX vector, chained
  together with Q6_Vh_vpack_VwVw_sat + Q6_Vub_vpack_VhVh_sat (which also
  drops the separate [0,255] clamp: the two chained saturating narrows
  are byte-identical to it for every input, since [0,255] sits inside
  int16's range). Rows not divisible by 4 (e.g. every row when M == 1,
  decode) fall back to the original scalar path.

  Verified on device (R3CY10WM83Y, V79): 14/14 tests pass,
  speedup_vs_harness 32.7x (up from 25.8x).

  **Self evaluation:**
  1. Build test: [X]Passed [ ]Failed [ ]Skipped
  2. Run test: [X]Passed [ ]Failed [ ]Skipped

  Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
  Co-authored-by: Claude <noreply@anthropic.com>

  </details>
<details><summary>5391a505 [HTP] Parallelize quant across a QuRT worker pool</summary><br />

  [HTP] Parallelize quant across a QuRT worker pool

  Add a small, reusable QuRT thread pool (hvx_worker_pool) for splitting
  HVX-bound work by unit index -- func(n_threads, i, ctx), the same shape
  as llama.cpp ggml-hexagon's work_queue_func_t, so a second task type
  (e.g. a future dequant fusion) can share this pool later by writing one
  more function with this signature. Sized from the real HVX context
  count minus one (the caller's own FastRPC thread uses one too),
  created/destroyed with the session.

  Apply it to quant: K1 (hvx_quant_rows_u8_params) splits by row, since
  rows are independent. K2 (hvx_quant_pack_u8_ah) splits by k-tile, not
  row -- a k-tile's destination bytes never overlap another k-tile's,
  which is what lets workers write without stepping on each other, and
  it keeps every 4-row vectorized store group on a single worker instead
  of scattering it across several.

  Two bugs found and fixed on the way, both worth flagging for review:
  - qurt_futex_wake(addr, n) wakes n ARBITRARY sleepers, not n specific
    ones by identity -- waking only the (n-1) workers meant to
    participate risked waking the wrong ones and leaving the real
    participants asleep forever. Now wakes every pool worker on every
    job; non-participants recheck their id and go back to sleep.
  - The two per-row vinv/vz lookup arrays K2 needs are malloc'd, so they
    are HVX_UVector (unaligned access), not HVX_Vector: malloc gives no
    128-byte alignment guarantee, and HVX_Vector's aligned load/store
    faults the instant it isn't.

  Verified on device (R3CY10WM83Y, V79): 14/14 tests pass across 3
  consecutive runs, speedup_vs_harness 34.7x (up from 32.7x).

  **Self evaluation:**
  1. Build test: [X]Passed [ ]Failed [ ]Skipped
  2. Run test: [X]Passed [ ]Failed [ ]Skipped

  Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>
  Co-authored-by: Claude <noreply@anthropic.com>

  </details>

  ### Summary

  Three stacked optimizations to the u8i4/u8i8 layer path's DSP-internal
  time, each independently device-verified (14/14, `R3CY10WM83Y` V79):

  - Accumulator copy-out: scalar strided copy -> async DMA
  - Quant (K2) store: scalar per-byte -> 4-row HVX vector store
  - Quant (K1+K2): single-threaded -> QuRT worker pool
