### PR TITLE
[causallm] Make num_to_generate optional: absent or <=0 generates until EOS

### DIFF
--- a/Applications/CausalLM/models/causal_lm.cpp
+++ b/Applications/CausalLM/models/causal_lm.cpp
@@ -118,6 +118,14 @@ void CausalLM::setupParameters(json &cfg, json &generation_cfg,
     EOS_TOKEN_ID.clear();
     EOS_TOKEN_ID.push_back(generation_cfg["eos_token_id"].get<unsigned int>());
   }
+  if (EOS_TOKEN_ID.empty()) {
+    // Without an EOS id nothing can break the decode loop early, so a config
+    // with no explicit num_to_generate will always run to the context window.
+    std::cerr << "[CausalLM] WARNING: no eos_token_id in the config; "
+                 "generation can only stop at num_to_generate or at the end of "
+                 "the context window."
+              << std::endl;
+  }
   BOS_TOKEN_ID = generation_cfg["bos_token_id"].empty()
                    ? cfg["bos_token_id"].get<unsigned int>()
                    : generation_cfg["bos_token_id"].get<unsigned int>();
@@ -438,7 +446,16 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   std::vector<int64_t> init_input;
   unsigned int _len = _input.size();
-  unsigned int num_allow_str = MAX_SEQ_LEN - NUM_TO_GENERATE;
+  // NUM_TO_GENERATE <= 0 means "no explicit cap": generation runs until EOS or
+  // until the window is full, so nothing has to be held back for it beyond the
+  // single position the decode loop starts at (input_len + 1). Reserving 1
+  // keeps the prompt budget at MAX_SEQ_LEN - 1 and that loop in bounds.
+  const bool unlimited_generation = (NUM_TO_GENERATE <= 0);
+  const unsigned int reserved_for_generation =
+    unlimited_generation ? 1u : static_cast<unsigned int>(NUM_TO_GENERATE);
+  unsigned int num_allow_str = MAX_SEQ_LEN > reserved_for_generation
+                                 ? MAX_SEQ_LEN - reserved_for_generation
+                                 : 0u;
   unsigned int text_len = _len;
 
   if (_len > num_allow_str) {
@@ -451,9 +468,11 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
     std::cerr << "[CausalLM] WARNING: prompt (" << _len
               << " tokens) exceeds the max allowed prefill length ("
               << num_allow_str
-              << " = max_seq_len - num_to_generate); "
-                 "truncating "
-              << (_len - num_allow_str) << " tail tokens." << std::endl;
+              << (unlimited_generation
+                    ? " = max_seq_len - 1, generating until EOS)"
+                    : " = max_seq_len - num_to_generate)")
+              << "; truncating " << (_len - num_allow_str) << " tail tokens."
+              << std::endl;
   }
 
   // feed only available length
