### PR TITLE
[opencl] Order the BLAS read-backs against their kernels, and fix the dotCl 1x1 shortcut

### DIFF
--- a/nntrainer/opencl/opencl_command_queue_manager.cpp
+++ b/nntrainer/opencl/opencl_command_queue_manager.cpp
@@ -321,6 +321,18 @@ bool CommandQueueManager::enqueueSVMUnmap(void *svm_ptr, cl_event *event) {
   return true;
 }
 
+bool CommandQueueManager::enqueueBarrier() {
+  const cl_int error_code =
+    clEnqueueBarrierWithWaitList(command_queue_, 0, nullptr, nullptr);
+  if (error_code != CL_SUCCESS) {
+    ml_loge(
+      "Failed to clEnqueueBarrierWithWaitList. OpenCL error code: %d : %s",
+      error_code, OpenCLErrorCodeToString(error_code));
+    return false;
+  }
+  return true;
+}
+
 /**
  * @brief Function to initiate execution of the command queue.
  *
@@ -363,6 +375,16 @@ bool CommandQueueManager::DispatchCommand(
     return false;
   }
 
+  // The queue is out of order. A launch that neither waits on an event nor
+  // hands one out has expressed no dependency at all, so nothing stops the
+  // read-back (or the next kernel) that follows it from running first. Every
+  // such caller in the tree consumes this kernel's output on the very next
+  // command, so close the launch with a barrier. Callers that do sequence
+  // themselves with events keep their overlap.
+  if (event == nullptr && events_to_wait.empty()) {
+    return enqueueBarrier();
+  }
+
   return true;
 }
 
@@ -395,6 +417,16 @@ bool CommandQueueManager::DispatchCommand(
     ml_loge("Failed to clEnqueueNDRangeKernel. OpenCL error code: %d : %s",
             error_code, OpenCLErrorCodeToString(error_code));
     return false;
+  }
+
+  // The queue is out of order. A launch that neither waits on an event nor
+  // hands one out has expressed no dependency at all, so nothing stops the
+  // read-back (or the next kernel) that follows it from running first. Every
+  // such caller in the tree consumes this kernel's output on the very next
+  // command, so close the launch with a barrier. Callers that do sequence
+  // themselves with events keep their overlap.
+  if (event == nullptr && events_to_wait.empty()) {
+    return enqueueBarrier();
   }
 
   return true;

--- a/nntrainer/opencl/opencl_command_queue_manager.h
+++ b/nntrainer/opencl/opencl_command_queue_manager.h
@@ -194,6 +194,19 @@ public:
                        std::vector<cl_event> events_to_wait = {});
 
   /**
+   * @brief Enqueue a barrier on the command queue.
+   *
+   * The queue is created with CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, so a
+   * command that carries no event dependency may run before, during or after
+   * any other command already enqueued. Everything enqueued after this barrier
+   * is ordered against everything enqueued before it. Use it whenever the next
+   * command consumes what the previous one produced.
+   *
+   * @return true if the barrier was enqueued, false otherwise
+   */
+  bool enqueueBarrier();
+
+  /**
    * @brief Get the OpenCL Command Queue object
    *
    * @return const cl_command_queue

--- a/nntrainer/opencl/opencl_loader.cpp
+++ b/nntrainer/opencl/opencl_loader.cpp
@@ -207,6 +207,7 @@ void LoadOpenCLFunctions(void *libopencl) {
   LoadFunction(clEnqueueSVMUnmap);
   LoadFunction(clSetKernelArgSVMPointer);
   LoadFunction(clWaitForEvents);
+  LoadFunction(clEnqueueBarrierWithWaitList);
 }
 
 PFN_clGetPlatformIDs clGetPlatformIDs;
@@ -246,4 +247,5 @@ PFN_clEnqueueSVMMap clEnqueueSVMMap;
 PFN_clEnqueueSVMUnmap clEnqueueSVMUnmap;
 PFN_clSetKernelArgSVMPointer clSetKernelArgSVMPointer;
 PFN_clWaitForEvents clWaitForEvents;
+PFN_clEnqueueBarrierWithWaitList clEnqueueBarrierWithWaitList;
 } // namespace nntrainer::opencl

--- a/nntrainer/opencl/opencl_loader.h
+++ b/nntrainer/opencl/opencl_loader.h
@@ -215,6 +215,11 @@ typedef cl_int(CL_API_CALL *PFN_clEnqueueSVMUnmap)(
 typedef cl_int (CL_API_CALL *PFN_clWaitForEvents)(cl_uint num_events,
     const cl_event* event_list);
 
+typedef cl_int(CL_API_CALL *PFN_clEnqueueBarrierWithWaitList)(
+  cl_command_queue /**< command_queue */,
+  cl_uint /**< num_events_in_wait_list */,
+  const cl_event * /**< event_wait_list */, cl_event * /**< event */);
+
 extern PFN_clGetPlatformIDs clGetPlatformIDs;
 extern PFN_clGetDeviceIDs clGetDeviceIDs;
 extern PFN_clGetDeviceInfo clGetDeviceInfo;
