### PR TITLE
[CausalLM] Add Qwen3 MoE streaming conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Applications/CausalLM/res/gemma4/test/*
 !Applications/CausalLM/res/gemma4/test/generate_gemma4_reference.py
 !Applications/CausalLM/res/qwen3/
 Applications/CausalLM/res/qwen3/*
+!Applications/CausalLM/res/qwen3/qwen3-30b-a3b/
+!Applications/CausalLM/res/qwen3/qwen3-30b-a3b/weight_converter_stream.py
 !Applications/CausalLM/res/qwen3/test/
 Applications/CausalLM/res/qwen3/test/*
 !Applications/CausalLM/res/qwen3/test/generate_qwen3_moe_reference.py

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Applications/CausalLM/res/xlm_roberta/*
 !Applications/CausalLM/res/gemma4/
 Applications/CausalLM/res/gemma4/*
 !Applications/CausalLM/res/gemma4/weight_converter.py
+!Applications/CausalLM/res/gemma4/weight_converter_stream.py
 !Applications/CausalLM/res/gemma4/nntr_config.json
 !Applications/CausalLM/res/gemma4/test/
 Applications/CausalLM/res/gemma4/test/*

--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -403,6 +403,29 @@ shards. The default FP32 chunk size is 64 MiB and can be changed with
 `--chunk_size_mib`. Set the resulting filename as `model_file_name` in an FP32
 `nntr_config.json` before quantization or inference.
 
+### Streaming Qwen3-MoE quantization
+
+`nntr_quantize_stream` converts an FP32 `Qwen3MoeForCausalLM` binary without
+initializing the model or loading all expert weights into memory. Router and
+normalization weights remain FP32; attention, expert, embedding, and LM-head
+dtypes follow the command-line options. Large untied LM heads are transposed in
+64 MiB blocks.
+
+```bash
+# Q4_0 attention and experts, with FP32 embedding/LM head:
+nntr_quantize_stream /path/to/Qwen3-30B-A3B --isa ARM
+
+# Select an explicit output directory and filename:
+nntr_quantize_stream /path/to/Qwen3-30B-A3B \
+  -o /output/qwen3-moe-q4 --output_bin qwen3-moe-q40-arm.bin --isa ARM
+```
+
+The streaming path currently accepts NNTrainer FP32 `.bin` input and supports
+`FP32`, `Q4_0`, `Q4_K`, and `Q6_K`. QS4CX is intentionally deferred and
+returns an explicit unsupported error. The tool rejects Slim/CachedSlim
+architectures and safetensors input because their storage layouts differ from
+the full Qwen3-MoE model.
+
 ## Quantized Safetensors Format
 
 NNTrainer can store quantized weights (`Q4_0` / `Q4_K` / `Q6_K`) in the

--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -426,6 +426,48 @@ returns an explicit unsupported error. The tool rejects Slim/CachedSlim
 architectures and safetensors input because their storage layouts differ from
 the full Qwen3-MoE model.
 
+### Streaming Gemma4-MoE FP32 conversion
+
+`weight_converter_stream.py` reads a local Hugging Face safetensors checkpoint
+with bounded memory. It keeps one input shard open at a time and writes large
+FP32 tensors in chunks, including transposed dense and per-expert MoE matrices.
+The default chunk size is 64 MiB. The existing `weight_converter.py` remains
+the general converter and retains its Hugging Face loading and NNTrainer
+safetensors-output paths.
+
+```bash
+python3 Applications/CausalLM/res/gemma4/weight_converter_stream.py \
+  --model_path /path/to/gemma-4-26b-a4b-it \
+  --output_name /path/to/gemma-4-26b-a4b-it/nntr_gemma4_fp32.bin
+```
+
+Use `--chunk_size_mib <size>` to change the chunk size and `--overwrite` to
+replace an existing output. The streaming script requires a local
+`model.safetensors` or `model.safetensors.index.json` checkpoint and produces
+an FP32 `.bin`. Use `weight_converter.py` for a Hub model ID, a legacy PyTorch
+checkpoint, or NNTrainer safetensors output.
+
+### Streaming Gemma4-MoE quantization
+
+`nntr_quantize_stream` converts the generated FP32 `.bin` without constructing
+the Gemma 4 graph or loading all expert weights. Dense attention/MLP and expert
+weights support `Q4_0`; router, router-scale, normalization, and scalar weights
+remain FP32. Embedding and tied LM-head weights remain FP32 by default.
+
+```bash
+# Build with -Denable-transformer=true first.
+build/Applications/CausalLM/nntr_quantize_stream \
+  /path/to/gemma-4-26b-a4b-it \
+  --fc_dtype Q4_0 --embd_dtype FP32 --isa ARM \
+  -o /output/gemma-4-26b-a4b-it-q40
+```
+
+The input directory must contain `config.json`, `nntr_config.json`, and the
+FP32 `.bin` referenced by `model_file_name`. The tool writes a self-contained
+output directory and an updated `nntr_config.json`. Gemma 4 MoE FC/expert
+weights currently support `FP32` and `Q4_0`; embedding/LM-head options also
+support `Q6_K`. Tied embedding and LM-head dtypes must match.
+
 ## Quantized Safetensors Format
 
 NNTrainer can store quantized weights (`Q4_0` / `Q4_K` / `Q6_K`) in the

--- a/Applications/CausalLM/README.md
+++ b/Applications/CausalLM/README.md
@@ -384,6 +384,25 @@ nntr_causallm /path/to/model
 nntr_causallm /output/dir
 ```
 
+### Streaming Qwen3-MoE FP32 conversion
+
+The Qwen3-MoE converter can read a local HuggingFace safetensors checkpoint
+without constructing the full FP32 model. It opens one shard at a time and
+writes large tensors in bounded chunks. This requires Python packages `torch`
+and `safetensors`.
+
+```bash
+python3 Applications/CausalLM/res/qwen3/qwen3-30b-a3b/weight_converter_stream.py \
+  --model_path /path/to/Qwen3-30B-A3B \
+  --output_name /path/to/Qwen3-30B-A3B/nntr_qwen3_moe_fp32.bin
+```
+
+The input directory must contain `config.json` and either
+`model.safetensors` or `model.safetensors.index.json` with all referenced
+shards. The default FP32 chunk size is 64 MiB and can be changed with
+`--chunk_size_mib`. Set the resulting filename as `model_file_name` in an FP32
+`nntr_config.json` before quantization or inference.
+
 ## Quantized Safetensors Format
 
 NNTrainer can store quantized weights (`Q4_0` / `Q4_K` / `Q6_K`) in the

--- a/Applications/CausalLM/jni/Android.mk
+++ b/Applications/CausalLM/jni/Android.mk
@@ -251,6 +251,21 @@ LOCAL_C_INCLUDES += \
 
 include $(BUILD_EXECUTABLE)
 
+# Build nntr_quantize_stream executable
+include $(CLEAR_VARS)
+
+LOCAL_CFLAGS += $(CAUSALLM_COMMON_CFLAGS)
+LOCAL_MODULE := nntr_quantize_stream
+LOCAL_LDLIBS := -llog -landroid
+
+LOCAL_SRC_FILES := ../quantize_stream.cpp
+
+LOCAL_SHARED_LIBRARIES := nntrainer ccapi-nntrainer
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/..
+
+include $(BUILD_EXECUTABLE)
+
 # Build nntr_safetensors_info executable
 include $(CLEAR_VARS)
 

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -186,6 +186,17 @@ e_quantize = executable('nntr_quantize',
 )
 
 
+quantize_stream_src = [
+    meson.current_source_dir() / 'quantize_stream.cpp',
+]
+
+e_quantize_stream = executable('nntr_quantize_stream',
+    quantize_stream_src,
+    include_directories: causallm_inc,
+    dependencies: [nntrainer_dep],
+)
+
+
 safetensors_info_src = [
     meson.current_source_dir() / 'safetensors_info.cpp',
 ]

--- a/Applications/CausalLM/quantize_stream.cpp
+++ b/Applications/CausalLM/quantize_stream.cpp
@@ -1,0 +1,798 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   quantize_stream.cpp
+ * @brief  Bounded-memory weight quantizer for Qwen3 MoE models.
+ */
+
+#include <cpu_backend.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-literal-operator"
+#endif
+#include "json.hpp"
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+namespace {
+
+using json = nlohmann::json;
+
+constexpr size_t QK4_0 = 32;
+constexpr size_t Q4_0_BLOCK_BYTES = 18;
+constexpr size_t QK_K = 256;
+constexpr size_t Q4_K_BLOCK_BYTES = 144;
+constexpr size_t Q6_K_BLOCK_BYTES = 210;
+constexpr size_t MAX_TENSOR_BUFFER_BYTES = 64U * 1024U * 1024U;
+
+using DType = ml::train::TensorDim::DataType;
+
+struct QuantizationPlan {
+  DType fc_dtype;
+  DType embedding_dtype;
+  DType lmhead_dtype;
+  ml::train::ISA target_isa;
+};
+
+struct Qwen3MoePlan {
+  size_t hidden_size;
+  size_t vocab_size;
+  size_t num_layers;
+  size_t num_attention_heads;
+  size_t num_key_value_heads;
+  size_t head_dim;
+  size_t intermediate_size;
+  size_t num_experts;
+  bool tied_embeddings;
+};
+
+std::string upper(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
+  return value;
+}
+
+std::string lower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return value;
+}
+
+size_t checkedMultiply(size_t lhs, size_t rhs, const std::string &name) {
+  if (lhs != 0 && rhs > std::numeric_limits<size_t>::max() / lhs) {
+    throw std::overflow_error("Tensor size overflow for " + name);
+  }
+  return lhs * rhs;
+}
+
+size_t tensorElements(size_t rows, size_t columns, const std::string &name) {
+  return checkedMultiply(rows, columns, name);
+}
+
+size_t tensorBytes(size_t rows, size_t columns, const std::string &name) {
+  return checkedMultiply(tensorElements(rows, columns, name), sizeof(float),
+                         name);
+}
+
+json readJson(const std::filesystem::path &path) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open " + path.string());
+  }
+
+  json value;
+  file >> value;
+  return value;
+}
+
+size_t getSize(const json &cfg, const std::string &key) {
+  if (!cfg.contains(key) || !cfg[key].is_number_unsigned()) {
+    throw std::runtime_error("config.json is missing unsigned numeric key: " +
+                             key);
+  }
+  return cfg[key].get<size_t>();
+}
+
+Qwen3MoePlan makeModelPlan(const json &cfg) {
+  if (!cfg.contains("architectures") || !cfg["architectures"].is_array() ||
+      cfg["architectures"].empty()) {
+    throw std::runtime_error("config.json is missing architectures[0]");
+  }
+
+  const std::string architecture = cfg["architectures"][0].get<std::string>();
+  if (architecture != "Qwen3MoeForCausalLM") {
+    throw std::runtime_error(
+      "nntr_quantize_stream only supports Qwen3MoeForCausalLM, but got " +
+      architecture);
+  }
+
+  const size_t hidden_size = getSize(cfg, "hidden_size");
+  const size_t num_attention_heads = getSize(cfg, "num_attention_heads");
+  if (num_attention_heads == 0) {
+    throw std::runtime_error("num_attention_heads must be greater than zero");
+  }
+
+  const size_t head_dim = cfg.contains("head_dim")
+                            ? getSize(cfg, "head_dim")
+                            : hidden_size / num_attention_heads;
+  const size_t num_key_value_heads = cfg.contains("num_key_value_heads")
+                                       ? getSize(cfg, "num_key_value_heads")
+                                       : num_attention_heads;
+
+  if (head_dim == 0 || num_key_value_heads == 0) {
+    throw std::runtime_error(
+      "head_dim and num_key_value_heads must be greater than zero");
+  }
+
+  return {
+    hidden_size,
+    getSize(cfg, "vocab_size"),
+    getSize(cfg, "num_hidden_layers"),
+    num_attention_heads,
+    num_key_value_heads,
+    head_dim,
+    getSize(cfg, "moe_intermediate_size"),
+    getSize(cfg, "num_experts"),
+    cfg.value("tie_word_embeddings", false),
+  };
+}
+
+DType parseDType(const std::string &value) {
+  const std::string dtype = upper(value);
+  if (dtype == "FP32")
+    return DType::FP32;
+  if (dtype == "Q4_0" || dtype == "Q40")
+    return DType::Q4_0;
+  if (dtype == "Q4_K" || dtype == "Q4K")
+    return DType::Q4_K;
+  if (dtype == "Q6_K" || dtype == "Q6K")
+    return DType::Q6_K;
+  if (dtype == "QS4CX") {
+    // TODO: Add QS4CX streaming layout support for Qwen3 MoE weights.
+    throw std::invalid_argument(
+      "QS4CX is not supported by nntr_quantize_stream yet");
+  }
+  throw std::invalid_argument("Unsupported dtype: " + value +
+                              " (supported: FP32, Q4_0, Q4_K, Q6_K)");
+}
+
+const char *dtypeName(DType dtype) {
+  switch (dtype) {
+  case DType::FP32:
+    return "FP32";
+  case DType::Q4_0:
+    return "Q4_0";
+  case DType::Q4_K:
+    return "Q4_K";
+  case DType::Q6_K:
+    return "Q6_K";
+  default:
+    throw std::invalid_argument("Unknown dtype");
+  }
+}
+
+std::string dtypeSuffix(DType dtype) {
+  std::string suffix = lower(dtypeName(dtype));
+  suffix.erase(std::remove(suffix.begin(), suffix.end(), '_'), suffix.end());
+  return suffix;
+}
+
+ml::train::ISA parseIsa(const std::string &value) {
+  const std::string isa = upper(value);
+  if (isa == "DEFAULT")
+    return ml::train::ISA::DEFAULT;
+  if (isa == "X86")
+    return ml::train::ISA::X86;
+  if (isa == "ARM")
+    return ml::train::ISA::ARM;
+  throw std::invalid_argument("Unsupported ISA: " + value +
+                              " (supported: DEFAULT, X86, ARM)");
+}
+
+const char *isaName(ml::train::ISA isa) {
+  switch (isa) {
+  case ml::train::ISA::DEFAULT:
+    return "DEFAULT";
+  case ml::train::ISA::X86:
+    return "X86";
+  case ml::train::ISA::ARM:
+    return "ARM";
+  }
+  throw std::invalid_argument("Unknown ISA");
+}
+
+size_t quantizedSize(DType dtype, size_t rows, size_t columns, bool repack,
+                     const std::string &name) {
+  switch (dtype) {
+  case DType::FP32:
+    return tensorBytes(rows, columns, name);
+  case DType::Q4_0:
+    if (columns % QK4_0 != 0 || (repack && rows % QK4_0 != 0)) {
+      throw std::invalid_argument(
+        name + " Q4_0 shape must have columns divisible by 32" +
+        (repack ? " and rows divisible by 32" : ""));
+    }
+    return checkedMultiply(checkedMultiply(rows, columns / QK4_0, name),
+                           Q4_0_BLOCK_BYTES, name);
+  case DType::Q4_K:
+    if (columns % QK_K != 0 || (repack && rows % 8 != 0)) {
+      throw std::invalid_argument(
+        name + " Q4_K shape must have columns divisible by 256" +
+        (repack ? " and rows divisible by 8" : ""));
+    }
+    return checkedMultiply(checkedMultiply(rows, columns / QK_K, name),
+                           Q4_K_BLOCK_BYTES, name);
+  case DType::Q6_K:
+    if (columns % QK_K != 0) {
+      throw std::invalid_argument(name +
+                                  " Q6_K columns must be divisible by 256");
+    }
+    return checkedMultiply(checkedMultiply(rows, columns / QK_K, name),
+                           Q6_K_BLOCK_BYTES, name);
+  default:
+    break;
+  }
+  throw std::invalid_argument("Unknown dtype for " + name);
+}
+
+class TensorWriter {
+public:
+  TensorWriter(std::ifstream &input, std::ofstream &output,
+               ml::train::ISA target_isa) :
+    input_(input), output_(output), target_isa_(target_isa) {}
+
+  void copyFp32(size_t elements, const std::string &name) {
+    copyBytes(checkedMultiply(elements, sizeof(float), name), name);
+  }
+
+  void writeEmbedding(size_t rows, size_t columns, DType dtype,
+                      const std::string &name) {
+    if (dtype == DType::FP32) {
+      copyBytes(tensorBytes(rows, columns, name), name);
+      return;
+    }
+    if (dtype == DType::Q4_K) {
+      throw std::invalid_argument(
+        "Q4_K embedding is not supported by the CausalLM embedding layer");
+    }
+    quantizedSize(dtype, rows, columns, false, name);
+
+    const size_t bytes_per_row = tensorBytes(1, columns, name);
+    const size_t rows_per_block =
+      std::max<size_t>(1, MAX_TENSOR_BUFFER_BYTES / bytes_per_row);
+
+    for (size_t row = 0; row < rows;) {
+      const size_t block_rows = std::min(rows_per_block, rows - row);
+      std::vector<float> source(tensorElements(block_rows, columns, name));
+      readFloats(source, name);
+      writeQuantized(source, block_rows, columns, dtype, false, name);
+      row += block_rows;
+    }
+  }
+
+  /**
+   * The FP32 NNTrainer file stores FC weights as [input, output]. Quantized FC
+   * tensors are stored row-wise as [output, input], so only quantized output
+   * is transposed. Large matrices (normally an untied LM head) use a seek-based
+   * blocked transpose to cap memory use.
+   */
+  void writeFc(size_t input_size, size_t output_size, DType dtype,
+               const std::string &name) {
+    const size_t source_bytes = tensorBytes(input_size, output_size, name);
+    if (dtype == DType::FP32) {
+      copyBytes(source_bytes, name);
+      return;
+    }
+
+    // Validate the complete shape before writing any part of this tensor.
+    quantizedSize(dtype, output_size, input_size, true, name);
+
+    if (source_bytes <= MAX_TENSOR_BUFFER_BYTES) {
+      std::vector<float> source(tensorElements(input_size, output_size, name));
+      readFloats(source, name);
+      std::vector<float> transposed(source.size());
+      for (size_t input = 0; input < input_size; ++input) {
+        for (size_t output = 0; output < output_size; ++output) {
+          transposed[output * input_size + input] =
+            source[input * output_size + output];
+        }
+      }
+      writeQuantized(transposed, output_size, input_size, dtype, true, name);
+      return;
+    }
+
+    writeBlockedTransposed(input_size, output_size, dtype, name);
+  }
+
+  void requireEndOfFile() {
+    const std::streampos consumed = input_.tellg();
+    input_.peek();
+    if (!input_.eof()) {
+      throw std::runtime_error(
+        "Input weight file has trailing unread bytes after offset " +
+        std::to_string(static_cast<std::streamoff>(consumed)));
+    }
+  }
+
+private:
+  void writeBytes(const void *source, size_t bytes, const std::string &name) {
+    if (bytes >
+        static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+      throw std::overflow_error("Write size is too large for " + name);
+    }
+    output_.write(static_cast<const char *>(source),
+                  static_cast<std::streamsize>(bytes));
+    if (!output_)
+      throw std::runtime_error("Failed to write " + name);
+  }
+
+  void copyBytes(size_t bytes, const std::string &name) {
+    constexpr size_t COPY_BUFFER_BYTES = 16U * 1024U * 1024U;
+    std::vector<char> buffer(std::min(COPY_BUFFER_BYTES, bytes));
+    size_t remaining = bytes;
+    while (remaining != 0) {
+      const size_t chunk = std::min(buffer.size(), remaining);
+      readExact(buffer.data(), chunk, name);
+      writeBytes(buffer.data(), chunk, name);
+      remaining -= chunk;
+    }
+  }
+
+  void readExact(char *destination, size_t bytes, const std::string &name) {
+    if (bytes >
+        static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+      throw std::overflow_error("Read size is too large for " + name);
+    }
+    input_.read(destination, static_cast<std::streamsize>(bytes));
+    if (input_.gcount() != static_cast<std::streamsize>(bytes)) {
+      throw std::runtime_error("Unexpected EOF while reading " + name);
+    }
+  }
+
+  void readFloats(std::vector<float> &destination, const std::string &name) {
+    readExact(reinterpret_cast<char *>(destination.data()),
+              checkedMultiply(destination.size(), sizeof(float), name), name);
+  }
+
+  void writeQuantized(const std::vector<float> &source, size_t rows,
+                      size_t columns, DType dtype, bool repack,
+                      const std::string &name) {
+    const size_t output_size =
+      quantizedSize(dtype, rows, columns, repack, name);
+    if (dtype == DType::FP32) {
+      throw std::invalid_argument("Internal FP32 quantization request for " +
+                                  name);
+    }
+
+    std::vector<char> quantized(output_size);
+    size_t written = 0;
+    if (dtype == DType::Q4_0) {
+      if (repack) {
+        std::vector<char> plain(output_size);
+        written = nntrainer::quantize_q4_0(
+          source.data(), plain.data(), static_cast<int64_t>(rows),
+          static_cast<int64_t>(columns), nullptr);
+        nntrainer::repack_q4_0(quantized.data(), plain.data(), output_size,
+                               static_cast<unsigned int>(rows),
+                               static_cast<unsigned int>(columns), target_isa_);
+      } else {
+        written = nntrainer::quantize_q4_0(
+          source.data(), quantized.data(), static_cast<int64_t>(rows),
+          static_cast<int64_t>(columns), nullptr);
+      }
+    } else if (dtype == DType::Q4_K) {
+      if (repack) {
+        std::vector<char> plain(output_size);
+        written = nntrainer::quantize_q4_K(
+          source.data(), plain.data(), static_cast<int64_t>(rows),
+          static_cast<int64_t>(columns), nullptr);
+        nntrainer::repack_q4_K(quantized.data(), plain.data(), output_size,
+                               static_cast<unsigned int>(rows),
+                               static_cast<unsigned int>(columns));
+      } else {
+        written = nntrainer::quantize_q4_K(
+          source.data(), quantized.data(), static_cast<int64_t>(rows),
+          static_cast<int64_t>(columns), nullptr);
+      }
+    } else if (dtype == DType::Q6_K) {
+      written = nntrainer::quantize_q6_K(
+        source.data(), quantized.data(), static_cast<int64_t>(rows),
+        static_cast<int64_t>(columns), nullptr);
+    }
+
+    if (written != output_size) {
+      throw std::runtime_error("Unexpected quantized size for " + name +
+                               ": expected " + std::to_string(output_size) +
+                               ", got " + std::to_string(written));
+    }
+
+    writeBytes(quantized.data(), quantized.size(), name);
+  }
+
+  void writeBlockedTransposed(size_t input_size, size_t output_size,
+                              DType dtype, const std::string &name) {
+    const std::streampos tensor_start = input_.tellg();
+    if (tensor_start < 0) {
+      throw std::runtime_error("Failed to determine input offset for " + name);
+    }
+
+    size_t row_alignment = 1;
+    if (dtype == DType::Q4_0)
+      row_alignment = 32;
+    else if (dtype == DType::Q4_K)
+      row_alignment = 8;
+
+    const size_t target_row_bytes = tensorBytes(1, input_size, name);
+    size_t rows_per_block =
+      std::max(row_alignment, MAX_TENSOR_BUFFER_BYTES / target_row_bytes);
+    rows_per_block -= rows_per_block % row_alignment;
+    rows_per_block = std::min(rows_per_block, output_size);
+
+    std::vector<float> strip(rows_per_block);
+    for (size_t output_begin = 0; output_begin < output_size;) {
+      const size_t block_rows =
+        std::min(rows_per_block, output_size - output_begin);
+      std::vector<float> transposed(
+        tensorElements(block_rows, input_size, name));
+
+      for (size_t input = 0; input < input_size; ++input) {
+        const size_t element_offset =
+          checkedMultiply(input, output_size, name) + output_begin;
+        const size_t byte_offset =
+          checkedMultiply(element_offset, sizeof(float), name);
+        input_.clear();
+        input_.seekg(tensor_start + static_cast<std::streamoff>(byte_offset));
+        if (!input_) {
+          throw std::runtime_error("Failed to seek while reading " + name);
+        }
+        readExact(reinterpret_cast<char *>(strip.data()),
+                  checkedMultiply(block_rows, sizeof(float), name), name);
+        for (size_t output = 0; output < block_rows; ++output) {
+          transposed[output * input_size + input] = strip[output];
+        }
+      }
+
+      writeQuantized(transposed, block_rows, input_size, dtype, true, name);
+      output_begin += block_rows;
+    }
+
+    const size_t source_bytes = tensorBytes(input_size, output_size, name);
+    input_.clear();
+    input_.seekg(tensor_start + static_cast<std::streamoff>(source_bytes));
+    if (!input_) {
+      throw std::runtime_error("Failed to advance past " + name);
+    }
+  }
+
+  std::ifstream &input_;
+  std::ofstream &output_;
+  ml::train::ISA target_isa_;
+};
+
+void validateSourceConfig(const json &nntr_cfg) {
+  const auto requireFp32 = [&nntr_cfg](const std::string &key) {
+    if (nntr_cfg.contains(key) &&
+        upper(nntr_cfg[key].get<std::string>()) != "FP32") {
+      throw std::runtime_error("Source " + key + " must be FP32");
+    }
+  };
+
+  requireFp32("fc_layer_dtype");
+  requireFp32("embedding_dtype");
+  requireFp32("lmhead_dtype");
+  if (nntr_cfg.contains("model_tensor_type") &&
+      upper(nntr_cfg["model_tensor_type"].get<std::string>()) != "FP32-FP32") {
+    throw std::runtime_error(
+      "Source model_tensor_type must be FP32-FP32 for streaming quantization");
+  }
+}
+
+void writeQwen3Moe(TensorWriter &writer, const Qwen3MoePlan &model,
+                   const QuantizationPlan &quant) {
+  writer.writeEmbedding(model.vocab_size, model.hidden_size,
+                        quant.embedding_dtype, "embedding0");
+
+  const size_t query_width =
+    checkedMultiply(model.num_attention_heads, model.head_dim, "query width");
+  const size_t kv_width =
+    checkedMultiply(model.num_key_value_heads, model.head_dim, "KV width");
+
+  for (size_t layer = 0; layer < model.num_layers; ++layer) {
+    const std::string prefix = "layer" + std::to_string(layer);
+    writer.copyFp32(model.hidden_size, prefix + "_attention_norm");
+    writer.writeFc(model.hidden_size, query_width, quant.fc_dtype,
+                   prefix + "_wq");
+    writer.copyFp32(model.head_dim, prefix + "_q_norm");
+    writer.writeFc(model.hidden_size, kv_width, quant.fc_dtype, prefix + "_wk");
+    writer.copyFp32(model.head_dim, prefix + "_k_norm");
+    writer.writeFc(model.hidden_size, kv_width, quant.fc_dtype, prefix + "_wv");
+    writer.writeFc(query_width, model.hidden_size, quant.fc_dtype,
+                   prefix + "_attention_out");
+    writer.copyFp32(model.hidden_size, prefix + "_ffn_norm");
+
+    // The router is explicitly FP32 in qwen_moe_layer::finalize(). Keeping it
+    // unquantized also avoids invalid Q4_0 shapes such as [hidden, 128].
+    writer.copyFp32(
+      tensorElements(model.hidden_size, model.num_experts, prefix + "_router"),
+      prefix + "_router");
+
+    for (size_t expert = 0; expert < model.num_experts; ++expert) {
+      const std::string expert_prefix =
+        prefix + "_expert" + std::to_string(expert);
+      writer.writeFc(model.hidden_size, model.intermediate_size, quant.fc_dtype,
+                     expert_prefix + "_up");
+      writer.writeFc(model.hidden_size, model.intermediate_size, quant.fc_dtype,
+                     expert_prefix + "_gate");
+      writer.writeFc(model.intermediate_size, model.hidden_size, quant.fc_dtype,
+                     expert_prefix + "_down");
+    }
+
+    std::cout << "  Quantized layer " << layer + 1 << "/" << model.num_layers
+              << '\n';
+  }
+
+  writer.copyFp32(model.hidden_size, "output_norm");
+  if (!model.tied_embeddings) {
+    writer.writeFc(model.hidden_size, model.vocab_size, quant.lmhead_dtype,
+                   "output_of_causallm");
+  }
+  writer.requireEndOfFile();
+}
+
+std::string stripKnownDtypeSuffix(std::string base) {
+  const std::vector<std::string> suffixes = {"_fp32", "_fp16", "_q40", "_q4_0",
+                                             "_q4k",  "_q4_k", "_q6k", "_q6_k"};
+  for (const auto &suffix : suffixes) {
+    if (base.size() >= suffix.size() &&
+        base.compare(base.size() - suffix.size(), suffix.size(), suffix) == 0) {
+      base.resize(base.size() - suffix.size());
+      break;
+    }
+  }
+  return base;
+}
+
+std::string defaultOutputBin(const std::string &input_bin,
+                             const QuantizationPlan &quant) {
+  std::filesystem::path input_path(input_bin);
+  std::string base = stripKnownDtypeSuffix(input_path.stem().string());
+  std::string result = base + "_" + dtypeSuffix(quant.fc_dtype);
+  if (quant.embedding_dtype != quant.fc_dtype)
+    result += "_embd" + dtypeSuffix(quant.embedding_dtype);
+  if (quant.lmhead_dtype != quant.embedding_dtype)
+    result += "_lmhead" + dtypeSuffix(quant.lmhead_dtype);
+  result += "_" + lower(isaName(quant.target_isa)) + ".bin";
+  return result;
+}
+
+std::filesystem::path
+defaultOutputDirectory(const std::filesystem::path &model_dir,
+                       const QuantizationPlan &quant) {
+  return model_dir / ("quantized_fc_" + lower(dtypeName(quant.fc_dtype)) +
+                      "_embd_" + lower(dtypeName(quant.embedding_dtype)) +
+                      "_lmhead_" + lower(dtypeName(quant.lmhead_dtype)) +
+                      "_isa_" + lower(isaName(quant.target_isa)));
+}
+
+void copyAuxiliaryFiles(const std::filesystem::path &model_dir,
+                        const std::filesystem::path &output_dir) {
+  const char *files[] = {
+    "config.json",           "generation_config.json",  "tokenizer.json",
+    "tokenizer_config.json", "special_tokens_map.json", "tokenizer.model",
+    "spiece.model",          "sentencepiece.bpe.model", "modules.json"};
+  for (const char *file : files) {
+    const std::filesystem::path source = model_dir / file;
+    if (std::filesystem::exists(source)) {
+      std::filesystem::copy_file(
+        source, output_dir / file,
+        std::filesystem::copy_options::overwrite_existing);
+    }
+  }
+}
+
+void writeOutputConfig(const std::filesystem::path &model_dir,
+                       const std::filesystem::path &output_dir,
+                       const std::string &output_bin,
+                       const QuantizationPlan &quant, json nntr_cfg) {
+  nntr_cfg["model_file_name"] = output_bin;
+  nntr_cfg["model_tensor_type"] =
+    std::string(dtypeName(quant.fc_dtype)) + "-FP32";
+  nntr_cfg["fc_layer_dtype"] = dtypeName(quant.fc_dtype);
+  nntr_cfg["embedding_dtype"] = dtypeName(quant.embedding_dtype);
+  nntr_cfg["lmhead_dtype"] = dtypeName(quant.lmhead_dtype);
+
+  const std::filesystem::path output_config =
+    std::filesystem::equivalent(model_dir, output_dir)
+      ? output_dir / "nntr_config_quantized.json"
+      : output_dir / "nntr_config.json";
+  std::ofstream file(output_config);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open " + output_config.string());
+  }
+  file << nntr_cfg.dump(4) << '\n';
+}
+
+void printUsage(const char *program) {
+  std::cout
+    << "Usage: " << program << " <model_path> [options]\n\n"
+    << "Stream-quantize an FP32 Qwen3MoeForCausalLM .bin model without "
+       "loading the full model.\n\n"
+    << "Options:\n"
+    << "  --output, -o <path>   Output directory (default: dtype/ISA "
+       "subdirectory)\n"
+    << "  --fc_dtype <type>     Attention/expert dtype (default: Q4_0)\n"
+    << "  --embd_dtype <type>   Embedding dtype (default: FP32)\n"
+    << "  --lmhead_dtype <type> LM head dtype (default: embedding dtype)\n"
+    << "  --isa <target>        DEFAULT, X86, or ARM (default: DEFAULT)\n"
+    << "  --output_bin <name>   Output .bin filename\n"
+    << "  --config <path>       Read target dtype fields and filename from an "
+       "nntr config\n"
+    << "  -h, --help            Show this help\n\n"
+    << "Supported dtypes: FP32, Q4_0, Q4_K, Q6_K\n";
+}
+
+int run(int argc, char **argv) {
+  if (argc < 2) {
+    printUsage(argv[0]);
+    return EXIT_FAILURE;
+  }
+  if (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help") {
+    printUsage(argv[0]);
+    return EXIT_SUCCESS;
+  }
+
+  const std::filesystem::path model_dir = argv[1];
+  std::filesystem::path output_dir;
+  std::string fc_dtype = "Q4_0";
+  std::string embedding_dtype = "FP32";
+  std::string lmhead_dtype;
+  std::string target_isa = "DEFAULT";
+  std::string output_bin;
+  std::filesystem::path target_config;
+
+  for (int index = 2; index < argc; ++index) {
+    const std::string argument = argv[index];
+    const auto requireValue = [&](const std::string &option) {
+      if (index + 1 >= argc)
+        throw std::invalid_argument("Missing value for " + option);
+      return std::string(argv[++index]);
+    };
+
+    if (argument == "--output" || argument == "-o")
+      output_dir = requireValue(argument);
+    else if (argument == "--fc_dtype")
+      fc_dtype = requireValue(argument);
+    else if (argument == "--embd_dtype")
+      embedding_dtype = requireValue(argument);
+    else if (argument == "--lmhead_dtype")
+      lmhead_dtype = requireValue(argument);
+    else if (argument == "--isa")
+      target_isa = requireValue(argument);
+    else if (argument == "--output_bin")
+      output_bin = requireValue(argument);
+    else if (argument == "--config")
+      target_config = requireValue(argument);
+    else if (argument == "--help" || argument == "-h") {
+      printUsage(argv[0]);
+      return EXIT_SUCCESS;
+    } else {
+      throw std::invalid_argument("Unknown option: " + argument);
+    }
+  }
+
+  const json cfg = readJson(model_dir / "config.json");
+  json nntr_cfg = readJson(model_dir / "nntr_config.json");
+  validateSourceConfig(nntr_cfg);
+  const Qwen3MoePlan model = makeModelPlan(cfg);
+
+  if (!target_config.empty()) {
+    const json requested = readJson(target_config);
+    if (requested.contains("fc_layer_dtype"))
+      fc_dtype = requested["fc_layer_dtype"].get<std::string>();
+    if (requested.contains("embedding_dtype"))
+      embedding_dtype = requested["embedding_dtype"].get<std::string>();
+    if (requested.contains("lmhead_dtype"))
+      lmhead_dtype = requested["lmhead_dtype"].get<std::string>();
+    if (requested.contains("model_file_name") && output_bin.empty())
+      output_bin = requested["model_file_name"].get<std::string>();
+  }
+
+  if (lmhead_dtype.empty())
+    lmhead_dtype = embedding_dtype;
+  const QuantizationPlan quant{parseDType(fc_dtype),
+                               parseDType(embedding_dtype),
+                               parseDType(lmhead_dtype), parseIsa(target_isa)};
+
+  if (model.tied_embeddings && quant.embedding_dtype != quant.lmhead_dtype) {
+    throw std::invalid_argument(
+      "A tied Qwen3 MoE model requires matching embedding and LM head dtypes");
+  }
+  const std::string input_bin =
+    nntr_cfg.at("model_file_name").get<std::string>();
+  if (std::filesystem::path(input_bin).extension() != ".bin") {
+    throw std::invalid_argument(
+      "Streaming quantization currently requires an NNTrainer .bin input");
+  }
+  if (output_dir.empty())
+    output_dir = defaultOutputDirectory(model_dir, quant);
+  std::filesystem::create_directories(output_dir);
+  if (output_bin.empty())
+    output_bin = defaultOutputBin(input_bin, quant);
+  if (std::filesystem::path(output_bin).extension() != ".bin") {
+    throw std::invalid_argument("--output_bin must use the .bin extension");
+  }
+
+  const std::filesystem::path input_path = model_dir / input_bin;
+  const std::filesystem::path output_path = output_dir / output_bin;
+  if (std::filesystem::exists(output_path) &&
+      std::filesystem::equivalent(input_path, output_path)) {
+    throw std::invalid_argument("Input and output weight paths must differ");
+  }
+
+  std::ifstream input(input_path, std::ios::binary);
+  if (!input.is_open())
+    throw std::runtime_error("Failed to open " + input_path.string());
+  std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open())
+    throw std::runtime_error("Failed to open " + output_path.string());
+
+  std::cout << "NNTrainer Qwen3 MoE streaming quantizer\n"
+            << "  Source: " << input_path << '\n'
+            << "  Target: " << output_path << '\n'
+            << "  Layers: " << model.num_layers << '\n'
+            << "  Experts per layer: " << model.num_experts << '\n'
+            << "  FC dtype: " << dtypeName(quant.fc_dtype) << '\n'
+            << "  Embedding dtype: " << dtypeName(quant.embedding_dtype) << '\n'
+            << "  LM head dtype: " << dtypeName(quant.lmhead_dtype) << '\n'
+            << "  Target ISA: " << isaName(quant.target_isa) << '\n';
+
+  TensorWriter writer(input, output, quant.target_isa);
+  writeQwen3Moe(writer, model, quant);
+  output.close();
+  if (!output)
+    throw std::runtime_error("Failed to finalize " + output_path.string());
+
+  if (!std::filesystem::equivalent(model_dir, output_dir))
+    copyAuxiliaryFiles(model_dir, output_dir);
+  writeOutputConfig(model_dir, output_dir, output_bin, quant, nntr_cfg);
+
+  const uintmax_t input_size = std::filesystem::file_size(input_path);
+  const uintmax_t output_size = std::filesystem::file_size(output_path);
+  const double ratio = input_size == 0
+                         ? 0.0
+                         : 100.0 * static_cast<double>(output_size) /
+                             static_cast<double>(input_size);
+  std::cout << "  Source size: " << input_size / (1024 * 1024) << " MiB\n"
+            << "  Output size: " << output_size / (1024 * 1024) << " MiB\n"
+            << "  Output/source: " << std::fixed << std::setprecision(1)
+            << ratio << "%\n"
+            << "Streaming quantization complete\n";
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  try {
+    return run(argc, argv);
+  } catch (const std::exception &error) {
+    std::cerr << "[!] FATAL ERROR: " << error.what() << '\n';
+    return EXIT_FAILURE;
+  }
+}

