### PR TITLE
[CausalLM] delegate repack to each layers

### DIFF
--- a/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.cpp
@@ -184,6 +184,14 @@ void SharedFullyConnectedLayer::exportTo(
   exporter.saveResult(fc_props, method, this);
 }
 
+void SharedFullyConnectedLayer::pack(nntrainer::RunLayerContext &context) {
+  for (auto &w : context.getWeights()) {
+    nntrainer::Tensor &var = w->getVariableRef();
+    if (var.getDataType() == nntrainer::TensorDim::DataType::QS4CX)
+      var.pack();
+  }
+}
+
 void SharedFullyConnectedLayer::read(
   std::ifstream &file, nntrainer::RunLayerContext &context, bool opt_var,
   ml::train::ExecutionMode mode, bool trainable,

--- a/Applications/CausalLM/layers/shared_fully_connected_layer.h
+++ b/Applications/CausalLM/layers/shared_fully_connected_layer.h
@@ -140,6 +140,11 @@ public:
    */
   bool supportBackwarding() const override { return true; }
 
+  /**
+   * @copydoc Layer::pack(RunLayerContext &context)
+   */
+  void pack(nntrainer::RunLayerContext &context) override;
+
   static constexpr const char *type = "shared_fully_connected";
 
 private:

--- a/Applications/CausalLM/models/transformer.cpp
+++ b/Applications/CausalLM/models/transformer.cpp
@@ -361,22 +361,12 @@ void Transformer::repack_weight() {
   }
   std::function<void(ml::train::Layer &, nntrainer::RunLayerContext &, void *)>
     fn = [](ml::train::Layer &l, nntrainer::RunLayerContext &context, void *) {
-      // repack FC layer only
-      if (l.getType() != "fully_connected" &&
-          l.getType() != "shared_fully_connected")
-        return;
-
-      auto weights = context.getWeights();
-      for (auto &w : weights) {
-        if (w->getVariableRef().getDataType() ==
-            ml::train::TensorDim::DataType::QS4CX) {
-          w->getVariableRef().pack();
-        }
-      }
+      // Each layer determines whether it repacks its own weights or not
+      static_cast<nntrainer::LayerNode &>(l).pack(context);
     };
   try {
     model->forEachLayer(fn, nullptr);
-    ml_logd("QS4CX weights repacked successfully");
+    ml_logd("weights repacked successfully");
   } catch (const std::exception &e) {
     throw std::runtime_error("Failed to repack weights: " +
                              std::string(e.what()));

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -214,6 +214,14 @@ void FullyConnectedLayer::setBatch(nntrainer::RunLayerContext &context,
   }
 }
 
+void FullyConnectedLayer::pack(RunLayerContext &context) {
+  for (auto &w : context.getWeights()) {
+    Tensor &var = w->getVariableRef();
+    if (var.getDataType() == TensorDim::DataType::QS4CX)
+      var.pack();
+  }
+}
+
 void FullyConnectedLayer::forwarding(RunLayerContext &context, bool training) {
   Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);

--- a/nntrainer/layers/fc_layer.h
+++ b/nntrainer/layers/fc_layer.h
@@ -109,6 +109,11 @@ public:
   void setBatch(nntrainer::RunLayerContext &context,
                 unsigned int batch) override;
 
+  /**
+   * @copydoc Layer::pack(RunLayerContext &context)
+   */
+  void pack(RunLayerContext &context) override;
+
   static constexpr const char *type = "fully_connected";
 
 private:

--- a/nntrainer/layers/layer_devel.h
+++ b/nntrainer/layers/layer_devel.h
@@ -246,6 +246,15 @@ public:
   virtual void calcGradient(RunLayerContext &context) {}
 
   /**
+   * @brief     Pack the layer's weights into a backend-optimized layout
+   * @details   Invoked after weights are loaded.
+   * - The default implementation is a no-op
+   * - Each derived layer overrides this if weight repack needed
+   * @param     context Context of the layer, providing access to its weights
+   */
+  virtual void pack(RunLayerContext &context) {}
+
+  /**
    * @brief     set Property of layer
    * @param     values values of property
    * @throw std::invalid_argument invalid parameter.

--- a/nntrainer/layers/layer_node.h
+++ b/nntrainer/layers/layer_node.h
@@ -422,6 +422,14 @@ public:
   bool supportBackwarding() const { return getLayer()->supportBackwarding(); }
 
   /**
+   * @brief     Pack the underlying layer's weights
+   * @details   Delegates to the wrapped layer so each layer type decides how
+   *            (and whether) to repack its own weights.
+   * @param     context Run context bound to this node
+   */
+  void pack(RunLayerContext &context) { getLayer()->pack(context); }
+
+  /**
    * Support interfaces for the properties intercepted from layer
    */
 


### PR DESCRIPTION
## Related
* #4169

## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] delegate repack to each layers</summary><br />

This commit delegates whether and how to repack weights to each layer
not from the transformer object. With this commit, we don't have to
change transformer logic to add new rule to repack weights.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

Let's delegate repack logic to each layer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
