### PR TITLE
[CI] check_review: trigger only on review submission

### DIFF
--- a/.github/workflows/check_count.yml
+++ b/.github/workflows/check_count.yml
@@ -1,10 +1,8 @@
 name: Check Review
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
   pull_request_review:
-    types: [edited, dismissed, submitted]
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[CI] check_review: trigger only on review submission</summary><br />

Reduce the triggers to pull_request_review [submitted]. This drops the
pull_request (opened/edited/reopened/synchronize) and review
(edited/dismissed) events that never change the approval count, which
removes redundant runs and the cross-event concurrency cancellations
that left a stale "cancelled" check on the PR.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

`check_review` triggers `labeler` workflows which checks `review count >= 2`.
So, we just need to run `check_review` when new review is submitted.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