@@ -252,6 +257,7 @@ extern PFN_clEnqueueSVMMap clEnqueueSVMMap;
 extern PFN_clEnqueueSVMUnmap clEnqueueSVMUnmap;
 extern PFN_clSetKernelArgSVMPointer clSetKernelArgSVMPointer;
 extern PFN_clWaitForEvents clWaitForEvents;
+extern PFN_clEnqueueBarrierWithWaitList clEnqueueBarrierWithWaitList;
 } // namespace nntrainer::opencl
 
 #endif // __OPENCL_LOADER_H__

--- a/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
+++ b/nntrainer/tensor/cl_operations/blas_kernel_interface.cpp
@@ -128,8 +128,7 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     /// (1 * K) X (1 * M) can be a case
     /// case1: (1 * K) X (K * 1)
     if (M == 1 && N == 1) {
-      // *rdata = dot_cl(data, mdata, K) + (*rdata);
-      *rdata = dot_cl(K, data, mdata) + (*rdata);
+      *rdata = dot_cl(K, data, mdata);
     }
     /// case2: (M * K) X (K * 1)
     else if (N == 1) {
@@ -165,7 +164,7 @@ void dotCl(Tensor const &input, Tensor const &m, Tensor &result, bool trans,
     /// (1 * K) X (1 * M) can be a case
     /// case1: (1 * K) X (K * 1)
     if (M == 1 && N == 1) {
-      *rdata = dot_cl(data, mdata, K) + (*rdata);
+      *rdata = dot_cl(data, mdata, K);
     }
     /// case2: (M * K) X (K * 1)
     else if (N == 1) {

--- a/nntrainer/tensor/cl_operations/blas_kernels_templates.h
+++ b/nntrainer/tensor/cl_operations/blas_kernels_templates.h
@@ -146,7 +146,10 @@ T dot_cl_internal(ClContext::SharedPtrClKernel kernel, const T *vecAdata,
       break;
     }
 
-    const int work_groups_count[3] = {(int)dim1, 1, 1};
+    // The dot kernel is a whole-vector reduction: one work-item walks all dim1
+    // elements and stores the single result. Launching dim1 of them had every
+    // work-item redo the same reduction and race on the same output word.
+    const int work_groups_count[3] = {1, 1, 1};
     const int work_group_size[3] = {1, 1, 1};
 
     result = blas_cc->command_queue_inst_.DispatchCommand(

--- a/nntrainer/tensor/cl_operations/clblast_interface.cpp
+++ b/nntrainer/tensor/cl_operations/clblast_interface.cpp
@@ -33,6 +33,10 @@ void scal_cl(const unsigned int N, const float alpha, float *X,
   clblast::Scal<float>(N, alpha, clBuffManagerInst.getOutBufferA()->GetBuffer(),
                        0, incX, &command_queue);
 
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), X);
 }
@@ -50,6 +54,10 @@ void copy_cl(const unsigned int N, const float *X, float *Y, unsigned int incX,
   clblast::Copy<float>(N, clBuffManagerInst.getInBufferA()->GetBuffer(), 0,
                        incX, clBuffManagerInst.getOutBufferA()->GetBuffer(), 0,
                        incY, &command_queue);
+
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), Y);
@@ -71,6 +79,10 @@ void axpy_cl(const unsigned int N, const float alpha, const float *X, float *Y,
   clblast::Axpy<float>(N, alpha, clBuffManagerInst.getInBufferA()->GetBuffer(),
                        0, incX, clBuffManagerInst.getOutBufferA()->GetBuffer(),
                        0, incY, &command_queue);
+
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
 
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, N * sizeof(float), Y);
@@ -95,6 +107,10 @@ float dot_cl(const unsigned int N, const float *X, const float *Y,
                       &command_queue);
 
   float result;
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, sizeof(float), &result);
   return result;
