### PR TITLE
[CI] skip redundant CI build

### DIFF
--- a/.github/workflows/causallm_android.yml
+++ b/.github/workflows/causallm_android.yml
@@ -18,12 +18,20 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: nttld/setup-ndk@v1
+    # Skip the heavy build for doc-only PRs
+    # env.rebuild == '1' means PR contains non doc changes
+    - name: Check if rebuild required
+      if: github.event_name == 'pull_request'
+      uses: ./.github/actions/check-rebuild
+
+    - if: github.event_name != 'pull_request' || env.rebuild == '1'
+      uses: nttld/setup-ndk@v1
       with:
         ndk-version: r26d
         link-to-sdk: true
 
     - name: Install required packages
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       run: |
         sudo apt-get update
         sudo apt-get install -y tar wget gzip libglib2.0-dev libjson-glib-dev \
@@ -33,9 +41,11 @@ jobs:
           libflatbuffers-dev flatbuffers-compiler protobuf-compiler
 
     - name: Install submodules
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       run: git submodule sync && git submodule update --init --recursive
 
     - name: Install Rust
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -44,6 +54,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Build CausalLM for Android
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       run: |
         chmod +x Applications/CausalLM/build_android.sh
         chmod +x Applications/CausalLM/build_tokenizer_android.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,8 +58,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check if rebuild required
+      if: github.event_name == 'pull_request'
+      uses: ./.github/actions/check-rebuild
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
@@ -75,7 +81,7 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
+    - if: (github.event_name != 'pull_request' || env.rebuild == '1') && matrix.build-mode == 'manual'
       shell: bash
       run: |
         sudo rm -f /etc/apt/sources.list.d/azure-cli.sources /etc/apt/sources.list.d/azure-cli.list || true
@@ -111,6 +117,7 @@ jobs:
           build/
         meson compile -C build/
     - name: Perform CodeQL Analysis
+      if: github.event_name != 'pull_request' || env.rebuild == '1'
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -19,30 +19,42 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check if rebuild required
+      uses: ./.github/actions/check-rebuild
     - name: Set up Python 3.10
+      if: env.rebuild == '1'
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: install additional package from PPA for testing
+      if: env.rebuild == '1'
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements
+      if: env.rebuild == '1'
       run: sudo apt-get update && sudo apt-get install -y gcc g++ pkg-config libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
+      if: env.rebuild == '1'
       run: sudo apt-get install -y python3-dev python3-numpy python3
     - name: gcc version change
+      if: env.rebuild == '1'
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt-get update
         sudo apt-get install -y --fix-broken build-essential
         sudo apt-get install -y gcc-13 g++-13 libcc1-0 libgcc-13-dev
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000 
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 1000
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 1000
         sudo update-alternatives --set gcc /usr/bin/gcc-13
     - name: Install submodules
+      if: env.rebuild == '1'
       run: git submodule sync && git submodule update --init --recursive
     - name: install build systems
+      if: env.rebuild == '1'
       run: sudo apt install meson ninja-build
-    - run: |
+    - if: env.rebuild == '1'
+      run: |
         causallm_option="-Denable-transformer=false"
         if [ "${{ matrix.meson_options }}" = "-Denable-fp16=false" ]; then
           causallm_option="-Denable-transformer=true"
@@ -69,7 +81,7 @@ jobs:
           ${{ matrix.meson_options }} \
           build
     - name: Check CausalLM model tests are enabled
-      if: ${{ matrix.meson_options == '-Denable-fp16=false' }}
+      if: ${{ matrix.meson_options == '-Denable-fp16=false' && env.rebuild == '1' }}
       run: |
         meson introspect build --tests > meson-tests.json
         python3 - <<'PY'
@@ -89,8 +101,11 @@ jobs:
 
         print("CausalLM Meson model tests enabled: " + ", ".join(sorted(required_tests)))
         PY
-    - run: ninja -C build
+    - if: env.rebuild == '1'
+      run: ninja -C build
     - name: run App Tests
+      if: env.rebuild == '1'
       run: meson test -C build --no-suite unittests --print-errorlogs
     - name: run Unittests
+      if: env.rebuild == '1'
       run: meson test -C build --suite unittests --print-errorlogs

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -2,7 +2,7 @@ name: "Build Test - Ubuntu Meson"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -17,25 +17,39 @@ jobs:
         os: [ ubuntu-22.04, ubuntu-24.04 ]
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check if rebuild required
+      uses: ./.github/actions/check-rebuild
     - name: Set up Python 3.10
+      if: env.rebuild == '1'
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: install additional package from PPA for testing
+      if: env.rebuild == '1'
       run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
     - name: install minimal requirements