--- a/Applications/CausalLM/quantize_stream.cpp
+++ b/Applications/CausalLM/quantize_stream.cpp
@@ -4,6 +4,8 @@
  *
  * @file   quantize_stream.cpp
  * @brief  Bounded-memory weight quantizer for supported CausalLM models.
+ * @author Jungwon-Lee <jungone.lee@samsung.com>
+ * @bug    No known bugs except for NYI items
  */
 
 #include <cpu_backend.h>

--- a/Applications/CausalLM/quantize_stream.cpp
+++ b/Applications/CausalLM/quantize_stream.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
  *
  * @file   quantize_stream.cpp
- * @brief  Bounded-memory weight quantizer for Qwen3 MoE models.
+ * @brief  Bounded-memory weight quantizer for supported CausalLM models.
  */
 
 #include <cpu_backend.h>
@@ -19,6 +19,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if defined(__clang__)
@@ -59,6 +60,25 @@ struct Qwen3MoePlan {
   size_t head_dim;
   size_t intermediate_size;
   size_t num_experts;
+  bool tied_embeddings;
+};
+
+struct Gemma4MoePlan {
+  size_t hidden_size;
+  size_t vocab_size;
+  size_t num_layers;
+  size_t num_attention_heads;
+  size_t num_key_value_heads;
+  size_t head_dim;
+  size_t global_head_dim;
+  size_t num_global_key_value_heads;
+  size_t intermediate_size;
+  size_t moe_intermediate_size;
+  size_t num_experts;
+  size_t per_layer_input_size;
+  size_t per_layer_vocab_size;
+  std::vector<std::string> layer_types;
+  bool attention_k_eq_v;
   bool tied_embeddings;
 };
 