@@ -617,8 +636,24 @@ void CausalLM::run(const WSTR prompt, bool do_sample, const WSTR system_prompt,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
-  for (unsigned int token_generation_idx = input_len + 1;
-       token_generation_idx < input_len + 1 + NUM_TO_GENERATE &&
+  // Without an explicit cap (NUM_TO_GENERATE <= 0) the budget is the whole
+  // window; the std::min below is then what actually bounds the loop, so
+  // generation runs until EOS breaks out of it or the window is exhausted.
+  // The window bound also has to hold for an explicit cap: SYS_PROMP_LEN is
+  // added to input_len above on top of the already-truncated prompt, so
+  // input_len + NUM_TO_GENERATE can reach MAX_SEQ_LEN and index
+  // ids_history[b * MAX_SEQ_LEN + idx] out of its row.
+  const unsigned int generation_budget =
+    NUM_TO_GENERATE > 0 ? static_cast<unsigned int>(NUM_TO_GENERATE)
+                        : MAX_SEQ_LEN;
+  const unsigned int generation_begin = input_len + 1;
+  const unsigned int generation_end =
+    generation_begin < MAX_SEQ_LEN
+      ? std::min(generation_begin + generation_budget, MAX_SEQ_LEN)
+      : generation_begin;
+
+  for (unsigned int token_generation_idx = generation_begin;
+       token_generation_idx < generation_end &&
        !stop_requested_.load(std::memory_order_acquire);
        ++token_generation_idx) {
 

--- a/Applications/CausalLM/models/gpt_oss/gptoss_causallm.cpp
+++ b/Applications/CausalLM/models/gpt_oss/gptoss_causallm.cpp
@@ -74,7 +74,11 @@ Tensor GptOssForCausalLM::createAttention(const int layer_id, int seq_len,
     "mha_core",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention"),
      withKey("num_heads", n_heads), withKey("num_heads_kv", n_heads / GQA_SIZE),
-     withKey("max_timestep", std::to_string(INIT_SEQ_LEN + NUM_TO_GENERATE)),
+     // KV-cache height and RoPE LUT extent: size it to the context window,
+     // as every other model in the tree does. INIT_SEQ_LEN + NUM_TO_GENERATE
+     // leaves every position past init_seq_len uncovered when
+     // num_to_generate carries no explicit cap.
+     withKey("max_timestep", std::to_string(MAX_SEQ_LEN)),
      withKey("sliding_window", sliding_window),
      withKey("rope_theta", ROPE_THETA),
      withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),

--- a/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.cpp
+++ b/Applications/CausalLM/models/gpt_oss_cached_slim/gptoss_cached_slim_causallm.cpp
@@ -74,7 +74,11 @@ Tensor GptOssCachedSlimCausalLM::createAttention(const int layer_id,
     "mha_core",
     {withKey("name", "layer" + std::to_string(layer_id) + "_attention"),
      withKey("num_heads", n_heads), withKey("num_heads_kv", n_heads / GQA_SIZE),
-     withKey("max_timestep", std::to_string(INIT_SEQ_LEN + NUM_TO_GENERATE)),
+     // KV-cache height and RoPE LUT extent: size it to the context window,
+     // as every other model in the tree does. INIT_SEQ_LEN + NUM_TO_GENERATE
+     // leaves every position past init_seq_len uncovered when
+     // num_to_generate carries no explicit cap.
+     withKey("max_timestep", std::to_string(MAX_SEQ_LEN)),
      withKey("sliding_window", sliding_window),
      withKey("rope_theta", ROPE_THETA),
      withKey("max_position_embeddings", MAX_POSITION_EMBEDDINGS),

--- a/Applications/CausalLM/models/lfm2/lfm2_causallm.cpp
+++ b/Applications/CausalLM/models/lfm2/lfm2_causallm.cpp
@@ -608,9 +608,20 @@ void Lfm2CausalLM::run_with_embeddings(const void *inputs_embeds,
 
   auto start_generation = std::chrono::high_resolution_clock::now();
 
-  for (unsigned int token_generation_idx = input_len + 1;
-       token_generation_idx < input_len + 1 + NUM_TO_GENERATE;
-       ++token_generation_idx) {
+  // Same bound as CausalLM::run: NUM_TO_GENERATE <= 0 means "no explicit cap"
+  // (budget is the whole window), and the window itself bounds the loop either
+  // way so ids_history[b * MAX_SEQ_LEN + idx] stays inside its row.
+  const unsigned int generation_budget =
+    NUM_TO_GENERATE > 0 ? static_cast<unsigned int>(NUM_TO_GENERATE)
+                        : MAX_SEQ_LEN;
+  const unsigned int generation_begin = input_len + 1;
+  const unsigned int generation_end =
+    generation_begin < MAX_SEQ_LEN
+      ? std::min(generation_begin + generation_budget, MAX_SEQ_LEN)
+      : generation_begin;
+
+  for (unsigned int token_generation_idx = generation_begin;
+       token_generation_idx < generation_end; ++token_generation_idx) {
 
     // Look up embedding for the last generated token and fill gen_input
     std::fill(gen_input.begin(), gen_input.end(), 0.0f);

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -134,7 +134,14 @@ void Transformer::setupParameters(json &cfg, json &generation_cfg,
   MODEL_TENSOR_TYPE = nntr_cfg["model_tensor_type"].get<std::string>();
   INIT_SEQ_LEN = nntr_cfg["init_seq_len"];
   MAX_SEQ_LEN = nntr_cfg["max_seq_len"];
-  NUM_TO_GENERATE = nntr_cfg["num_to_generate"];
+  // num_to_generate is optional: absent (or <= 0) means "no explicit cap",
+  // i.e. generate until EOS or until the context window runs out. 0 is the
+  // sentinel every consumer tests for, so normalize negatives to it here --
+  // a negative value is a supported way to ask for "no cap", not a
+  // misconfiguration.
+  NUM_TO_GENERATE = nntr_cfg.value("num_to_generate", 0);
+  if (NUM_TO_GENERATE < 0)
+    NUM_TO_GENERATE = 0;
   MODEL_TENSOR_TYPE = nntr_cfg["model_tensor_type"];
   MEMORY_SWAP = nntr_cfg.contains("fsu") ? nntr_cfg["fsu"].get<bool>() : false;
   FSU_LOOKAHEAD = nntr_cfg.contains("fsu_lookahead")


### PR DESCRIPTION
`num_to_generate` was a required key, read with `nntr_cfg["num_to_generate"]`, so a config without it threw. Worse, every value it did carry was a hard cap: the decode loop stopped after exactly that many tokens even when the model had already committed to a longer answer and the context window still had room. There was no way to say "just let it finish", so answers were routinely cut mid-sentence and never got the chance to reach EOS.

This makes the field optional and gives a non-positive value the meaning "no explicit cap".

### Semantics

| `num_to_generate` | before | after |
| --- | --- | --- |
| absent | throws | generate until EOS or until the context window is full |
| `0` | loop runs zero times (generates nothing) | generate until EOS or until the context window is full |
| negative | unsigned wraparound in the loop bound | generate until EOS or until the context window is full |
| positive `N` | stop after `N` tokens | unchanged — stop after `N` tokens |

### What changed

- `Transformer::setupParameters` reads the key with a `0` default and normalizes negatives to that same `0` sentinel. `TimmVitTransformer` already read the key this way; the base class now agrees.
- `CausalLM::run` reserves 1 token instead of `num_to_generate` for the prompt budget in the uncapped case, so the prompt may use `max_seq_len - 1` while the decode loop still has the position it starts at (`input_len + 1`). The subtraction is guarded, since it is unsigned and `num_to_generate` is not otherwise bounded by the window.
- The decode loop derives its end from the window as well as from the budget and stops at whichever comes first. That is what bounds the uncapped case, and it is needed for an explicit cap too: `SYS_PROMP_LEN` is added to `input_len` on top of the already-truncated prompt, so `input_len + num_to_generate` could reach `max_seq_len` and index `ids_history[b * MAX_SEQ_LEN + idx]` out of its row. `Lfm2CausalLM::run_with_embeddings` has the identical loop and gets the identical change.
- The prompt-truncation warning names the limit it actually applied, since `max_seq_len - num_to_generate` is not what bounds the uncapped case.
- A missing `eos_token_id` is reported once at setup. Without it nothing can end an uncapped run early, which is worth saying out loud rather than discovering as a run to the end of the window.
- The two GPT-OSS variants sized `mha_core`'s `max_timestep` as `init_seq_len + num_to_generate`. That is the KV cache height and the RoPE LUT extent, so with no explicit cap it would have left every position past `init_seq_len` uncovered. Both now pass `max_seq_len`, which is what every other model in the tree already does.

### Compatibility

Existing configs are unaffected. Every causal `nntr_config.json` in the tree carries a positive `num_to_generate` (128..1024), the causallm test fixtures all use `1`, and the C API fills the key from an unsigned field whose default is 512. The only `0` in the tree is the ViT config, which runs `TimmVitTransformer` — it already read the key with a `0` default and never enters the causal decode loop.

One semantic change is worth calling out for API users: an explicit `0` used to mean "generate nothing" and now means "no explicit cap".

### Verification

x86 build (`--buildtype=plain`, `enable-transformer=true`, `enable-test=true`, fp16 off): clean, and the causallm model unit tests pass unchanged (their fixtures pin `num_to_generate: 1`, i.e. the explicit-cap path).

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