@@ -114,6 +130,10 @@ float nrm2_cl(const unsigned int N, const float *X, unsigned int incX) {
                        &command_queue);
 
   float result;
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, sizeof(float), &result);
 
@@ -134,6 +154,10 @@ float asum_cl(const unsigned int N, const float *X, unsigned int incX) {
                        &command_queue);
 
   float result;
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, sizeof(float), &result);
 
@@ -154,6 +178,10 @@ int amax_cl(const unsigned int N, const float *X, unsigned int incX) {
                        &command_queue);
 
   int result;
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, sizeof(int), &result);
 
@@ -174,6 +202,10 @@ int amin_cl(const unsigned int N, const float *X, unsigned int incX) {
                        &command_queue);
 
   int result;
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, sizeof(int), &result);
 
@@ -211,7 +243,9 @@ void gemv_cl(const unsigned int layout, bool TransA, const unsigned int M,
     clBuffManagerInst.getInBufferB()->GetBuffer(), 0, incX, beta,
     clBuffManagerInst.getOutBufferA()->GetBuffer(), 0, incY, &command_queue);
 
-  opencl::clFinish(clblast_cc->command_queue_inst_.GetCommandQueue());
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
 
   opencl::clEnqueueReadBuffer(clblast_cc->command_queue_inst_.GetCommandQueue(),
                               clBuffManagerInst.getOutBufferA()->GetBuffer(),
@@ -251,6 +285,10 @@ void gemm_cl(const unsigned int layout, bool TransA, bool TransB,
     clBuffManagerInst.getOutBufferA()->GetBuffer(), 0, ldc, &command_queue);
 
   // Read the result back to C
+  // CLBlast enqueued its kernels on our out-of-order queue without handing
+  // back an event, so nothing orders the read-back after them.
+  clblast_cc->command_queue_inst_.enqueueBarrier();
+
   clBuffManagerInst.getOutBufferA()->ReadDataRegion(
     clblast_cc->command_queue_inst_, M * N * sizeof(float), C);
 }


### PR DESCRIPTION
`unittest_opencl_kernels_blas` fails on an Intel Xe iGPU today: 10-11 of 16 pass with `-Denable-fp16=false`, 12-13 of 28 with `-Denable-fp16=true`, and the set of failures moves between runs. This fixes the cause, and the suite goes to 16/16 and 27/28.

### What is wrong

The command queue is created with `CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE`. Every staged BLAS primitive is written as if it were in order:

```
write A, write B, write C   (blocking, so they have landed)
clEnqueueNDRangeKernel      (no event, no wait list)
clEnqueueReadBufferRect     (blocking)
```

The read is blocking, but blocking only means the host waits for *that* command; nothing makes that command wait for the kernel. On this device the read wins, so the caller gets back whatever the staging buffer held before the kernel ran. Every step reports success, so the operation returns cleanly on stale numbers.