@@ -109,13 +129,16 @@ size_t getSize(const json &cfg, const std::string &key) {
   return cfg[key].get<size_t>();
 }
 
-Qwen3MoePlan makeModelPlan(const json &cfg) {
+std::string getArchitecture(const json &cfg) {
   if (!cfg.contains("architectures") || !cfg["architectures"].is_array() ||
       cfg["architectures"].empty()) {
     throw std::runtime_error("config.json is missing architectures[0]");
   }
+  return cfg["architectures"][0].get<std::string>();
+}
 
-  const std::string architecture = cfg["architectures"][0].get<std::string>();
+Qwen3MoePlan makeQwen3MoePlan(const json &cfg) {
+  const std::string architecture = getArchitecture(cfg);
   if (architecture != "Qwen3MoeForCausalLM") {
     throw std::runtime_error(
       "nntr_quantize_stream only supports Qwen3MoeForCausalLM, but got " +
@@ -150,6 +173,98 @@ Qwen3MoePlan makeModelPlan(const json &cfg) {
     getSize(cfg, "moe_intermediate_size"),
     getSize(cfg, "num_experts"),
     cfg.value("tie_word_embeddings", false),
+  };
+}
+
+Gemma4MoePlan makeGemma4MoePlan(const json &root_cfg) {
+  const std::string architecture = getArchitecture(root_cfg);
+  if (architecture != "Gemma4ForCausalLM" &&
+      architecture != "Gemma4ForConditionalGeneration") {
+    throw std::runtime_error("Unsupported Gemma4 architecture: " +
+                             architecture);
+  }
+
+  const json &cfg =
+    root_cfg.contains("text_config") ? root_cfg.at("text_config") : root_cfg;
+  if (!cfg.is_object())
+    throw std::runtime_error("Gemma4 text_config must be an object");
+  if (!cfg.value("enable_moe_block", false)) {
+    throw std::runtime_error(
+      "Gemma4 streaming quantization requires enable_moe_block=true");
+  }
+
+  const size_t hidden_size = getSize(cfg, "hidden_size");
+  const size_t num_layers = getSize(cfg, "num_hidden_layers");
+  const size_t num_attention_heads = getSize(cfg, "num_attention_heads");
+  if (num_attention_heads == 0)
+    throw std::runtime_error("num_attention_heads must be greater than zero");
+
+  const size_t head_dim = cfg.contains("head_dim")
+                            ? getSize(cfg, "head_dim")
+                            : hidden_size / num_attention_heads;
+  const size_t num_key_value_heads = cfg.contains("num_key_value_heads")
+                                       ? getSize(cfg, "num_key_value_heads")
+                                       : num_attention_heads;
+  const size_t global_head_dim =
+    cfg.contains("global_head_dim") && !cfg["global_head_dim"].is_null()
+      ? getSize(cfg, "global_head_dim")
+      : head_dim;
+  const size_t num_global_key_value_heads =
+    cfg.contains("num_global_key_value_heads") &&
+        !cfg["num_global_key_value_heads"].is_null()
+      ? getSize(cfg, "num_global_key_value_heads")
+      : num_key_value_heads;
+
+  const size_t num_kv_shared_layers =
+    cfg.value("num_kv_shared_layers", size_t{0});
+  if (num_kv_shared_layers != 0) {
+    throw std::runtime_error(
+      "Gemma4 MoE streaming quantization does not support shared KV layers");
+  }
+
+  std::vector<std::string> layer_types(num_layers,
+                                       std::string("sliding_attention"));
+  if (cfg.contains("layer_types")) {
+    layer_types = cfg["layer_types"].get<std::vector<std::string>>();
+    if (layer_types.size() != num_layers) {
+      throw std::runtime_error(
+        "Gemma4 layer_types size must match num_hidden_layers");
+    }
+  }
+  for (const auto &type : layer_types) {
+    if (type != "sliding_attention" && type != "full_attention")
+      throw std::runtime_error("Unsupported Gemma4 layer type: " + type);
+  }
+
+  const size_t per_layer_input_size =
+    cfg.value("hidden_size_per_layer_input", size_t{0});
+  const size_t per_layer_vocab_size =
+    cfg.value("vocab_size_per_layer_input", getSize(cfg, "vocab_size"));
+  if (per_layer_input_size != 0 && per_layer_vocab_size == 0) {
+    throw std::runtime_error(
+      "vocab_size_per_layer_input must be greater than zero");
+  }
+
+  const bool tied_embeddings = cfg.contains("tie_word_embeddings")
+                                 ? cfg["tie_word_embeddings"].get<bool>()
+                                 : root_cfg.value("tie_word_embeddings", true);
+  return {
+    hidden_size,
+    getSize(cfg, "vocab_size"),
+    num_layers,
+    num_attention_heads,
+    num_key_value_heads,
+    head_dim,
+    global_head_dim,
+    num_global_key_value_heads,
+    getSize(cfg, "intermediate_size"),
+    getSize(cfg, "moe_intermediate_size"),
+    getSize(cfg, "num_experts"),
+    per_layer_input_size,
+    per_layer_vocab_size,
+    std::move(layer_types),
+    cfg.value("attention_k_eq_v", false),
+    tied_embeddings,
   };
 }
 
@@ -261,6 +376,17 @@ public:
     copyBytes(checkedMultiply(elements, sizeof(float), name), name);
   }
 
+  void discardFp32(size_t elements, const std::string &name) {
+    discardBytes(checkedMultiply(elements, sizeof(float), name), name);
+  }
+
+  bool hasRemainingBytes() {
+    input_.peek();
+    const bool remaining = !input_.eof();
+    input_.clear();
+    return remaining;
+  }
+
   void writeEmbedding(size_t rows, size_t columns, DType dtype,
                       const std::string &name) {
     if (dtype == DType::FP32) {
@@ -350,6 +476,17 @@ private:
       const size_t chunk = std::min(buffer.size(), remaining);
       readExact(buffer.data(), chunk, name);
       writeBytes(buffer.data(), chunk, name);
+      remaining -= chunk;
+    }
+  }
+
+  void discardBytes(size_t bytes, const std::string &name) {
+    constexpr size_t DISCARD_BUFFER_BYTES = 16U * 1024U * 1024U;
+    std::vector<char> buffer(std::min(DISCARD_BUFFER_BYTES, bytes));
+    size_t remaining = bytes;
+    while (remaining != 0) {
+      const size_t chunk = std::min(buffer.size(), remaining);
+      readExact(buffer.data(), chunk, name);
       remaining -= chunk;
     }
   }
@@ -555,6 +692,108 @@ void writeQwen3Moe(TensorWriter &writer, const Qwen3MoePlan &model,
   writer.requireEndOfFile();
 }
 
+void writeGemma4Moe(TensorWriter &writer, const Gemma4MoePlan &model,
+                    const QuantizationPlan &quant) {
+  writer.writeEmbedding(model.vocab_size, model.hidden_size,
+                        quant.embedding_dtype, "embedding0");
+
+  for (size_t layer = 0; layer < model.num_layers; ++layer) {
+    const std::string prefix = "layer" + std::to_string(layer);
+    const bool is_sliding = model.layer_types[layer] == "sliding_attention";
+    const size_t head_dim = is_sliding ? model.head_dim : model.global_head_dim;
+    const size_t kv_heads = is_sliding || !model.attention_k_eq_v
+                              ? model.num_key_value_heads
+                              : model.num_global_key_value_heads;
+    const size_t query_width = checkedMultiply(
+      model.num_attention_heads, head_dim, prefix + " query width");
+    const size_t kv_width =
+      checkedMultiply(kv_heads, head_dim, prefix + " KV width");
+
+    writer.copyFp32(model.hidden_size, prefix + "_attention_norm");
+    writer.writeFc(model.hidden_size, query_width, quant.fc_dtype,
+                   prefix + "_wq");
+    writer.copyFp32(head_dim, prefix + "_q_norm");
+    writer.writeFc(model.hidden_size, kv_width, quant.fc_dtype, prefix + "_wk");
+    writer.copyFp32(head_dim, prefix + "_k_norm");
+    if (!model.attention_k_eq_v || is_sliding) {
+      writer.writeFc(model.hidden_size, kv_width, quant.fc_dtype,
+                     prefix + "_wv");
+    }
+    writer.writeFc(query_width, model.hidden_size, quant.fc_dtype,
+                   prefix + "_attention_out");
+
+    writer.copyFp32(model.hidden_size, prefix + "_post_attention_norm");
+    writer.copyFp32(model.hidden_size, prefix + "_pre_ffn_norm");
+    writer.writeFc(model.hidden_size, model.intermediate_size, quant.fc_dtype,
+                   prefix + "_ffn_gate");
+    writer.writeFc(model.hidden_size, model.intermediate_size, quant.fc_dtype,
+                   prefix + "_ffn_up");
+    writer.writeFc(model.intermediate_size, model.hidden_size, quant.fc_dtype,
+                   prefix + "_ffn_down");
+
+    writer.copyFp32(model.hidden_size, prefix + "_post_ffn_norm_1");
+    writer.copyFp32(model.hidden_size, prefix + "_pre_ffn_norm_2");
+    writer.copyFp32(tensorElements(model.hidden_size, model.num_experts,
+                                   prefix + "_sparse_moe router"),
+                    prefix + "_sparse_moe router");
+    writer.copyFp32(model.hidden_size, prefix + "_sparse_moe router_scale");
+    writer.copyFp32(model.num_experts,
+                    prefix + "_sparse_moe router_per_expert_scale");
+
+    for (size_t expert = 0; expert < model.num_experts; ++expert) {
+      const std::string expert_prefix =
+        prefix + "_expert" + std::to_string(expert);
+      writer.writeFc(model.hidden_size, model.moe_intermediate_size,
+                     quant.fc_dtype, expert_prefix + "_gate");
+      writer.writeFc(model.hidden_size, model.moe_intermediate_size,
+                     quant.fc_dtype, expert_prefix + "_up");
+      writer.writeFc(model.moe_intermediate_size, model.hidden_size,
+                     quant.fc_dtype, expert_prefix + "_down");
+    }
+
+    writer.copyFp32(model.hidden_size, prefix + "_post_ffn_norm_2");
+    writer.copyFp32(model.hidden_size, prefix + "_post_ffn_norm");
+
+    if (model.per_layer_input_size != 0) {
+      writer.writeFc(model.hidden_size, model.per_layer_input_size,
+                     quant.fc_dtype, prefix + "_per_layer_input_gate");
+      if (layer == 0) {
+        const size_t total_per_layer_size =
+          checkedMultiply(model.num_layers, model.per_layer_input_size,
+                          "per-layer input total size");
+        writer.writeEmbedding(model.per_layer_vocab_size, total_per_layer_size,
+                              quant.fc_dtype, "per_layer_input_embedding");
+        writer.writeFc(model.hidden_size, total_per_layer_size, quant.fc_dtype,
+                       "per_layer_input_projection");
+        writer.copyFp32(model.per_layer_input_size,
+                        "per_layer_projection_norm");
+      }
+      writer.writeFc(model.per_layer_input_size, model.hidden_size,
+                     quant.fc_dtype, prefix + "_per_layer_input_proj");
+      writer.copyFp32(model.hidden_size, prefix + "_post_per_layer_input_norm");
+    }
+    writer.copyFp32(1, prefix + "_layer_scalar");
+
+    std::cout << "  Quantized layer " << layer + 1 << "/" << model.num_layers
+              << '\n';
+  }
+
+  writer.copyFp32(model.hidden_size, "output_norm");
+  if (model.tied_embeddings) {
+    // The Gemma4 converter retains a legacy trailing shared embedding, while
+    // NNTrainer model saving emits only embedding0. Accept either FP32 source.
+    if (writer.hasRemainingBytes()) {
+      writer.discardFp32(tensorElements(model.vocab_size, model.hidden_size,
+                                        "tied output_of_causallm"),
+                         "tied output_of_causallm");
+    }
+  } else {
+    writer.writeFc(model.hidden_size, model.vocab_size, quant.lmhead_dtype,
+                   "output_of_causallm");
+  }
+  writer.requireEndOfFile();
+}
+
 std::string stripKnownDtypeSuffix(std::string base) {
   const std::vector<std::string> suffixes = {"_fp32", "_fp16", "_q40", "_q4_0",
                                              "_q4k",  "_q4_k", "_q6k", "_q6_k"};
@@ -631,8 +870,8 @@ void writeOutputConfig(const std::filesystem::path &model_dir,
 void printUsage(const char *program) {
   std::cout
     << "Usage: " << program << " <model_path> [options]\n\n"
-    << "Stream-quantize an FP32 Qwen3MoeForCausalLM .bin model without "
-       "loading the full model.\n\n"
+    << "Stream-quantize a supported FP32 CausalLM .bin model without loading "
+       "the full model.\n\n"
     << "Options:\n"
     << "  --output, -o <path>   Output directory (default: dtype/ISA "
        "subdirectory)\n"
@@ -644,7 +883,10 @@ void printUsage(const char *program) {
     << "  --config <path>       Read target dtype fields and filename from an "
        "nntr config\n"
     << "  -h, --help            Show this help\n\n"
-    << "Supported dtypes: FP32, Q4_0, Q4_K, Q6_K\n";
+    << "Architectures: Qwen3MoeForCausalLM, Gemma4ForCausalLM, "
+       "Gemma4ForConditionalGeneration\n"
+    << "Supported dtypes: FP32, Q4_0, Q4_K, Q6_K\n"
+    << "Gemma4 MoE FC/expert weights currently support FP32 or Q4_0.\n";
 }
 
 int run(int argc, char **argv) {
@@ -699,7 +941,26 @@ int run(int argc, char **argv) {
   const json cfg = readJson(model_dir / "config.json");
   json nntr_cfg = readJson(model_dir / "nntr_config.json");
   validateSourceConfig(nntr_cfg);
-  const Qwen3MoePlan model = makeModelPlan(cfg);
+  const std::string architecture = getArchitecture(cfg);
+  const bool is_qwen3_moe = architecture == "Qwen3MoeForCausalLM";
+  const bool is_gemma4_moe = architecture == "Gemma4ForCausalLM" ||
+                             architecture == "Gemma4ForConditionalGeneration";
+  if (!is_qwen3_moe && !is_gemma4_moe)
+    throw std::runtime_error("Unsupported architecture: " + architecture);
+
+  Qwen3MoePlan qwen3_model{};
+  Gemma4MoePlan gemma4_model{};
+  if (is_qwen3_moe)
+    qwen3_model = makeQwen3MoePlan(cfg);
+  else
+    gemma4_model = makeGemma4MoePlan(cfg);
+
+  const bool tied_embeddings =
+    is_qwen3_moe ? qwen3_model.tied_embeddings : gemma4_model.tied_embeddings;
+  const size_t num_layers =
+    is_qwen3_moe ? qwen3_model.num_layers : gemma4_model.num_layers;
+  const size_t num_experts =
+    is_qwen3_moe ? qwen3_model.num_experts : gemma4_model.num_experts;
 
   if (!target_config.empty()) {
     const json requested = readJson(target_config);
@@ -711,6 +972,8 @@ int run(int argc, char **argv) {
       lmhead_dtype = requested["lmhead_dtype"].get<std::string>();
     if (requested.contains("model_file_name") && output_bin.empty())
       output_bin = requested["model_file_name"].get<std::string>();
+    if (requested.contains("moe_cache_size"))
+      nntr_cfg["moe_cache_size"] = requested["moe_cache_size"];
   }
 
   if (lmhead_dtype.empty())
@@ -719,9 +982,14 @@ int run(int argc, char **argv) {
                                parseDType(embedding_dtype),
                                parseDType(lmhead_dtype), parseIsa(target_isa)};
 
-  if (model.tied_embeddings && quant.embedding_dtype != quant.lmhead_dtype) {
+  if (tied_embeddings && quant.embedding_dtype != quant.lmhead_dtype) {
     throw std::invalid_argument(
-      "A tied Qwen3 MoE model requires matching embedding and LM head dtypes");
+      "A tied model requires matching embedding and LM head dtypes");
+  }
+  if (is_gemma4_moe && quant.fc_dtype != DType::FP32 &&
+      quant.fc_dtype != DType::Q4_0) {
+    throw std::invalid_argument(
+      "Gemma4 MoE FC/expert dtype must be FP32 or Q4_0");
   }
   const std::string input_bin =
     nntr_cfg.at("model_file_name").get<std::string>();
@@ -752,18 +1020,22 @@ int run(int argc, char **argv) {
   if (!output.is_open())
     throw std::runtime_error("Failed to open " + output_path.string());
 
-  std::cout << "NNTrainer Qwen3 MoE streaming quantizer\n"
+  std::cout << "NNTrainer CausalLM streaming quantizer\n"
+            << "  Architecture: " << architecture << '\n'
             << "  Source: " << input_path << '\n'
             << "  Target: " << output_path << '\n'
-            << "  Layers: " << model.num_layers << '\n'
-            << "  Experts per layer: " << model.num_experts << '\n'
+            << "  Layers: " << num_layers << '\n'
+            << "  Experts per layer: " << num_experts << '\n'
             << "  FC dtype: " << dtypeName(quant.fc_dtype) << '\n'
             << "  Embedding dtype: " << dtypeName(quant.embedding_dtype) << '\n'
             << "  LM head dtype: " << dtypeName(quant.lmhead_dtype) << '\n'
             << "  Target ISA: " << isaName(quant.target_isa) << '\n';
 
   TensorWriter writer(input, output, quant.target_isa);
-  writeQwen3Moe(writer, model, quant);
+  if (is_qwen3_moe)
+    writeQwen3Moe(writer, qwen3_model, quant);
+  else
+    writeGemma4Moe(writer, gemma4_model, quant);
   output.close();
   if (!output)
     throw std::runtime_error("Failed to finalize " + output_path.string());

--- a/Applications/CausalLM/res/gemma4/weight_converter_stream.py
+++ b/Applications/CausalLM/res/gemma4/weight_converter_stream.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+## @file weight_converter_stream.py
+## @brief Bounded-memory HuggingFace to NNTrainer FP32 converter for Gemma4
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+
+DEFAULT_CHUNK_MIB = 64
+FP32_BYTES = 4
+MODEL_PREFIXES = (
+    "model.language_model.",
+    "language_model.",
+    "model.",
+    "",
+)
+
+
+class SafetensorsSource:
+    """Resolve tensors from a local HuggingFace safetensors checkpoint.
+
+    Only one shard is kept open at a time. Tensor payloads are requested with
+    get_slice(), so callers can materialize bounded slices instead of loading a
+    complete shard or model.
+    """
+
+    def __init__(self, model_path):
+        self.model_path = Path(model_path)
+        self.weight_map = self._load_weight_map()
+        self._active_context = None
+        self._active_handle = None
+        self._active_shard = None
+
+    def _load_weight_map(self):
+        index_path = self.model_path / "model.safetensors.index.json"
+        if index_path.is_file():
+            with index_path.open(encoding="utf-8") as index_file:
+                index = json.load(index_file)
+            weight_map = index.get("weight_map")
+            if not isinstance(weight_map, dict) or not weight_map:
+                raise ValueError(f"Invalid or empty weight_map in {index_path}")
+            return weight_map
+
+        model_file = self.model_path / "model.safetensors"
+        if not model_file.is_file():
+            raise FileNotFoundError(
+                "Expected model.safetensors or model.safetensors.index.json in "
+                f"{self.model_path}"
+            )
+        with safe_open(str(model_file), framework="pt", device="cpu") as handle:
+            return {key: model_file.name for key in handle.keys()}
+
+    def resolve_key(self, relative_key):
+        for prefix in MODEL_PREFIXES:
+            key = prefix + relative_key
+            if key in self.weight_map:
+                return key
+        raise KeyError(
+            f"Could not find '{relative_key}' under prefixes {MODEL_PREFIXES}"
+        )
+
+    def _open_shard(self, shard_name):
+        if shard_name == self._active_shard:
+            return
+        self.close()
+
+        shard_path = self.model_path / shard_name
+        if not shard_path.is_file():
+            raise FileNotFoundError(f"Missing safetensors shard: {shard_path}")
+        self._active_context = safe_open(
+            str(shard_path), framework="pt", device="cpu"
+        )
+        self._active_handle = self._active_context.__enter__()
+        self._active_shard = shard_name
+
+    def get_slice(self, relative_key):
+        key = self.resolve_key(relative_key)
+        self._open_shard(self.weight_map[key])
+        return self._active_handle.get_slice(key)
+
+    def close(self):
+        if self._active_context is not None:
+            self._active_context.__exit__(None, None, None)
+        self._active_context = None
+        self._active_handle = None
+        self._active_shard = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+class Fp32Writer:
+    """Write safetensors tensors in NNTrainer's positional FP32 layout."""
+
+    def __init__(self, source, output, chunk_bytes):
+        self.source = source
+        self.output = output
+        self.chunk_bytes = chunk_bytes
+        self.elements_written = 0
+
+    @staticmethod
+    def _check_shape(key, actual, expected):
+        actual = tuple(actual)
+        expected = tuple(expected)
+        if actual != expected:
+            raise ValueError(
+                f"Unexpected shape for {key}: expected {expected}, got {actual}"
+            )
+
+    @staticmethod
+    def _compose_slice(parent, child, dimension):
+        selected = range(dimension)[parent][child]
+        if isinstance(selected, int):
+            return selected
+        return slice(selected.start, selected.stop, selected.step)
+
+    @classmethod
+    def _compose_index(cls, view_index, child_index, source_shape):
+        source_index = []
+        logical_axis = 0
+        for axis, parent in enumerate(view_index):
+            if isinstance(parent, int):
+                source_index.append(parent)
+                continue
+            source_index.append(
+                cls._compose_slice(
+                    parent, child_index[logical_axis], source_shape[axis]
+                )
+            )
+            logical_axis += 1
+        return tuple(source_index)
+
+    def _write(self, tensor, transpose):
+        tensor = tensor.detach().cpu()
+        if transpose:
+            tensor = tensor.transpose(0, 1).contiguous()
+        if tensor.dtype != torch.float32:
+            tensor = tensor.to(torch.float32)
+        elif not tensor.is_contiguous():
+            tensor = tensor.contiguous()
+
+        array = tensor.numpy()
+        array.tofile(self.output)
+        self.elements_written += array.size
+
+    def _write_view(self, tensor_slice, source_shape, view_index, shape,
+                    transpose):
+        if len(shape) == 0:
+            self._write(tensor_slice[view_index], transpose=False)
+            return
+
+        if len(shape) == 1:
+            elements_per_chunk = max(1, self.chunk_bytes // FP32_BYTES)
+            ranges = (
+                (slice(start, min(start + elements_per_chunk, shape[0])),)
+                for start in range(0, shape[0], elements_per_chunk)
+            )
+        elif len(shape) == 2 and transpose:
+            source_rows, source_columns = shape
+            columns_per_chunk = max(
+                1, self.chunk_bytes // max(1, source_rows * FP32_BYTES)
+            )
+            ranges = (
+                (slice(None), slice(start, min(start + columns_per_chunk,
+                                               source_columns)))
+                for start in range(0, source_columns, columns_per_chunk)
+            )
+        elif len(shape) == 2:
+            source_rows, source_columns = shape
+            rows_per_chunk = max(
+                1, self.chunk_bytes // max(1, source_columns * FP32_BYTES)
+            )
+            ranges = (
+                (slice(start, min(start + rows_per_chunk, source_rows)),
+                 slice(None))
+                for start in range(0, source_rows, rows_per_chunk)
+            )
+        else:
+            raise ValueError(f"Expected a scalar, vector, or matrix, got {shape}")
+
+        for child_index in ranges:
+            source_index = self._compose_index(
+                view_index, child_index, source_shape
+            )
+            self._write(tensor_slice[source_index], transpose)
+
+    def write_tensor(self, key, expected_shape, transpose=False):
+        tensor_slice = self.source.get_slice(key)
+        source_shape = tuple(tensor_slice.get_shape())
+        self._check_shape(key, source_shape, expected_shape)
+        view_index = tuple(slice(None) for _ in source_shape)
+        self._write_view(
+            tensor_slice, source_shape, view_index, source_shape, transpose
+        )
+
+    def write_view(self, key, source_shape, view_index, expected_shape,
+                   transpose=False):
+        tensor_slice = self.source.get_slice(key)
+        actual_shape = tuple(tensor_slice.get_shape())
+        self._check_shape(key, actual_shape, source_shape)
+        if len(view_index) != len(source_shape):
+            raise ValueError(f"Invalid view rank for {key}: {view_index}")
+
+        view_shape = []
+        for dimension, index in zip(source_shape, view_index):
+            if isinstance(index, int):
+                range(dimension)[index]
+            elif isinstance(index, slice):
+                view_shape.append(len(range(dimension)[index]))
+            else:
+                raise ValueError(f"Invalid view index for {key}: {index}")
+        self._check_shape(f"{key} view", view_shape, expected_shape)
+        self._write_view(
+            tensor_slice,
+            tuple(source_shape),
+            tuple(view_index),
+            tuple(expected_shape),
+            transpose,
+        )
+
+
+def require_positive_int(config, key):
+    value = config.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"config.json requires a positive integer '{key}'")
+    return value
+
+
+def optional_positive_int(config, key, default):
+    value = config.get(key, default)
+    if value is None:
+        value = default
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"config.json requires a positive integer '{key}'")
+    return value
+
+
+def optional_nonnegative_int(config, key, default=0):
+    value = config.get(key, default)
+    if value is None:
+        value = default
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(
+            f"config.json requires a non-negative integer '{key}'"
+        )
+    return value
+
+
+def load_model_plan(model_path):
+    config_path = Path(model_path) / "config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        root_config = json.load(config_file)
+
+    architectures = root_config.get("architectures")
+    if not isinstance(architectures, list) or not architectures:
+        raise ValueError("config.json requires architectures[0]")
+    supported = ("Gemma4ForCausalLM", "Gemma4ForConditionalGeneration")
+    if architectures[0] not in supported:
+        raise ValueError(
+            "Streaming conversion only supports Gemma4, got "
+            f"{architectures[0]}"
+        )
+
+    config = root_config.get("text_config", root_config)
+    if not isinstance(config, dict):
+        raise ValueError("config.json text_config must be an object")
+
+    hidden_size = require_positive_int(config, "hidden_size")
+    vocab_size = require_positive_int(config, "vocab_size")
+    num_layers = require_positive_int(config, "num_hidden_layers")
+    num_attention_heads = require_positive_int(config, "num_attention_heads")
+    head_dim = optional_positive_int(
+        config, "head_dim", hidden_size // num_attention_heads
+    )
+    num_key_value_heads = optional_positive_int(
+        config, "num_key_value_heads", num_attention_heads
+    )
+    global_head_dim = optional_positive_int(config, "global_head_dim", head_dim)
+    num_global_key_value_heads = optional_positive_int(
+        config, "num_global_key_value_heads", num_key_value_heads
+    )
+
+    layer_types = config.get(
+        "layer_types", ["sliding_attention"] * num_layers
+    )
+    if not isinstance(layer_types, list) or len(layer_types) != num_layers:
+        raise ValueError("layer_types must contain one entry per hidden layer")
+    for layer_type in layer_types:
+        if layer_type not in ("sliding_attention", "full_attention"):
+            raise ValueError(f"Unsupported Gemma4 layer type: {layer_type}")
+
+    num_kv_shared_layers = optional_nonnegative_int(
+        config, "num_kv_shared_layers"
+    )
+    if num_kv_shared_layers >= num_layers:
+        raise ValueError("num_kv_shared_layers must be less than num_hidden_layers")
+
+    ple_size = optional_nonnegative_int(
+        config, "hidden_size_per_layer_input"
+    )
+    ple_vocab_size = optional_positive_int(
+        config, "vocab_size_per_layer_input", vocab_size
+    )
+    enable_moe = bool(config.get("enable_moe_block", False))
+    if enable_moe:
+        moe_intermediate_size = require_positive_int(
+            config, "moe_intermediate_size"
+        )
+        num_experts = require_positive_int(config, "num_experts")
+    else:
+        moe_intermediate_size = 0
+        num_experts = 0
+
+    tied_embeddings = bool(
+        config.get(
+            "tie_word_embeddings",
+            root_config.get("tie_word_embeddings", True),
+        )
+    )
+    return {
+        "hidden_size": hidden_size,
+        "vocab_size": vocab_size,
+        "num_layers": num_layers,
+        "num_attention_heads": num_attention_heads,
+        "num_key_value_heads": num_key_value_heads,
+        "head_dim": head_dim,
+        "global_head_dim": global_head_dim,
+        "num_global_key_value_heads": num_global_key_value_heads,
+        "intermediate_size": require_positive_int(config, "intermediate_size"),
+        "moe_intermediate_size": moe_intermediate_size,
+        "num_experts": num_experts,
+        "num_kv_shared_layers": num_kv_shared_layers,
+        "layer_types": layer_types,
+        "attention_k_eq_v": bool(config.get("attention_k_eq_v", False)),
+        "enable_moe": enable_moe,
+        "ple_size": ple_size,
+        "ple_vocab_size": ple_vocab_size,
+        "tied_embeddings": tied_embeddings,
+    }
+
+
+def write_gemma4(source, output, model, chunk_bytes):
+    writer = Fp32Writer(source, output, chunk_bytes)
+    hidden_size = model["hidden_size"]
+    dense_width = model["intermediate_size"]
+    first_kv_shared_layer = (
+        model["num_layers"] - model["num_kv_shared_layers"]
+    )
+
+    writer.write_tensor(
+        "embed_tokens.weight", (model["vocab_size"], hidden_size)
+    )
+
+    for layer in range(model["num_layers"]):
+        prefix = f"layers.{layer}."
+        is_sliding = model["layer_types"][layer] == "sliding_attention"
+        is_kv_shared = layer >= first_kv_shared_layer
+        head_dim = model["head_dim"] if is_sliding else model["global_head_dim"]
+        kv_heads = (
+            model["num_key_value_heads"]
+            if is_sliding or not model["attention_k_eq_v"]
+            else model["num_global_key_value_heads"]
+        )
+        query_width = model["num_attention_heads"] * head_dim
+        kv_width = kv_heads * head_dim
+
+        writer.write_tensor(f"{prefix}input_layernorm.weight", (hidden_size,))
+        writer.write_tensor(
+            f"{prefix}self_attn.q_proj.weight",
+            (query_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(f"{prefix}self_attn.q_norm.weight", (head_dim,))
+
+        if not is_kv_shared:
+            writer.write_tensor(
+                f"{prefix}self_attn.k_proj.weight",
+                (kv_width, hidden_size),
+                transpose=True,
+            )
+            writer.write_tensor(f"{prefix}self_attn.k_norm.weight", (head_dim,))
+            if not (model["attention_k_eq_v"] and not is_sliding):
+                writer.write_tensor(
+                    f"{prefix}self_attn.v_proj.weight",
+                    (kv_width, hidden_size),
+                    transpose=True,
+                )
+
+        writer.write_tensor(
+            f"{prefix}self_attn.o_proj.weight",
+            (hidden_size, query_width),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}post_attention_layernorm.weight", (hidden_size,)
+        )
+        writer.write_tensor(
+            f"{prefix}pre_feedforward_layernorm.weight", (hidden_size,)
+        )
+        writer.write_tensor(
+            f"{prefix}mlp.gate_proj.weight",
+            (dense_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}mlp.up_proj.weight",
+            (dense_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}mlp.down_proj.weight",
+            (hidden_size, dense_width),
+            transpose=True,
+        )
+
+        if model["enable_moe"]:
+            writer.write_tensor(
+                f"{prefix}post_feedforward_layernorm_1.weight", (hidden_size,)
+            )
+            writer.write_tensor(
+                f"{prefix}pre_feedforward_layernorm_2.weight", (hidden_size,)
+            )
+            writer.write_tensor(
+                f"{prefix}router.proj.weight",
+                (model["num_experts"], hidden_size),
+                transpose=True,
+            )
+            writer.write_tensor(f"{prefix}router.scale", (hidden_size,))
+            writer.write_tensor(
+                f"{prefix}router.per_expert_scale", (model["num_experts"],)
+            )
+
+            moe_width = model["moe_intermediate_size"]
+            gate_up_shape = (model["num_experts"], 2 * moe_width, hidden_size)
+            down_shape = (model["num_experts"], hidden_size, moe_width)
+            for expert in range(model["num_experts"]):
+                writer.write_view(
+                    f"{prefix}experts.gate_up_proj",
+                    gate_up_shape,
+                    (expert, slice(0, moe_width), slice(None)),
+                    (moe_width, hidden_size),
+                    transpose=True,
+                )
+                writer.write_view(
+                    f"{prefix}experts.gate_up_proj",
+                    gate_up_shape,
+                    (expert, slice(moe_width, None), slice(None)),
+                    (moe_width, hidden_size),
+                    transpose=True,
+                )
+                writer.write_view(
+                    f"{prefix}experts.down_proj",
+                    down_shape,
+                    (expert, slice(None), slice(None)),
+                    (hidden_size, moe_width),
+                    transpose=True,
+                )
+
+            writer.write_tensor(
+                f"{prefix}post_feedforward_layernorm_2.weight", (hidden_size,)
+            )
+
+        writer.write_tensor(
+            f"{prefix}post_feedforward_layernorm.weight", (hidden_size,)
+        )
+
+        if model["ple_size"] > 0:
+            ple_size = model["ple_size"]
+            total_ple_size = model["num_layers"] * ple_size
+            writer.write_tensor(
+                f"{prefix}per_layer_input_gate.weight",
+                (ple_size, hidden_size),
+                transpose=True,
+            )
+            if layer == 0:
+                writer.write_tensor(
+                    "embed_tokens_per_layer.weight",
+                    (model["ple_vocab_size"], total_ple_size),
+                )
+                writer.write_tensor(
+                    "per_layer_model_projection.weight",
+                    (total_ple_size, hidden_size),
+                    transpose=True,
+                )
+                writer.write_tensor(
+                    "per_layer_projection_norm.weight", (ple_size,)
+                )
+            writer.write_tensor(
+                f"{prefix}per_layer_projection.weight",
+                (hidden_size, ple_size),
+                transpose=True,
+            )
+            writer.write_tensor(
+                f"{prefix}post_per_layer_input_norm.weight", (hidden_size,)
+            )
+
+        writer.write_tensor(f"{prefix}layer_scalar", (1,))
+        print(f"  Converted layer {layer + 1}/{model['num_layers']}")
+
+    writer.write_tensor("norm.weight", (hidden_size,))
+    if model["tied_embeddings"]:
+        # Match the legacy Gemma4 binary converter and NNTrainer lm-head save.
+        writer.write_tensor(
+            "embed_tokens.weight", (model["vocab_size"], hidden_size)
+        )
+    else:
+        writer.write_tensor(
+            "lm_head.weight",
+            (model["vocab_size"], hidden_size),
+            transpose=True,
+        )
+    return writer.elements_written * FP32_BYTES
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert local HuggingFace Gemma4 safetensors to an NNTrainer "
+            "FP32 .bin without loading the full model"
+        )
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--output_name", required=True)
+    parser.add_argument(
+        "--chunk_size_mib",
+        type=int,
+        default=DEFAULT_CHUNK_MIB,
+        help=f"Maximum FP32 output chunk size (default: {DEFAULT_CHUNK_MIB})",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing output file",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model_path = Path(args.model_path)
+    output_path = Path(args.output_name)
+    partial_path = output_path.with_name(output_path.name + ".part")
+
+    if args.chunk_size_mib <= 0:
+        raise ValueError("--chunk_size_mib must be greater than zero")
+    if output_path.suffix != ".bin":
+        raise ValueError("--output_name must use the .bin extension")
+    if output_path.exists() and not args.overwrite:
+        raise FileExistsError(
+            f"Output already exists: {output_path}; pass --overwrite to replace it"
+        )
+
+    model = load_model_plan(model_path)
+    chunk_bytes = args.chunk_size_mib * 1024 * 1024
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print("NNTrainer Gemma4 streaming FP32 converter")
+    print(f"  Source: {model_path}")
+    print(f"  Target: {output_path}")
+    print(f"  Layers: {model['num_layers']}")
+    print(f"  Experts per layer: {model['num_experts']}")
+    print(f"  Chunk size: {args.chunk_size_mib} MiB")
+
+    try:
+        with SafetensorsSource(model_path) as source:
+            with partial_path.open("wb") as output:
+                expected_size = write_gemma4(
+                    source, output, model, chunk_bytes
+                )
+        actual_size = partial_path.stat().st_size
+        if actual_size != expected_size:
+            raise RuntimeError(
+                "Unexpected output size: "
+                f"expected {expected_size} bytes, got {actual_size}"
+            )
+        os.replace(partial_path, output_path)
+    except BaseException:
+        partial_path.unlink(missing_ok=True)
+        raise
+
+    print(f"Completed: {output_path} ({expected_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/Applications/CausalLM/res/qwen3/qwen3-30b-a3b/weight_converter_stream.py
+++ b/Applications/CausalLM/res/qwen3/qwen3-30b-a3b/weight_converter_stream.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+
+## @file weight_converter_stream.py
+## @brief Bounded-memory HuggingFace to NNTrainer FP32 converter for Qwen3 MoE
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+
+DEFAULT_CHUNK_MIB = 64
+FP32_BYTES = 4
+
+
+class SafetensorsSource:
+    """Resolve tensors from a local HuggingFace safetensors checkpoint.
+
+    Only one shard is kept open at a time. Tensor payloads are requested with
+    get_slice(), so callers can materialize bounded slices instead of loading a
+    complete shard or model.
+    """
+
+    def __init__(self, model_path):
+        self.model_path = Path(model_path)
+        self.weight_map = self._load_weight_map()
+        self._active_context = None
+        self._active_handle = None
+        self._active_shard = None
+
+    def _load_weight_map(self):
+        index_path = self.model_path / "model.safetensors.index.json"
+        if index_path.is_file():
+            with index_path.open(encoding="utf-8") as index_file:
+                index = json.load(index_file)
+            weight_map = index.get("weight_map")
+            if not isinstance(weight_map, dict) or not weight_map:
+                raise ValueError(f"Invalid or empty weight_map in {index_path}")
+            return weight_map
+
+        model_file = self.model_path / "model.safetensors"
+        if not model_file.is_file():
+            raise FileNotFoundError(
+                "Expected model.safetensors or model.safetensors.index.json in "
+                f"{self.model_path}"
+            )
+        with safe_open(str(model_file), framework="pt", device="cpu") as handle:
+            return {key: model_file.name for key in handle.keys()}
+
+    def _open_shard(self, shard_name):
+        if shard_name == self._active_shard:
+            return
+        self.close()
+
+        shard_path = self.model_path / shard_name
+        if not shard_path.is_file():
+            raise FileNotFoundError(f"Missing safetensors shard: {shard_path}")
+        self._active_context = safe_open(
+            str(shard_path), framework="pt", device="cpu"
+        )
+        self._active_handle = self._active_context.__enter__()
+        self._active_shard = shard_name
+
+    def get_slice(self, key):
+        if key not in self.weight_map:
+            raise KeyError(f"Missing tensor in HuggingFace checkpoint: {key}")
+        self._open_shard(self.weight_map[key])
+        return self._active_handle.get_slice(key)
+
+    def close(self):
+        if self._active_context is not None:
+            self._active_context.__exit__(None, None, None)
+        self._active_context = None
+        self._active_handle = None
+        self._active_shard = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+class Fp32Writer:
+    """Write safetensors tensors in NNTrainer's positional FP32 layout."""
+
+    def __init__(self, source, output, chunk_bytes):
+        self.source = source
+        self.output = output
+        self.chunk_bytes = chunk_bytes
+        self.elements_written = 0
+
+    @staticmethod
+    def _check_shape(key, actual, expected):
+        actual = tuple(actual)
+        expected = tuple(expected)
+        if actual != expected:
+            raise ValueError(
+                f"Unexpected shape for {key}: expected {expected}, got {actual}"
+            )
+
+    def _write(self, tensor, transpose):
+        tensor = tensor.detach().cpu()
+        if transpose:
+            tensor = tensor.transpose(0, 1).contiguous()
+        if tensor.dtype != torch.float32:
+            tensor = tensor.to(torch.float32)
+        elif not tensor.is_contiguous():
+            tensor = tensor.contiguous()
+
+        array = tensor.numpy()
+        array.tofile(self.output)
+        self.elements_written += array.size
+
+    def write_tensor(self, key, expected_shape, transpose=False):
+        tensor_slice = self.source.get_slice(key)
+        shape = tuple(tensor_slice.get_shape())
+        self._check_shape(key, shape, expected_shape)
+
+        if transpose:
+            if len(shape) != 2:
+                raise ValueError(f"Cannot transpose non-matrix tensor: {key}")
+            source_rows, source_columns = shape
+            columns_per_chunk = max(
+                1, self.chunk_bytes // (source_rows * FP32_BYTES)
+            )
+            for column in range(0, source_columns, columns_per_chunk):
+                end = min(column + columns_per_chunk, source_columns)
+                self._write(tensor_slice[:, column:end], transpose=True)
+            return
+
+        if len(shape) == 1:
+            elements_per_chunk = max(1, self.chunk_bytes // FP32_BYTES)
+            for element in range(0, shape[0], elements_per_chunk):
+                end = min(element + elements_per_chunk, shape[0])
+                self._write(tensor_slice[element:end], transpose=False)
+            return
+
+        if len(shape) != 2:
+            raise ValueError(f"Expected a vector or matrix tensor: {key}")
+        row_bytes = shape[1] * FP32_BYTES
+        rows_per_chunk = max(1, self.chunk_bytes // row_bytes)
+        for row in range(0, shape[0], rows_per_chunk):
+            end = min(row + rows_per_chunk, shape[0])
+            self._write(tensor_slice[row:end, :], transpose=False)
+
+
+def require_positive_int(config, key):
+    value = config.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"config.json requires a positive integer '{key}'")
+    return value
+
+
+def load_model_plan(model_path):
+    config_path = Path(model_path) / "config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        config = json.load(config_file)
+
+    architectures = config.get("architectures")
+    if not isinstance(architectures, list) or not architectures:
+        raise ValueError("config.json requires architectures[0]")
+    if architectures[0] != "Qwen3MoeForCausalLM":
+        raise ValueError(
+            "Streaming conversion only supports Qwen3MoeForCausalLM, got "
+            f"{architectures[0]}"
+        )
+
+    hidden_size = require_positive_int(config, "hidden_size")
+    num_attention_heads = require_positive_int(config, "num_attention_heads")
+    head_dim = config.get("head_dim", hidden_size // num_attention_heads)
+    if not isinstance(head_dim, int) or isinstance(head_dim, bool) or head_dim <= 0:
+        raise ValueError("config.json requires a positive integer 'head_dim'")
+
+    return {
+        "hidden_size": hidden_size,
+        "vocab_size": require_positive_int(config, "vocab_size"),
+        "num_layers": require_positive_int(config, "num_hidden_layers"),
+        "num_attention_heads": num_attention_heads,
+        "num_key_value_heads": require_positive_int(
+            config, "num_key_value_heads"
+        ),
+        "head_dim": head_dim,
+        "moe_intermediate_size": require_positive_int(
+            config, "moe_intermediate_size"
+        ),
+        "num_experts": require_positive_int(config, "num_experts"),
+        "tied_embeddings": bool(config.get("tie_word_embeddings", False)),
+    }
+
+
+def write_qwen3_moe(source, output, model, chunk_bytes):
+    writer = Fp32Writer(source, output, chunk_bytes)
+    hidden_size = model["hidden_size"]
+    query_width = model["num_attention_heads"] * model["head_dim"]
+    kv_width = model["num_key_value_heads"] * model["head_dim"]
+    moe_width = model["moe_intermediate_size"]
+
+    writer.write_tensor(
+        "model.embed_tokens.weight",
+        (model["vocab_size"], hidden_size),
+    )
+
+    for layer in range(model["num_layers"]):
+        prefix = f"model.layers.{layer}."
+        writer.write_tensor(
+            f"{prefix}input_layernorm.weight", (hidden_size,)
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.q_proj.weight",
+            (query_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.q_norm.weight", (model["head_dim"],)
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.k_proj.weight",
+            (kv_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.k_norm.weight", (model["head_dim"],)
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.v_proj.weight",
+            (kv_width, hidden_size),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}self_attn.o_proj.weight",
+            (hidden_size, query_width),
+            transpose=True,
+        )
+        writer.write_tensor(
+            f"{prefix}post_attention_layernorm.weight", (hidden_size,)
+        )
+        writer.write_tensor(
+            f"{prefix}mlp.gate.weight",
+            (model["num_experts"], hidden_size),
+            transpose=True,
+        )
+
+        for expert in range(model["num_experts"]):
+            expert_prefix = f"{prefix}mlp.experts.{expert}."
+            for projection, shape in (
+                ("up_proj", (moe_width, hidden_size)),
+                ("gate_proj", (moe_width, hidden_size)),
+                ("down_proj", (hidden_size, moe_width)),
+            ):
+                writer.write_tensor(
+                    f"{expert_prefix}{projection}.weight",
+                    shape,
+                    transpose=True,
+                )
+
+        print(f"  Converted layer {layer + 1}/{model['num_layers']}")
+
+    writer.write_tensor("model.norm.weight", (hidden_size,))
+    if not model["tied_embeddings"]:
+        writer.write_tensor(
+            "lm_head.weight",
+            (model["vocab_size"], hidden_size),
+            transpose=True,
+        )
+    return writer.elements_written * FP32_BYTES
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert local HuggingFace Qwen3-MoE safetensors to an NNTrainer "
+            "FP32 .bin without loading the full model"
+        )
+    )
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--output_name", required=True)
+    parser.add_argument(
+        "--chunk_size_mib",
+        type=int,
+        default=DEFAULT_CHUNK_MIB,
+        help=f"Maximum FP32 output chunk size (default: {DEFAULT_CHUNK_MIB})",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing output file",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model_path = Path(args.model_path)
+    output_path = Path(args.output_name)
+    partial_path = output_path.with_name(output_path.name + ".part")
+
+    if args.chunk_size_mib <= 0:
+        raise ValueError("--chunk_size_mib must be greater than zero")
+    if output_path.suffix != ".bin":
+        raise ValueError("--output_name must use the .bin extension")
+    if output_path.exists() and not args.overwrite:
+        raise FileExistsError(
+            f"Output already exists: {output_path}; pass --overwrite to replace it"
+        )
+
+    model = load_model_plan(model_path)
+    chunk_bytes = args.chunk_size_mib * 1024 * 1024
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print("NNTrainer Qwen3 MoE streaming FP32 converter")
+    print(f"  Source: {model_path}")
+    print(f"  Target: {output_path}")
+    print(f"  Layers: {model['num_layers']}")
+    print(f"  Experts per layer: {model['num_experts']}")
+    print(f"  Chunk size: {args.chunk_size_mib} MiB")
+
+    try:
+        with SafetensorsSource(model_path) as source:
+            with partial_path.open("wb") as output:
+                expected_size = write_qwen3_moe(
+                    source, output, model, chunk_bytes
+                )
+        actual_size = partial_path.stat().st_size
+        if actual_size != expected_size:
+            raise RuntimeError(
+                "Unexpected output size: "
+                f"expected {expected_size} bytes, got {actual_size}"
+            )
+        os.replace(partial_path, output_path)
+    except BaseException:
+        partial_path.unlink(missing_ok=True)
+        raise
+
+    print(f"Completed: {output_path} ({expected_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unittest/models/causallm_reference/generators/test_gemma4_weight_converter_stream.py
+++ b/test/unittest/models/causallm_reference/generators/test_gemma4_weight_converter_stream.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the bounded-memory Gemma4 FP32 converter."""
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+
+torch_stub = types.ModuleType("torch")
+torch_stub.float32 = "float32"
+safetensors_stub = types.ModuleType("safetensors")
+safetensors_stub.safe_open = None
+
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("safetensors", safetensors_stub)
+
+SCRIPT = (
+    pathlib.Path(__file__).parents[5]
+    / "Applications"
+    / "CausalLM"
+    / "res"
+    / "gemma4"
+    / "weight_converter_stream.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "gemma4_weight_converter_stream", SCRIPT
+)
+CONVERTER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CONVERTER)
+
+
+class MatrixSlice:
+    """Small safetensors slice stand-in for layout tests."""
+
+    def __init__(self, rows, columns):
+        self.values = [
+            [row * columns + column for column in range(columns)]
+            for row in range(rows)
+        ]
+
+    def get_shape(self):
+        return (len(self.values), len(self.values[0]))
+
+    def __getitem__(self, index):
+        rows, columns = index
+        return [
+            [self.values[row][column] for column in range(len(self.values[0]))[
+                columns
+            ]]
+            for row in range(len(self.values))[rows]
+        ]
+
+
+class SingleTensorSource:
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+    def get_slice(self, _key):
+        return self.tensor
+
+
+class ListWriter(CONVERTER.Fp32Writer):
+    """Fp32Writer variant that writes integer lists instead of torch data."""
+
+    def _write(self, tensor, transpose):
+        if transpose:
+            tensor = [list(row) for row in zip(*tensor)]
+        values = [value for row in tensor for value in row]
+        self.output.extend(values)
+        self.elements_written += len(values)
+
+
+class RecordingSlice:
+    def __init__(self, shape):
+        self.shape = shape
+        self.requests = []
+
+    def get_shape(self):
+        return self.shape
+
+    def __getitem__(self, index):
+        self.requests.append(index)
+        return index
+
+
+class IndexWriter(CONVERTER.Fp32Writer):
+    def _write(self, _tensor, _transpose):
+        return
+
+
+class Gemma4WeightConverterStreamTest(unittest.TestCase):
+    def test_streamed_transpose_preserves_output_layout(self):
+        source = SingleTensorSource(MatrixSlice(3, 5))
+        output = []
+        writer = ListWriter(
+            source, output, 3 * 2 * CONVERTER.FP32_BYTES
+        )
+
+        writer.write_tensor("matrix", (3, 5), transpose=True)
+
+        self.assertEqual(
+            output,
+            [0, 5, 10, 1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14],
+        )
+        self.assertEqual(writer.elements_written, 15)
+
+    def test_expert_view_composes_chunk_with_fused_slice(self):
+        tensor = RecordingSlice((2, 6, 4))
+        writer = IndexWriter(
+            SingleTensorSource(tensor), [], 3 * 2 * CONVERTER.FP32_BYTES
+        )
+
+        writer.write_view(
+            "experts.gate_up_proj",
+            (2, 6, 4),
+            (1, slice(3, None), slice(None)),
+            (3, 4),
+            transpose=True,
+        )
+
+        self.assertEqual(
+            tensor.requests,
+            [
+                (1, slice(3, 6, 1), slice(0, 2, 1)),
+                (1, slice(3, 6, 1), slice(2, 4, 1)),
+            ],
+        )
+
+    def test_source_keeps_only_active_shard_open(self):
+        events = []
+
+        class Handle:
+            def __init__(self, path):
+                self.path = pathlib.Path(path).name
+
+            def get_slice(self, key):
+                events.append(("slice", self.path, key))
+                return key
+
+        class Context:
+            def __init__(self, path):
+                self.path = pathlib.Path(path).name
+
+            def __enter__(self):
+                events.append(("open", self.path))
+                return Handle(self.path)
+
+            def __exit__(self, _exc_type, _exc_value, _traceback):
+                events.append(("close", self.path))
+
+        with tempfile.TemporaryDirectory() as directory:
+            model_path = pathlib.Path(directory)
+            for shard in ("a.safetensors", "b.safetensors"):
+                (model_path / shard).touch()
+
+            source = CONVERTER.SafetensorsSource.__new__(
+                CONVERTER.SafetensorsSource
+            )
+            source.model_path = model_path
+            source.weight_map = {
+                "model.weight_a": "a.safetensors",
+                "model.weight_b": "b.safetensors",
+            }
+            source._active_context = None
+            source._active_handle = None
+            source._active_shard = None
+
+            with mock.patch.object(
+                CONVERTER,
+                "safe_open",
+                side_effect=lambda path, framework, device: Context(path),
+            ):
+                self.assertEqual(source.get_slice("weight_a"), "model.weight_a")
+                self.assertEqual(source.get_slice("weight_a"), "model.weight_a")
+                self.assertEqual(source.get_slice("weight_b"), "model.weight_b")
+                source.close()
+
+        self.assertEqual(
+            events,
+            [
+                ("open", "a.safetensors"),
+                ("slice", "a.safetensors", "model.weight_a"),
+                ("slice", "a.safetensors", "model.weight_a"),
+                ("close", "a.safetensors"),
+                ("open", "b.safetensors"),
+                ("slice", "b.safetensors", "model.weight_b"),
+                ("close", "b.safetensors"),
+            ],
+        )
+
+    def test_nested_config_builds_moe_plan(self):
+        config = {
+            "architectures": ["Gemma4ForConditionalGeneration"],
+            "text_config": {
+                "hidden_size": 64,
+                "vocab_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "global_head_dim": 16,
+                "num_global_key_value_heads": 1,
+                "intermediate_size": 96,
+                "moe_intermediate_size": 24,
+                "num_experts": 4,
+                "enable_moe_block": True,
+                "layer_types": ["sliding_attention", "full_attention"],
+                "attention_k_eq_v": True,
+                "hidden_size_per_layer_input": 0,
+                "tie_word_embeddings": True,
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "config.json"
+            path.write_text(json.dumps(config), encoding="utf-8")
+            plan = CONVERTER.load_model_plan(directory)
+
+        self.assertEqual(plan["global_head_dim"], 16)
+        self.assertEqual(plan["moe_intermediate_size"], 24)
+        self.assertEqual(plan["num_experts"], 4)
+        self.assertTrue(plan["attention_k_eq_v"])
+        self.assertTrue(plan["tied_embeddings"])
+
+    def test_weight_order_omits_full_attention_v_and_splits_experts(self):
+        calls = []
+
+        class RecordingWriter:
+            def __init__(self, _source, _output, _chunk_bytes):
+                self.elements_written = 0
+
+            def write_tensor(self, key, shape, transpose=False):
+                calls.append(("tensor", key, shape, transpose))
+
+            def write_view(self, key, source_shape, index, shape,
+                           transpose=False):
+                calls.append(
+                    ("view", key, source_shape, index, shape, transpose)
+                )
+
+        model = {
+            "hidden_size": 64,
+            "vocab_size": 32,
+            "num_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "global_head_dim": 16,
+            "num_global_key_value_heads": 1,
+            "intermediate_size": 96,
+            "moe_intermediate_size": 24,
+            "num_experts": 2,
+            "num_kv_shared_layers": 0,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "attention_k_eq_v": True,
+            "enable_moe": True,
+            "ple_size": 0,
+            "ple_vocab_size": 32,
+            "tied_embeddings": True,
+        }
+
+        with mock.patch.object(CONVERTER, "Fp32Writer", RecordingWriter):
+            CONVERTER.write_gemma4(None, None, model, 64)
+
+        tensor_keys = [call[1] for call in calls if call[0] == "tensor"]
+        self.assertIn("layers.0.self_attn.v_proj.weight", tensor_keys)
+        self.assertNotIn("layers.1.self_attn.v_proj.weight", tensor_keys)
+        self.assertEqual(tensor_keys[-2:], ["norm.weight", "embed_tokens.weight"])
+
+        expert_calls = [call for call in calls if call[0] == "view"]
+        self.assertEqual(len(expert_calls), 2 * 2 * 3)
+        self.assertEqual(
+            expert_calls[0][3],
+            (0, slice(0, 24), slice(None)),
+        )
+        self.assertEqual(
+            expert_calls[1][3],
+            (0, slice(24, None), slice(None)),
+        )
+        self.assertEqual(expert_calls[2][1], "layers.0.experts.down_proj")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittest/models/causallm_reference/generators/test_gemma4_weight_converter_stream.py
+++ b/test/unittest/models/causallm_reference/generators/test_gemma4_weight_converter_stream.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+## @file test_gemma4_weight_converter_stream.py
+## @brief Unit tests for the bounded-memory Gemma4 FP32 converter
+
 """Unit tests for the bounded-memory Gemma4 FP32 converter."""
 
 import importlib.util


### PR DESCRIPTION
## Dependency of the PR

None.

## Commits to be reviewed in this PR

<details><summary>[CausalLM] Add Qwen3 MoE streaming FP32 converter</summary><br />

[CausalLM] Add Qwen3 MoE streaming FP32 converter

Convert sharded HuggingFace safetensors into NNTrainer FP32 weights with bounded memory.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

<details><summary>[CausalLM] Add Qwen3 MoE streaming quantizer</summary><br />

[CausalLM] Add Qwen3 MoE streaming quantizer

Quantize NNTrainer FP32 weights into Q4_0, Q4_K, or Q6_K output with bounded memory.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>

</details>

## Background

### Problem

Qwen3-30B-A3B contains about 30.5 billion parameters. Its NNTrainer FP32 weight file is approximately 122 GB (113.7 GiB).

The existing HuggingFace conversion path constructs the entire model in FP32 before writing the NNTrainer binary. It therefore needs at least the full 113.7 GiB weight size in RAM, with additional memory required for framework
objects and tensor conversion/transposition buffers.

The existing quantization path also initializes the complete NNTrainer model and loads the FP32 weights before quantizing them. Its baseline RAM requirement is again over 110 GiB, with additional temporary quantization buffers.

These operations do not fit on typical personal computers with 32 or 64 GiB of RAM and generally require a high-end server with substantially more memory.

### Solution

Introduce a bounded-memory, two-stage streaming pipeline:

1. Stream HuggingFace safetensors shards into the NNTrainer FP32 binary. Only one shard is open at a time, and large tensors and transposes are processed in configurable chunks (64 MiB by default).
2. Stream the NNTrainer FP32 binary into Q4_0, Q4_K, or Q6_K output. Each tensor is read, converted, and written immediately; large transposes such as the LM head are also processed in bounded blocks.

Peak RAM is therefore determined by the active tensor chunks and quantization buffers instead of the approximately 114 GiB FP32 model size. The conversion still requires enough disk space for the FP32 intermediate file.


### Summary

- Add bounded-memory conversion from sharded HuggingFace Qwen3-MoE safetensors to the NNTrainer FP32 binary layout.
- Add streaming Q4_0, Q4_K, and Q6_K quantization for Qwen3-MoE without initializing the full model.
- Validate the stream with a BF16 multi-shard fixture, byte-for-byte comparison, and an NNTrainer FP32 round-trip.

Signed-off-by: Jungwon-Lee <jungone.lee@samsung.com>