+      if: env.rebuild == '1'
       run: sudo apt-get update && sudo apt-get install -y libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
     - name: install additional packages for features
+      if: env.rebuild == '1'
       run: sudo apt-get install -y python3-dev python3-numpy python3
     - name: Install llvm
+      if: env.rebuild == '1'
       run: sudo apt install -y llvm
     - name: Install submodules
+      if: env.rebuild == '1'
       run: git submodule sync && git submodule update --init --recursive
     - name: Install build systems
+      if: env.rebuild == '1'
       run: sudo apt install meson ninja-build
     - name: Prepare Build
+      if: env.rebuild == '1'
       run: meson setup --native-file configurations/linux-native-clang.ini builddir
     - name: Run Build
+      if: env.rebuild == '1'
       run: meson compile -C builddir
     - name: Run Test Suite
+      if: env.rebuild == '1'
       run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -2,7 +2,7 @@ name: "Build Test - Ubuntu Meson (clang)"
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,24 +15,42 @@ jobs:
       matrix:
         os: [ windows-2022, windows-2025 ]
 
-    name: Windows Meson build & test 
+    name: Windows Meson build & test
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: -${{ github.event.pull_request.commits }}
+          fetch-depth: 0
+      # The composite check-rebuild action is sh-only, so reuse the same
+      # classifier script inline via bash (git-bash) to skip doc-only PRs.
+      - name: Check if rebuild required
+        id: rebuild
+        shell: bash
+        run: |
+          tmpfile=$(mktemp)
+          git show --pretty="format:" --name-only --diff-filter=AMRC ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | sort | uniq | awk NF > "$tmpfile"
+          if bash .github/actions/check-rebuild/check_if_rebuild_requires.sh "$tmpfile" build | grep -q "REBUILD=YES"; then
+            echo "rebuild=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=0" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install submodules
+        if: steps.rebuild.outputs.rebuild == '1'
         run: git submodule sync && git submodule update --init --recursive
       - name: Install Python Dependencies
+        if: steps.rebuild.outputs.rebuild == '1'
         run: pip install meson==1.7.2 ninja
       - name: Prepare MSVC
+        if: steps.rebuild.outputs.rebuild == '1'
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: x64
       - name: Prepare Build
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson setup --native-file configurations/windows-native.ini builddir
       - name: Run Build
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson compile -C builddir
       - name: Run Test Suite
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/windows_arm_clang.yml
+++ b/.github/workflows/windows_arm_clang.yml
@@ -15,24 +15,42 @@ jobs:
       matrix:
         os: [ windows-11-arm ]
 
-    name: Windows Meson build & test 
+    name: Windows Meson build & test
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
+      # The composite check-rebuild action is sh-only, so reuse the same
+      # classifier script inline via bash (git-bash) to skip doc-only PRs.
+      - name: Check if rebuild required
+        id: rebuild
+        shell: bash
+        run: |
+          tmpfile=$(mktemp)
+          git show --pretty="format:" --name-only --diff-filter=AMRC ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | sort | uniq | awk NF > "$tmpfile"
+          if bash .github/actions/check-rebuild/check_if_rebuild_requires.sh "$tmpfile" build | grep -q "REBUILD=YES"; then
+            echo "rebuild=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=0" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install submodules
+        if: steps.rebuild.outputs.rebuild == '1'
         run: git submodule sync && git submodule update --init --recursive
       - name: Install Python Dependencies
+        if: steps.rebuild.outputs.rebuild == '1'
         run: pip install meson==1.7.2 ninja
       - name: Prepare MSVC
+        if: steps.rebuild.outputs.rebuild == '1'
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: arm64
       - name: Prepare Build
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson setup --native-file configurations/windows-native-clang.ini builddir
       - name: Run Build
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson compile -C builddir
       - name: Run Test Suite
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/windows_cross_compile.yml
+++ b/.github/workflows/windows_cross_compile.yml
@@ -12,30 +12,51 @@ jobs:
   cross-build:
     runs-on: windows-latest
     name: Cross Build (x64 -> ARM64)
+    # Expose the rebuild decision so downstream jobs can reuse it
+    outputs:
+      rebuild: ${{ steps.rebuild.outputs.rebuild }}
     steps:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
           submodules: recursive
 