A device probe over the primitives on plain host memory — `sgemv_cl`, `sgemm_cl`, `dot_cl`, all four transpose combinations, 768..2048 wide — shows it directly. As written, every output comes back exactly equal to the sentinel value staged into the output buffer before the dispatch (`cos = -0.9997` against that fill, i.e. untouched). With a single `clFinish` between the dispatch and the read, all of them are bit-accurate against the CPU reference (`cos = 1.000000`, `mse = 0`). Nothing about the kernels or their indexing was wrong.

The same shape is in `clblast_interface.cpp`: CLBlast enqueues on our queue and hands back no event, and eight of the nine wrappers read the result straight afterwards. `gemv_cl` already carried an ad-hoc `clFinish` for exactly this reason — a local patch for a queue-wide problem.

Second, unrelated to ordering, `dotCl()`'s `(1 x K) x (K x 1)` shortcut does

```c
*rdata = dot_cl(...) + (*rdata);
```

reading the result tensor before anything has written it, while the other three shapes in the same function store the product (`gemv` with `beta = 0`, `sgemm_cl`'s kernels write all of C). A tensor that owns its data is zero-initialised so this is invisible there, but a tensor backed by a shared allocation is explicitly not initialised (*"as this memory is shared, do NOT initialize"*, `FloatTensor::allocate`), and `dotBatchedCl()` passes slices of a caller-provided result that still hold the previous batch.

And the `dot` kernel is a whole-vector reduction — one work-item walks all K elements and stores one value — but was launched with `dim1` work-items, so every work-item redid the same reduction and they all wrote the same output word. In the fp32 kernel that write is a read-modify-write (`*res = 0` then `*res += ...`), which is a data race, not merely redundant work.

### What this does

* Close a launch that expressed no dependency with a barrier, and order the CLBlast read-backs the same way. Callers that do sequence themselves with events — `gemm_int4_async_cl` and friends, which is where the out-of-order queue is actually put to work — pass a wait list or an out event and are left alone, so their overlap is preserved.
* Store the product in the `1 x 1` shortcut, and launch the `dot` kernel with the one work-item it is written for.

### Measurements

Intel Xe iGPU (vendor `0x8086`), `unittest_opencl_kernels_blas`:

| build | before | after |
| --- | --- | --- |
| `-Denable-fp16=false` | 10-11 / 16 (varies run to run) | **16 / 16** (5 runs) |
| `-Denable-fp16=true` | 12-13 / 28 (varies run to run) | **27 / 28** (3 runs) |

The failures that go away are `dot_gemm` x4, `l2norm`, `addition_i`, `dotCL_sgemv_N_1_M_1_1`, and in the fp16 build the four `dotCL_sgemv_*_fp16`, the four `dot_gemm_*_fp16` and `multiply_i` — all the same race, which is why several were intermittent rather than constant.

The one that stays, `sgemv_3072_20120_noTrans`, is a different defect and is left alone: at 3072x20120 the operand exceeds the 32 MiB `ClBufferManager` staging buffer, so `WriteDataRegion` refuses and the primitive returns without writing anything, and the test then compares uninitialised memory.

No regression elsewhere: `unittest_attention_kernels_cl` and the OpenCL layer tests pass before and after; `unittest_opencl_kernels_int4` (16/27) and `unittest_opencl_kernels_qk_k` (1/11) fail identically before and after.

As a cross-check that the in-tree kernels themselves are sound, routing the FP32 NCHW cases to `sgemv_cl` / `sgemm_cl` / in-tree `dot_cl` instead of CLBlast also gives 16/16 with these fixes, against 5/16 without them. That routing change is not part of this PR.

### Relation to #4109

\#4109 proposes making the queue in-order by default as part of a larger rework. The ordering added here is what these primitives need under either policy: on an in-order queue the barrier is a no-op, and it keeps the out-of-order configuration correct rather than depending on the queue's default. The `dotCl` and `dot` kernel fixes are independent of the queue policy.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>
