### PR TITLE
[CI] prevent `check review` cancellation

### DIFF
--- a/.github/workflows/check_count.yml
+++ b/.github/workflows/check_count.yml
@@ -7,7 +7,7 @@ on:
     types: [edited, dismissed, submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[CI] prevent check review cancellation</summary><br />

This commit prevents check review CI cancellation by separating two
triggered events: pull_request and pull_request_review.

The Check Review workflow triggers on both pull_request and
pull_request_review events, but they shared one concurrency group.
If pull_request_review event triggers before pull_request finishes,
check_review (pull_request) event fails due to cancellation while
check_review (pull_request_review) suceeds.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped


Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
