### PR TITLE
[test/unittest] remove reinitialize in loadConfig test to isolate issue

### DIFF
--- a/test/unittest/unittest_nntrainer_graph.cpp
+++ b/test/unittest/unittest_nntrainer_graph.cpp
@@ -122,13 +122,6 @@ TEST_P(nntrainerGraphTest, loadConfig) {
     EXPECT_EQ(status, ML_ERROR_NONE);
   }
 
-  status = NN.reinitialize();
-  if (failAtLoad()) {
-    EXPECT_NE(status, ML_ERROR_NONE);
-  } else {
-    EXPECT_EQ(status, ML_ERROR_NONE);
-  }
-
   status = NN.allocate();
   if (failAtLoad()) {
     EXPECT_NE(status, ML_ERROR_NONE);


### PR DESCRIPTION
✦ Dependency of the PR
   - N/A

  Commits to be reviewed in this PR

  <details><summary>[test/unittest] remove reinitialize in loadConfig test to isolate issue</summary><br
  />

   - Remove NN.reinitialize() from nntrainerGraphTest.loadConfig parameterized test.
   - This is an isolation PR to verify if the reinitialize call is contributing to intermittent CI
     failures (crashes/timeouts) in specific test environments.

  Self evaluation:
   1. Build test: [X]Passed [ ]Failed [ ]Skipped
   2. Run test: [ ]Passed [ ]Failed [ ]Skipped

  Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

  </details>

  Summary

   - Debugging/Isolation PR: Removing NN.reinitialize() to check if it is the root cause of CI instability
     in the loadConfig unit test.

  Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>