### PR TITLE
[CI] Reduce PR build jobs

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -68,3 +68,36 @@ jobs:
         run: meson test -C build --no-suite unittests --print-errorlogs
       - name: run Unittests
         run: meson test -C build --suite unittests --print-errorlogs
+
+  clang_meson_test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        # @todo add options if necessary
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: install additional package from PPA for testing
+        run: sudo add-apt-repository -y ppa:nnstreamer/ppa && sudo apt-get update
+      - name: install minimal requirements
+        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev libiniparser-dev libjsoncpp-dev libcurl3-dev tensorflow2-lite-dev nnstreamer-dev libglib2.0-dev libgstreamer1.0-dev libgtest-dev ml-api-common-dev flatbuffers-compiler ml-inference-api-dev libunwind-dev
+      - name: install additional packages for features
+        run: sudo apt-get install -y python3-dev python3-numpy python3
+      - name: Install llvm
+        run: sudo apt install -y llvm
+      - name: Install submodules
+        run: git submodule sync && git submodule update --init --recursive
+      - name: Install build systems
+        run: sudo apt install meson ninja-build
+      - name: Prepare Build
+        run: meson setup --native-file configurations/linux-native-clang.ini builddir
+      - name: Run Build
+        run: meson compile -C builddir
+      - name: Run Test Suite
+        run: meson test -C builddir --print-errorlogs

--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04 ]
         meson_options: [ "-Denable-fp16=false", "-Denable-fp16=true" ]
 
     steps:

--- a/.github/workflows/ubuntu_clean_meson_build_clang.yml
+++ b/.github/workflows/ubuntu_clean_meson_build_clang.yml
@@ -1,8 +1,10 @@
 name: "Build Test - Ubuntu Meson (clang)"
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  # TODO: enable pull_request if needed
+  # pull_request:
+  #   types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2022, windows-2025 ]
+        os: [ windows-2025 ]
 
     name: Windows Meson build & test
     steps:

--- a/.github/workflows/windows_arm_clang.yml
+++ b/.github/workflows/windows_arm_clang.yml
@@ -1,8 +1,10 @@
 name: "Build Test - Windows on ARM Meson Clang"
 
 on:
-  pull_request:
-    branches: [ main ]
+  # TODO: enable pull_request if needed
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CI] Reduce PR build jobs</summary><br />

- ubuntu(gcc): 22.04 x fp16{t, f}
- windows: windows-2025
- ubuntu(clang) / windows(arm-native): disable the PR trigger and enable
  workflow_dispatch(manual run)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

Let's reduce CI for checking PR.
- ubuntu(gcc): drop 24.04 (daily build covers)
- windows: drop 2022 (daily build covers)
- ubuntu(clang) / windows(arm-native): moved to manual workflow at github actions

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