+      # The composite check-rebuild action is sh-only, so reuse the same
+      # classifier script inline via bash (git-bash) to skip doc-only PRs.
+      - name: Check if rebuild required
+        id: rebuild
+        shell: bash
+        run: |
+          tmpfile=$(mktemp)
+          git show --pretty="format:" --name-only --diff-filter=AMRC ${{ github.event.pull_request.head.sha }} -${{ github.event.pull_request.commits }} | sort | uniq | awk NF > "$tmpfile"
+          if bash .github/actions/check-rebuild/check_if_rebuild_requires.sh "$tmpfile" build | grep -q "REBUILD=YES"; then
+            echo "rebuild=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install Python Dependencies
+        if: steps.rebuild.outputs.rebuild == '1'
         run: pip install meson==1.7.2 ninja
 
       - name: Setup MSVC for Cross Compilation
+        if: steps.rebuild.outputs.rebuild == '1'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64_arm64
 
       - name: Prepare Build
+        if: steps.rebuild.outputs.rebuild == '1'
         # Using the CI-specific cross file
         run: meson setup build_cross --cross-file configurations/windows-cross-arm-ci.ini
 
       - name: Run Build
+        if: steps.rebuild.outputs.rebuild == '1'
         run: meson compile -C build_cross
 
       - name: Upload Build Artifacts
+        if: steps.rebuild.outputs.rebuild == '1'
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
@@ -50,51 +71,57 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ github.event.pull_request.commits }}
+          fetch-depth: 0
           submodules: recursive
 
+      # Reuse the rebuild decision from cross-build
       - name: Install Python Dependencies
+        if: needs.cross-build.outputs.rebuild == '1'
         run: pip install meson==1.7.2 ninja
 
       - name: Download Build Artifacts
+        if: needs.cross-build.outputs.rebuild == '1'
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: build_cross
 
       - name: Add build dir to PATH
+        if: needs.cross-build.outputs.rebuild == '1'
         run: echo "${{ github.workspace }}\build_cross" >> $env:GITHUB_PATH
 
       - name: Prepare Test Environment
+        if: needs.cross-build.outputs.rebuild == '1'
         run: |
           # Meson build directories are not relocatable (absolute paths are baked in).
           # To use 'meson test', we must recreate the build metadata on this runner.
-          
+
           # 1. Move the downloaded artifacts to a temporary location
           Rename-Item -Path build_cross -NewName binaries_backup
-          
+
           # 2. Create a fresh build configuration for the current runner
           # We use the native config because we are running on the target architecture (ARM64)
           meson setup build_cross --native-file configurations/windows-native.ini
-          
+
           # 3. Overlay the cross-compiled binaries into the fresh build directory
           # We use robocopy to exclude build system files (build.ninja, meson-*, etc.)
           # so we don't overwrite the valid local configuration with the stale cross-configuration.
           $exclude_files = @("build.ninja", "compile_commands.json", ".ninja_log")
           $exclude_dirs = @("meson-private", "meson-info", "meson-logs")
-          
+
           # Robocopy returns exit code < 8 on success
           robocopy binaries_backup build_cross /E /XF $exclude_files /XD $exclude_dirs
-          if ($LASTEXITCODE -ge 8) { 
+          if ($LASTEXITCODE -ge 8) {
             Write-Error "Robocopy failed with exit code $LASTEXITCODE"
-            exit 1 
+            exit 1
           }
           # Reset exit code because robocopy returns non-zero on success (e.g. 1 = files copied)
           if ($LASTEXITCODE -lt 8) { $global:LASTEXITCODE = 0 }
 
       - name: Debug File Listing
+        if: needs.cross-build.outputs.rebuild == '1'
         run: Get-ChildItem -Path build_cross\test\unittest -Recurse
 
       - name: Run Test Suite
+        if: needs.cross-build.outputs.rebuild == '1'
         run: meson test -C build_cross --no-rebuild --print-errorlogs


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CI] skip CI build for editing PR title and description</summary><br />

The event edited triggers ubuntu build even when there's no code change.
This commit removes this redundant trigger for capability of runners.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>



<details><summary>[CI] Skip doc-only PR builds with a rebuild guard</summary><br />

Add a doc-only rebuild guard to the heavy builds that lacked one, so a PR
touching only docs (.md/.png/...) no longer runs full builds. Jobs still run
and report success (only the heavy steps are skipped), so required status
checks are never left pending.

  - Linux (ubuntu meson x2, causallm_android): reuse the existing
    ./.github/actions/check-rebuild composite action.
  - Windows (meson, arm-clang, cross-compile): the composite action is sh-only
    and does not run on Windows, so the same classifier script is invoked
    inline via shell: bash (git-bash) and exposed as a step output.

CodeQL is intentionally left out: its init/build/analyze steps are coupled and
skipping the build breaks analysis; reducing its PR cost belongs to a separate
change (drop the pull_request trigger, keep push-to-main + schedule).

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

- remove redundant CI build for editing PR title/description
- skip CI build for doc only PR

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
