### PR TITLE
[CausalLM] Add backprop for rms_norm, reshaped_rms_norm and swiglu

### DIFF
--- a/Applications/CausalLM/layers/reshaped_rms_norm.cpp
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.cpp
@@ -7,11 +7,13 @@
  * @brief  Implementation of custom RMS normalization function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
 
 #include <cmath>
+#include <vector>
 #include <cpu_backend.h>
 #include <reshaped_rms_norm.h>
 
@@ -49,11 +51,24 @@ void ReshapedRMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
 }
 
 void ReshapedRMSNormLayer::forwarding(nntrainer::RunLayerContext &context,
-                                      bool training) {}
+                                      bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  computeRMSNorm(context, 0, in.getDim().height());
+}
 
 void ReshapedRMSNormLayer::incremental_forwarding(
   nntrainer::RunLayerContext &context, unsigned int from, unsigned int to,
   bool training) {
+  bool is_prefill = !from || (to - from) > 1;
+  if (skip_prefill && is_prefill)
+    return;
+
+  computeRMSNorm(context, from, to);
+}
+
+void ReshapedRMSNormLayer::computeRMSNorm(nntrainer::RunLayerContext &context,
+                                          unsigned int from,
+                                          unsigned int to) {
   auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
 
   nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
@@ -64,10 +79,6 @@ void ReshapedRMSNormLayer::incremental_forwarding(
 
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
-
-  bool is_prefill = !from || (to - from) > 1;
-  if (skip_prefill && is_prefill)
-    return;
 
   in_step_dim.batch(1);
   in_step_dim.height(to - from);
@@ -150,8 +161,137 @@ void ReshapedRMSNormLayer::updateTensorsByInputDimensions(
   context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
+/**
+ * @brief calcDerivative for ReshapedRMSNorm.
+ * @details Identical math to RMSNormLayer::calcDerivative, but each row of
+ *          width `feature_size` (rather than the full tensor width) is
+ *          normalized independently, matching the reshape done in
+ *          computeRMSNorm(). dgamma is computed in calcGradient(), which
+ *          the framework only calls when the layer is trainable.
+ */
 void ReshapedRMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {
-  std::throw_with_nested(std::runtime_error("Training is not supported yet."));
+  auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
+
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  const nntrainer::Tensor &dy =
+    context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &dx = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
+
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[reshaped_rms_norm] calcDerivative only supports FP32 for now";
+
+  nntrainer::Tensor gamma_fp32;
+  const float *g = nullptr;
+  if (use_gamma) {
+    nntrainer::Tensor &gamma = context.getWeight(wt_idx[RMSParams::gamma]);
+    gamma_fp32 = (gamma.getDataType() == ml::train::TensorDim::DataType::FP32)
+                   ? gamma
+                   : gamma.clone(ml::train::TensorDim::DataType::FP32);
+    g = gamma_fp32.getData<float>();
+  }
+
+  const ml::train::TensorDim &in_dim = in.getDim();
+  const unsigned int chunks_per_batch = in_dim.getFeatureLen() / feature_size;
+  const unsigned int batch = in_dim.batch();
+
+  const float *x = in.getData<float>();
+  const float *dy_ = dy.getData<float>();
+  float *dx_ = dx.getData<float>();
+
+  for (unsigned int b = 0; b < batch; ++b) {
+    const float *x_b = x + b * in_dim.getFeatureLen();
+    const float *dy_b = dy_ + b * in_dim.getFeatureLen();
+    float *dx_b = dx_ + b * in_dim.getFeatureLen();
+
+    for (unsigned int r = 0; r < chunks_per_batch; ++r) {
+      const float *x_row = x_b + r * feature_size;
+      const float *dy_row = dy_b + r * feature_size;
+      float *dx_row = dx_b + r * feature_size;
+
+      float ms = 0.0f;
+      for (unsigned int w = 0; w < feature_size; ++w)
+        ms += x_row[w] * x_row[w];
+      ms /= feature_size;
+      float inv_rms = 1.0f / std::sqrt(ms + epsilon);
+      float inv_rms3 = inv_rms * inv_rms * inv_rms;
+
+      float sum_gdyx = 0.0f;
+      for (unsigned int w = 0; w < feature_size; ++w) {
+        float gdy = use_gamma ? g[w] * dy_row[w] : dy_row[w];
+        sum_gdyx += gdy * x_row[w];
+      }
+      float mean_gdyx = sum_gdyx / feature_size;
+
+      for (unsigned int w = 0; w < feature_size; ++w) {
+        float gdy = use_gamma ? g[w] * dy_row[w] : dy_row[w];
+        dx_row[w] = inv_rms * gdy - inv_rms3 * x_row[w] * mean_gdyx;
+      }
+    }
+  }
+}
+
+/**
+ * @brief calcGradient for ReshapedRMSNorm.
+ * @details Same accumulation as RMSNormLayer::calcGradient, but gamma spans
+ *          one `feature_size`-wide chunk and every chunk in the tensor
+ *          contributes to it:
+ *          dL/dgamma[w] = sum over chunks of dy[c][w]*x[c][w]*inv_rms[c].
+ *          No-op when use_gamma is false, since then there is no weight.
+ */
+void ReshapedRMSNormLayer::calcGradient(nntrainer::RunLayerContext &context) {
+  if (!use_gamma)
+    return;
+
+  auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
+
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  const nntrainer::Tensor &dy =
+    context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &dgamma = context.getWeightGrad(wt_idx[RMSParams::gamma]);
+
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32 ||
+                  dgamma.getDataType() !=
+                    ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[reshaped_rms_norm] calcGradient only supports FP32 for now";
+
+  const ml::train::TensorDim &in_dim = in.getDim();
+  const unsigned int chunks_per_batch = in_dim.getFeatureLen() / feature_size;
+  const unsigned int batch = in_dim.batch();
+
+  const float *x = in.getData<float>();
+  const float *dy_ = dy.getData<float>();
+
+  std::vector<double> acc(feature_size, 0.0);
+
+  for (unsigned int b = 0; b < batch; ++b) {
+    const float *x_b = x + b * in_dim.getFeatureLen();
+    const float *dy_b = dy_ + b * in_dim.getFeatureLen();
+
+    for (unsigned int r = 0; r < chunks_per_batch; ++r) {
+      const float *x_row = x_b + r * feature_size;
+      const float *dy_row = dy_b + r * feature_size;
+
+      float ms = 0.0f;
+      for (unsigned int w = 0; w < feature_size; ++w)
+        ms += x_row[w] * x_row[w];
+      ms /= feature_size;
+      const float inv_rms = 1.0f / std::sqrt(ms + epsilon);
+
+      for (unsigned int w = 0; w < feature_size; ++w)
+        acc[w] += static_cast<double>(dy_row[w]) * x_row[w] * inv_rms;
+    }
+  }
+
+  float *dg = dgamma.getData<float>();
+  if (context.isGradientFirstAccess(wt_idx[RMSParams::gamma])) {
+    for (unsigned int w = 0; w < feature_size; ++w)
+      dg[w] = static_cast<float>(acc[w]);
+  } else {
+    for (unsigned int w = 0; w < feature_size; ++w)
+      dg[w] += static_cast<float>(acc[w]);
+  }
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/reshaped_rms_norm.h
+++ b/Applications/CausalLM/layers/reshaped_rms_norm.h
@@ -7,6 +7,7 @@
  * @brief  Implementation of RMS normalization function with reshaping.
  * @see    https://github.com/nntrainer/nntrainer
  * @author Eunju Yang <ej.yang@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  * @note   This layer only supports inference mode.
  */
@@ -85,9 +86,16 @@ public:
   WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   * @note Only invoked when the layer is trainable; frozen under LoRA-only
+   *       training. No-op when use_gamma is false (no weight to train).
+   */
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
    * @copydoc bool supportBackwarding() const
    */
-  WIN_EXPORT bool supportBackwarding() const override { return false; };
+  WIN_EXPORT bool supportBackwarding() const override { return true; };
 
   /**
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
@@ -128,6 +136,14 @@ private:
   unsigned int feature_size;
   bool skip_prefill = false;
   bool use_gamma;
+
+  /**
+   * @brief shared per-chunk RMS normalization compute used by both
+   *        forwarding (full sequence, [0, height)) and
+   *        incremental_forwarding (decode step, [from, to)).
+   */
+  void computeRMSNorm(nntrainer::RunLayerContext &context, unsigned int from,
+                      unsigned int to);
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/rms_norm.cpp
+++ b/Applications/CausalLM/layers/rms_norm.cpp
@@ -7,11 +7,13 @@
  * @brief  Implementation of custom RMS normalization function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
 
 #include <cmath>
+#include <vector>
 #include <cpu_backend.h>
 #include <iostream>
 
@@ -42,11 +44,23 @@ void RMSNormLayer::finalize(nntrainer::InitLayerContext &context) {
 }
 
 void RMSNormLayer::forwarding(nntrainer::RunLayerContext &context,
-                              bool training) {}
+                              bool training) {
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  computeRMSNorm(context, 0, in.getDim().height());
+}
 
 void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                           unsigned int from, unsigned int to,
                                           bool training) {
+  bool is_prefill = !from || (to - from) > 1;
+  if (skip_prefill && is_prefill)
+    return;
+
+  computeRMSNorm(context, from, to);
+}
+
+void RMSNormLayer::computeRMSNorm(nntrainer::RunLayerContext &context,
+                                  unsigned int from, unsigned int to) {
   auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
 
   nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
@@ -58,10 +72,6 @@ void RMSNormLayer::incremental_forwarding(nntrainer::RunLayerContext &context,
 
   ml::train::TensorDim in_step_dim = in_dim;
   ml::train::TensorDim out_step_dim = out_dim;
-
-  bool is_prefill = !from || (to - from) > 1;
-  if (skip_prefill && is_prefill)
-    return;
 
   in_step_dim.batch(1);
   in_step_dim.height(to - from);
@@ -129,8 +139,140 @@ void RMSNormLayer::updateTensorsByInputDimensions(
   context.updateOutput(SINGLE_INOUT_IDX, input_dimensions[0]);
 }
 
+/**
+ * @brief calcDerivative for RMSNorm.
+ * @details y_i = x_i * inv_rms * gamma_i, with
+ *          inv_rms = 1 / sqrt(mean(x^2) + eps).
+ *          dL/dx_j = inv_rms * (gamma_j*dy_j)
+ *                    - inv_rms^3 * x_j * mean_i(gamma_i*dy_i*x_i)
+ *          dgamma is computed separately in calcGradient(), which the
+ *          framework only calls when the layer is trainable (gamma stays
+ *          frozen under LoRA-only training).
+ */
 void RMSNormLayer::calcDerivative(nntrainer::RunLayerContext &context) {
-  std::throw_with_nested(std::runtime_error("Training is not supported yet."));
+  auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
+
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &gamma = context.getWeight(wt_idx[RMSParams::gamma]);
+  const nntrainer::Tensor &dy =
+    context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &dx = context.getOutgoingDerivative(SINGLE_INOUT_IDX);
+
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[rms_norm] calcDerivative only supports FP32 for now";
+
+  nntrainer::Tensor gamma_fp32 =
+    (gamma.getDataType() == ml::train::TensorDim::DataType::FP32)
+      ? gamma
+      : gamma.clone(ml::train::TensorDim::DataType::FP32);
+
+  const ml::train::TensorDim &in_dim = in.getDim();
+  const unsigned int width = in_dim.width();
+  const unsigned int rows_per_batch = in_dim.getFeatureLen() / width;
+  const unsigned int batch = in_dim.batch();
+
+  const float *x = in.getData<float>();
+  const float *dy_ = dy.getData<float>();
+  const float *g = gamma_fp32.getData<float>();
+  float *dx_ = dx.getData<float>();
+
+  for (unsigned int b = 0; b < batch; ++b) {
+    const float *x_b = x + b * in_dim.getFeatureLen();
+    const float *dy_b = dy_ + b * in_dim.getFeatureLen();
+    float *dx_b = dx_ + b * in_dim.getFeatureLen();
+
+    for (unsigned int r = 0; r < rows_per_batch; ++r) {
+      const float *x_row = x_b + r * width;
+      const float *dy_row = dy_b + r * width;
+      float *dx_row = dx_b + r * width;
+
+      float ms = 0.0f;
+      for (unsigned int w = 0; w < width; ++w)
+        ms += x_row[w] * x_row[w];
+      ms /= width;
+      float inv_rms = 1.0f / std::sqrt(ms + epsilon);
+      float inv_rms3 = inv_rms * inv_rms * inv_rms;
+
+      float sum_gdyx = 0.0f;
+      for (unsigned int w = 0; w < width; ++w)
+        sum_gdyx += g[w] * dy_row[w] * x_row[w];
+      float mean_gdyx = sum_gdyx / width;
+
+      for (unsigned int w = 0; w < width; ++w)
+        dx_row[w] =
+          inv_rms * (g[w] * dy_row[w]) - inv_rms3 * x_row[w] * mean_gdyx;
+    }
+  }
+}
+
+/**
+ * @brief calcGradient for RMSNorm.
+ * @details y[r][w] = x[r][w] * inv_rms[r] * gamma[w], so
+ *          dL/dgamma[w] = sum over all rows of dy[r][w] * x[r][w] *
+ *          inv_rms[r].
+ *
+ * @note Accumulated in double and written once per element, so a long
+ *       sequence cannot lose precision to repeated float rounding.
+ * @note Honours isGradientFirstAccess(): the gradient is overwritten on the
+ *       first visit and accumulated afterwards, so a gamma shared between
+ *       several layers sums their contributions instead of discarding all
+ *       but the last.
+ * @note Safe to read the input here: the framework runs calcGradient before
+ *       calcDerivative, and it is calcDerivative that overwrites the input
+ *       buffer with dx (see the aliasing note there).
+ */
+void RMSNormLayer::calcGradient(nntrainer::RunLayerContext &context) {
+  auto &epsilon = std::get<nntrainer::props::Epsilon>(rms_props).get();
+
+  nntrainer::Tensor &in = context.getInput(SINGLE_INOUT_IDX);
+  const nntrainer::Tensor &dy =
+    context.getIncomingDerivative(SINGLE_INOUT_IDX);
+  nntrainer::Tensor &dgamma = context.getWeightGrad(wt_idx[RMSParams::gamma]);
+
+  NNTR_THROW_IF(in.getDataType() != ml::train::TensorDim::DataType::FP32 ||
+                  dgamma.getDataType() !=
+                    ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[rms_norm] calcGradient only supports FP32 for now";
+
+  const ml::train::TensorDim &in_dim = in.getDim();
+  const unsigned int width = in_dim.width();
+  const unsigned int rows_per_batch = in_dim.getFeatureLen() / width;
+  const unsigned int batch = in_dim.batch();
+
+  const float *x = in.getData<float>();
+  const float *dy_ = dy.getData<float>();
+
+  std::vector<double> acc(width, 0.0);
+
+  for (unsigned int b = 0; b < batch; ++b) {
+    const float *x_b = x + b * in_dim.getFeatureLen();
+    const float *dy_b = dy_ + b * in_dim.getFeatureLen();
+
+    for (unsigned int r = 0; r < rows_per_batch; ++r) {
+      const float *x_row = x_b + r * width;
+      const float *dy_row = dy_b + r * width;
+
+      float ms = 0.0f;
+      for (unsigned int w = 0; w < width; ++w)
+        ms += x_row[w] * x_row[w];
+      ms /= width;
+      const float inv_rms = 1.0f / std::sqrt(ms + epsilon);
+
+      for (unsigned int w = 0; w < width; ++w)
+        acc[w] += static_cast<double>(dy_row[w]) * x_row[w] * inv_rms;
+    }
+  }
+
+  float *dg = dgamma.getData<float>();
+  if (context.isGradientFirstAccess(wt_idx[RMSParams::gamma])) {
+    for (unsigned int w = 0; w < width; ++w)
+      dg[w] = static_cast<float>(acc[w]);
+  } else {
+    for (unsigned int w = 0; w < width; ++w)
+      dg[w] += static_cast<float>(acc[w]);
+  }
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/rms_norm.h
+++ b/Applications/CausalLM/layers/rms_norm.h
@@ -7,6 +7,7 @@
  * @brief  Implementation of RMS normalization function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  * @note   This layer only supports inference mode.
  */
@@ -76,9 +77,17 @@ public:
   WIN_EXPORT void calcDerivative(nntrainer::RunLayerContext &context) override;
 
   /**
+   * @copydoc Layer::calcGradient(RunLayerContext &context)
+   * @note Only invoked when the layer is trainable. Under LoRA-only
+   *       training gamma is frozen so this never runs; it exists so that
+   *       full fine-tuning (or a "LoRA + norms" recipe) can train gamma.
+   */
+  WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
+
+  /**
    * @copydoc bool supportBackwarding() const
    */
-  WIN_EXPORT bool supportBackwarding() const override { return false; };
+  WIN_EXPORT bool supportBackwarding() const override { return true; };
 
   /**
    * @copydoc Layer::exportTo(Exporter &exporter, ExportMethods method)
@@ -116,6 +125,14 @@ private:
              nntrainer::props::SkipPrefill>
     rms_props;
   bool skip_prefill = false;
+
+  /**
+   * @brief shared per-row RMS normalization compute used by both forwarding
+   *        (full sequence, [0, height)) and incremental_forwarding (decode
+   *        step, [from, to)).
+   */
+  void computeRMSNorm(nntrainer::RunLayerContext &context, unsigned int from,
+                      unsigned int to);
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/swiglu.cpp
+++ b/Applications/CausalLM/layers/swiglu.cpp
@@ -7,10 +7,12 @@
  * @brief  Implementation of SwiGLU activation function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
 
+#include <cmath>
 #include <util_simd.h>
 
 #include "swiglu.h"
@@ -38,18 +40,26 @@ void SwiGLULayer::finalize(nntrainer::InitLayerContext &context) {
 }
 
 void SwiGLULayer::forwarding(nntrainer::RunLayerContext &context,
-                             bool training) {}
+                             bool training) {
+  nntrainer::Tensor &in1 = context.getInput(INPUT_IDX_1);
+  computeSwiGLU(context, 0, in1.getDim().height());
+}
 
 void SwiGLULayer::incremental_forwarding(nntrainer::RunLayerContext &context,
                                          unsigned int from, unsigned int to,
                                          bool training) {
-  nntrainer::Tensor &in1 = context.getInput(INPUT_IDX_1);
-  nntrainer::Tensor &in2 = context.getInput(INPUT_IDX_2);
-  nntrainer::Tensor &out = context.getOutput(OUT_IDX);
-
   bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
+
+  computeSwiGLU(context, from, to);
+}
+
+void SwiGLULayer::computeSwiGLU(nntrainer::RunLayerContext &context,
+                                unsigned int from, unsigned int to) {
+  nntrainer::Tensor &in1 = context.getInput(INPUT_IDX_1);
+  nntrainer::Tensor &in2 = context.getInput(INPUT_IDX_2);
+  nntrainer::Tensor &out = context.getOutput(OUT_IDX);
 
   int iter = to - from;
 
@@ -98,9 +108,54 @@ void SwiGLULayer::updateTensorsByInputDimensions(
   context.updateOutput(OUT_IDX, output_dim);
 }
 
+/**
+ * @brief calcDerivative for SwiGLU.
+ * @details out = silu(gate) * up, where gate = input[0], up = input[1] and
+ *          silu(g) = g * sigmoid(g).
+ *          d(out)/d(gate) = up * silu'(gate),
+ *            silu'(g) = sigmoid(g) * (1 + g * (1 - sigmoid(g)))
+ *          d(out)/d(up) = silu(gate)
+ *          SwiGLU has no weights of its own, so there is no
+ *          calcGradient to implement.
+ *
+ * @note nntrainer aliases each outgoing derivative onto its input's own
+ *       buffer (the activation's storage is recycled to hold its gradient),
+ *       so `d_gate` IS `gate` and `d_up` IS `up`. Every input element must
+ *       therefore be read into a local before *either* output element at
+ *       that index is written — otherwise writing d_up[i] destroys up[i]
+ *       before it is used to form d_gate[i].
+ */
 void SwiGLULayer::calcDerivative(nntrainer::RunLayerContext &context) {
-  // std::throw_with_nested(std::runtime_error("Training is not supported
-  // yet."));
+  nntrainer::Tensor &gate = context.getInput(INPUT_IDX_1);
+  nntrainer::Tensor &up = context.getInput(INPUT_IDX_2);
+  const nntrainer::Tensor &dy = context.getIncomingDerivative(OUT_IDX);
+  nntrainer::Tensor &d_gate = context.getOutgoingDerivative(INPUT_IDX_1);
+  nntrainer::Tensor &d_up = context.getOutgoingDerivative(INPUT_IDX_2);
+
+  NNTR_THROW_IF(gate.getDataType() != ml::train::TensorDim::DataType::FP32,
+                std::invalid_argument)
+    << "[swiglu] calcDerivative only supports FP32 for now";
+
+  const size_t len = gate.size();
+  const float *g = gate.getData<float>();
+  const float *u = up.getData<float>();
+  const float *dy_ = dy.getData<float>();
+  float *dg = d_gate.getData<float>();
+  float *du = d_up.getData<float>();
+
+  for (size_t i = 0; i < len; ++i) {
+    // Snapshot all inputs at this index first; see the aliasing note above.
+    const float gi = g[i];
+    const float ui = u[i];
+    const float dyi = dy_[i];
+
+    const float sig = 1.0f / (1.0f + std::exp(-gi));
+    const float silu = gi * sig;
+    const float dsilu = sig * (1.0f + gi * (1.0f - sig));
+
+    du[i] = dyi * silu;
+    dg[i] = dyi * ui * dsilu;
+  }
 }
 
 #ifdef PLUGGABLE

--- a/Applications/CausalLM/layers/swiglu.h
+++ b/Applications/CausalLM/layers/swiglu.h
@@ -7,6 +7,7 @@
  * @brief  Implementation of custom SwiGLU activation function
  * @see    https://github.com/nntrainer/nntrainer
  * @author Seungbaek Hong <sb92.hong@samsung.com>
+ * @author Niket Agarwal <niket.a@samsung.com>
  * @bug    No known bugs except for NYI items
  *
  */
@@ -109,6 +110,14 @@ public:
 private:
   std::tuple<nntrainer::props::SkipPrefill> swiglu_props;
   bool skip_prefill = false;
+
+  /**
+   * @brief shared elementwise SwiGLU compute used by both forwarding (full
+   *        sequence, [0, height)) and incremental_forwarding (decode step,
+   *        [from, to)).
+   */
+  void computeSwiGLU(nntrainer::RunLayerContext &context, unsigned int from,
+                     unsigned int to);
 };
 
 } // namespace causallm

--- a/Applications/CausalLM/layers/unittest_lora_backward_gradcheck.cpp
+++ b/Applications/CausalLM/layers/unittest_lora_backward_gradcheck.cpp
@@ -16,11 +16,13 @@
 
 #include <reshaped_rms_norm.h>
 #include <rms_norm.h>
+#include <swiglu.h>
 
 #include <gtest/gtest.h>
 
 #include <cmath>
 #include <functional>
+#include <memory>
 #include <vector>
 
 namespace {
@@ -197,6 +199,137 @@ TEST(CausalLmLoraBackward,
 
   checkGradient(inputs[0].getVariableRef().getData<float>(), analytic.data(),
                dy, height * width, height * width, forward);
+}
+
+TEST(CausalLmLoraBackward, SwiGLUCalcDerivativeMatchesFiniteDifference) {
+  const unsigned int height = 2, width = 3;
+
+  causallm::SwiGLULayer layer;
+  nntrainer::InitLayerContext init_context(
+    {nntrainer::TensorDim({1, 1, height, width}),
+     nntrainer::TensorDim({1, 1, height, width})},
+    {true}, false, "swiglu_gradcheck", "", 0.0f, {"NCHW", "FP32", "FP32"});
+  ASSERT_NO_THROW(layer.finalize(init_context));
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+
+  inputs.emplace_back(init_context.getInputDimensions()[0],
+                      nntrainer::Initializer::NONE, true, true, "gate");
+  inputs.emplace_back(init_context.getInputDimensions()[1],
+                      nntrainer::Initializer::NONE, true, true, "up");
+  outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                       nntrainer::Initializer::NONE, true, true, "output");
+
+  float gate[height * width] = {0.2f, -0.5f, 0.8f, -0.3f, 0.1f, 1.2f};
+  float up[height * width] = {0.4f, 0.9f, -0.6f, 0.3f, -1.1f, 0.2f};
+  std::copy(gate, gate + height * width,
+           inputs[0].getVariableRef().getData<float>());
+  std::copy(up, up + height * width,
+           inputs[1].getVariableRef().getData<float>());
+
+  auto run_context =
+    makeRunContext("swiglu_gradcheck", weights, inputs, outputs, tensors);
+
+  float dy[height * width] = {0.5f, -0.3f, 0.2f, 0.1f, 0.4f, -0.2f};
+  std::copy(dy, dy + height * width,
+           run_context.getOutputGradUnsafe(0).getData<float>());
+
+  layer.forwarding(run_context, true);
+  layer.calcDerivative(run_context);
+
+  std::vector<float> analytic_gate(height * width), analytic_up(height * width);
+  std::copy(run_context.getOutgoingDerivative(0).getData<float>(),
+           run_context.getOutgoingDerivative(0).getData<float>() +
+             height * width,
+           analytic_gate.begin());
+  std::copy(run_context.getOutgoingDerivative(1).getData<float>(),
+           run_context.getOutgoingDerivative(1).getData<float>() +
+             height * width,
+           analytic_up.begin());
+
+  auto forward = [&]() -> const float * {
+    layer.forwarding(run_context, true);
+    return run_context.getOutput(0).getData<float>();
+  };
+
+  checkGradient(inputs[0].getVariableRef().getData<float>(),
+               analytic_gate.data(), dy, height * width, height * width,
+               forward);
+  checkGradient(inputs[1].getVariableRef().getData<float>(),
+               analytic_up.data(), dy, height * width, height * width,
+               forward);
+}
+
+/**
+ * @brief Regression test: nntrainer aliases each outgoing derivative onto its
+ *        input's own buffer, so a calcDerivative that writes one output
+ *        before reading every input it needs will silently consume its own
+ *        output. SwiGLU is the case that matters (d_up aliases up, which is
+ *        still needed to form d_gate).
+ *
+ * @note The other gradient checks in this file build each Var_Grad with
+ *       independent variable/gradient storage, which does NOT reproduce the
+ *       aliasing the real graph uses — hence this dedicated test.
+ */
+TEST(CausalLmLoraBackward, SwiGLUCalcDerivativeIsSafeWhenGradAliasesInput) {
+  const unsigned int height = 2, width = 3, n = height * width;
+
+  const std::vector<float> gate0 = {0.2f, -0.5f, 0.8f, -0.3f, 0.1f, 1.2f};
+  const std::vector<float> up0 = {0.4f, 0.9f, -0.6f, 0.3f, -1.1f, 0.2f};
+  const std::vector<float> dy0 = {0.5f, -0.3f, 0.2f, 0.1f, 0.4f, -0.2f};
+
+  auto build = [&](bool alias) {
+    causallm::SwiGLULayer layer;
+    nntrainer::InitLayerContext init_context(
+      {nntrainer::TensorDim({1, 1, height, width}),
+       nntrainer::TensorDim({1, 1, height, width})},
+      {true}, false, "swiglu_alias", "", 0.0f, {"NCHW", "FP32", "FP32"});
+    layer.finalize(init_context);
+
+    // Storage kept alive by the caller via the returned vectors.
+    auto gate_t = std::make_shared<nntrainer::Tensor>(
+      init_context.getInputDimensions()[0], true);
+    auto up_t = std::make_shared<nntrainer::Tensor>(
+      init_context.getInputDimensions()[1], true);
+    auto gate_g = alias ? gate_t
+                        : std::make_shared<nntrainer::Tensor>(
+                            init_context.getInputDimensions()[0], true);
+    auto up_g = alias ? up_t
+                      : std::make_shared<nntrainer::Tensor>(
+                          init_context.getInputDimensions()[1], true);
+    std::copy(gate0.begin(), gate0.end(), gate_t->getData<float>());
+    std::copy(up0.begin(), up0.end(), up_t->getData<float>());
+
+    std::vector<nntrainer::Weight> weights;
+    std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+    inputs.emplace_back(gate_t.get(), gate_g.get(), false);
+    inputs.emplace_back(up_t.get(), up_g.get(), false);
+    outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                         nntrainer::Initializer::NONE, true, true, "out");
+
+    auto rc = makeRunContext("swiglu_alias", weights, inputs, outputs, tensors);
+    std::copy(dy0.begin(), dy0.end(),
+              rc.getOutputGradUnsafe(0).getData<float>());
+
+    layer.forwarding(rc, true);
+    layer.calcDerivative(rc);
+
+    std::vector<float> dg(gate_g->getData<float>(),
+                          gate_g->getData<float>() + n);
+    std::vector<float> du(up_g->getData<float>(), up_g->getData<float>() + n);
+    return std::make_pair(dg, du);
+  };
+
+  auto separate = build(false);
+  auto aliased = build(true);
+
+  for (unsigned int i = 0; i < n; ++i) {
+    EXPECT_NEAR(separate.first[i], aliased.first[i], 1e-6)
+      << "d_gate differs under aliasing at " << i;
+    EXPECT_NEAR(separate.second[i], aliased.second[i], 1e-6)
+      << "d_up differs under aliasing at " << i;
+  }
 }
 
 TEST(CausalLmLoraBackward, RmsNormCalcGradientMatchesFiniteDifference) {

--- a/Applications/CausalLM/layers/unittest_lora_backward_gradcheck.cpp
+++ b/Applications/CausalLM/layers/unittest_lora_backward_gradcheck.cpp
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Copyright (C) 2026 Samsung Electronics Co., Ltd. All Rights Reserved.
+ *
+ * @file   unittest_lora_backward_gradcheck.cpp
+ * @date   31 July 2026
+ * @brief  Finite-difference gradient checks for the calcDerivative() and
+ *         calcGradient() implementations added to support LoRA training on
+ *         the Qwen3 CausalLM layer stack.
+ * @bug    No known bugs except for NYI items
+ */
+
+#include <layer_context.h>
+#include <var_grad.h>
+#include <weight.h>
+
+#include <reshaped_rms_norm.h>
+#include <rms_norm.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <functional>
+#include <vector>
+
+namespace {
+
+std::vector<nntrainer::Weight *>
+makeWeightView(std::vector<nntrainer::Weight> &weights) {
+  std::vector<nntrainer::Weight *> view;
+  view.reserve(weights.size());
+  for (auto &weight : weights)
+    view.push_back(&weight);
+  return view;
+}
+
+std::vector<nntrainer::Var_Grad *>
+makeVarGradView(std::vector<nntrainer::Var_Grad> &vars) {
+  std::vector<nntrainer::Var_Grad *> view;
+  view.reserve(vars.size());
+  for (auto &var : vars)
+    view.push_back(&var);
+  return view;
+}
+
+nntrainer::RunLayerContext
+makeRunContext(const std::string &name, std::vector<nntrainer::Weight> &weights,
+              std::vector<nntrainer::Var_Grad> &inputs,
+              std::vector<nntrainer::Var_Grad> &outputs,
+              std::vector<nntrainer::Var_Grad> &tensors) {
+  return nntrainer::RunLayerContext(
+    name, true, 0.0f, false, 1.0f, nullptr, false, makeWeightView(weights),
+    makeVarGradView(inputs), makeVarGradView(outputs),
+    makeVarGradView(tensors));
+}
+
+/**
+ * @brief Central-difference numerical gradient check: perturbs each element
+ *        of `x`, re-runs `forward`, and compares (dL/dx)_i against
+ *        `analytic[i]`, where L(x) := dot(forward(x), dy) so that the exact
+ *        gradient of L w.r.t. x is what a correct backward pass should
+ *        produce for the fixed incoming derivative `dy`.
+ */
+void checkGradient(float *x, const float *analytic, const float *dy,
+                   size_t n, size_t out_n,
+                   const std::function<const float *()> &forward,
+                   float eps = 1e-3f, float tol = 5e-2f) {
+  auto loss = [&](const float *out) {
+    double l = 0.0;
+    for (size_t j = 0; j < out_n; ++j)
+      l += static_cast<double>(out[j]) * static_cast<double>(dy[j]);
+    return l;
+  };
+
+  for (size_t i = 0; i < n; ++i) {
+    float orig = x[i];
+
+    x[i] = orig + eps;
+    double lp = loss(forward());
+
+    x[i] = orig - eps;
+    double lm = loss(forward());
+
+    x[i] = orig;
+
+    double numeric = (lp - lm) / (2.0 * eps);
+    EXPECT_NEAR(analytic[i], numeric, tol)
+      << "gradient mismatch at index " << i << " (analytic=" << analytic[i]
+      << ", numeric=" << numeric << ")";
+  }
+}
+
+} // namespace
+
+TEST(CausalLmLoraBackward, RmsNormCalcDerivativeMatchesFiniteDifference) {
+  const unsigned int height = 2, width = 4;
+
+  causallm::RMSNormLayer layer;
+  nntrainer::InitLayerContext init_context(
+    {nntrainer::TensorDim({1, 1, height, width})}, {true}, false,
+    "rms_norm_gradcheck", "", 0.0f, {"NCHW", "FP32", "FP32"});
+  ASSERT_NO_THROW(layer.finalize(init_context));
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+
+  nntrainer::Tensor gamma_tensor(nntrainer::TensorDim({1, 1, 1, width}), true);
+  float gamma_vals[width] = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::copy(gamma_vals, gamma_vals + width, gamma_tensor.getData<float>());
+  weights.emplace_back(gamma_tensor, nntrainer::Tensor(), nntrainer::Tensor(),
+                       "gamma");
+
+  inputs.emplace_back(init_context.getInputDimensions()[0],
+                      nntrainer::Initializer::NONE, true, true, "input");
+  outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                       nntrainer::Initializer::NONE, true, true, "output");
+
+  float x[height * width] = {0.2f, -0.1f, 0.4f, 0.3f, -0.3f, 0.5f, -0.2f, 0.1f};
+  std::copy(x, x + height * width, inputs[0].getVariableRef().getData<float>());
+
+  auto run_context = makeRunContext("rms_norm_gradcheck", weights, inputs,
+                                    outputs, tensors);
+
+  float dy[height * width] = {0.5f, -0.3f, 0.2f, 0.1f, 0.4f, -0.2f, 0.3f, -0.1f};
+  std::copy(dy, dy + height * width,
+           run_context.getOutputGradUnsafe(0).getData<float>());
+
+  layer.forwarding(run_context, true);
+  layer.calcDerivative(run_context);
+
+  std::vector<float> analytic(height * width);
+  std::copy(run_context.getOutgoingDerivative(0).getData<float>(),
+           run_context.getOutgoingDerivative(0).getData<float>() +
+             height * width,
+           analytic.begin());
+
+  auto forward = [&]() -> const float * {
+    layer.forwarding(run_context, true);
+    return run_context.getOutput(0).getData<float>();
+  };
+
+  checkGradient(inputs[0].getVariableRef().getData<float>(), analytic.data(),
+               dy, height * width, height * width, forward);
+}
+
+TEST(CausalLmLoraBackward,
+    ReshapedRmsNormCalcDerivativeMatchesFiniteDifference) {
+  const unsigned int height = 1, width = 8, feature_size = 4;
+
+  causallm::ReshapedRMSNormLayer layer;
+  ASSERT_NO_THROW(
+    layer.setProperty({"feature_size=" + std::to_string(feature_size)}));
+  nntrainer::InitLayerContext init_context(
+    {nntrainer::TensorDim({1, 1, height, width})}, {true}, false,
+    "reshaped_rms_norm_gradcheck", "", 0.0f, {"NCHW", "FP32", "FP32"});
+  ASSERT_NO_THROW(layer.finalize(init_context));
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+
+  nntrainer::Tensor gamma_tensor(nntrainer::TensorDim({1, 1, 1, feature_size}),
+                                true);
+  float gamma_vals[feature_size] = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::copy(gamma_vals, gamma_vals + feature_size,
+           gamma_tensor.getData<float>());
+  weights.emplace_back(gamma_tensor, nntrainer::Tensor(), nntrainer::Tensor(),
+                       "gamma");
+
+  inputs.emplace_back(init_context.getInputDimensions()[0],
+                      nntrainer::Initializer::NONE, true, true, "input");
+  outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                       nntrainer::Initializer::NONE, true, true, "output");
+
+  float x[height * width] = {0.2f, -0.1f, 0.4f, 0.3f, -0.3f, 0.5f, -0.2f, 0.1f};
+  std::copy(x, x + height * width, inputs[0].getVariableRef().getData<float>());
+
+  auto run_context = makeRunContext("reshaped_rms_norm_gradcheck", weights,
+                                    inputs, outputs, tensors);
+
+  float dy[height * width] = {0.5f, -0.3f, 0.2f, 0.1f, 0.4f, -0.2f, 0.3f, -0.1f};
+  std::copy(dy, dy + height * width,
+           run_context.getOutputGradUnsafe(0).getData<float>());
+
+  layer.forwarding(run_context, true);
+  layer.calcDerivative(run_context);
+
+  std::vector<float> analytic(height * width);
+  std::copy(run_context.getOutgoingDerivative(0).getData<float>(),
+           run_context.getOutgoingDerivative(0).getData<float>() +
+             height * width,
+           analytic.begin());
+
+  auto forward = [&]() -> const float * {
+    layer.forwarding(run_context, true);
+    return run_context.getOutput(0).getData<float>();
+  };
+
+  checkGradient(inputs[0].getVariableRef().getData<float>(), analytic.data(),
+               dy, height * width, height * width, forward);
+}
+
+TEST(CausalLmLoraBackward, RmsNormCalcGradientMatchesFiniteDifference) {
+  const unsigned int height = 3, width = 4;
+
+  causallm::RMSNormLayer layer;
+  nntrainer::InitLayerContext init_context(
+    {nntrainer::TensorDim({1, 1, height, width})}, {true}, false,
+    "rms_norm_gradw", "", 0.0f, {"NCHW", "FP32", "FP32"});
+  ASSERT_NO_THROW(layer.finalize(init_context));
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+
+  // Weight needs a real gradient buffer for calcGradient to write into.
+  nntrainer::Tensor gamma_v(nntrainer::TensorDim({1, 1, 1, width}), true);
+  nntrainer::Tensor gamma_g(nntrainer::TensorDim({1, 1, 1, width}), true);
+  const float gamma_vals[width] = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::copy(gamma_vals, gamma_vals + width, gamma_v.getData<float>());
+  gamma_g.setZero();
+  weights.emplace_back(gamma_v, gamma_g, nntrainer::Tensor(), "gamma");
+
+  inputs.emplace_back(init_context.getInputDimensions()[0],
+                      nntrainer::Initializer::NONE, true, true, "input");
+  outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                       nntrainer::Initializer::NONE, true, true, "output");
+
+  const unsigned int n = height * width;
+  std::vector<float> x(n), dy(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    x[i] = std::sin(0.6f * i + 0.4f) * 0.7f;
+    dy[i] = std::cos(0.8f * i + 0.1f) * 0.5f;
+  }
+  std::copy(x.begin(), x.end(), inputs[0].getVariableRef().getData<float>());
+
+  auto rc = makeRunContext("rms_norm_gradw", weights, inputs, outputs, tensors);
+  std::copy(dy.begin(), dy.end(), rc.getOutputGradUnsafe(0).getData<float>());
+
+  layer.forwarding(rc, true);
+  layer.calcGradient(rc);
+
+  std::vector<float> analytic(rc.getWeightGrad(0).getData<float>(),
+                              rc.getWeightGrad(0).getData<float>() + width);
+
+  auto forward = [&]() -> const float * {
+    layer.forwarding(rc, true);
+    return rc.getOutput(0).getData<float>();
+  };
+  checkGradient(rc.getWeight(0).getData<float>(), analytic.data(), dy.data(),
+                width, n, forward);
+}
+
+/**
+ * @brief Finite-difference check of dL/dgamma for ReshapedRMSNorm, where
+ *        every feature_size-wide chunk contributes to the same gamma.
+ */
+TEST(CausalLmLoraBackward,
+     ReshapedRmsNormCalcGradientMatchesFiniteDifference) {
+  const unsigned int height = 2, width = 8, feature_size = 4;
+
+  causallm::ReshapedRMSNormLayer layer;
+  ASSERT_NO_THROW(
+    layer.setProperty({"feature_size=" + std::to_string(feature_size)}));
+  nntrainer::InitLayerContext init_context(
+    {nntrainer::TensorDim({1, 1, height, width})}, {true}, false,
+    "reshaped_gradw", "", 0.0f, {"NCHW", "FP32", "FP32"});
+  ASSERT_NO_THROW(layer.finalize(init_context));
+
+  std::vector<nntrainer::Weight> weights;
+  std::vector<nntrainer::Var_Grad> inputs, outputs, tensors;
+
+  nntrainer::Tensor gamma_v(nntrainer::TensorDim({1, 1, 1, feature_size}),
+                            true);
+  nntrainer::Tensor gamma_g(nntrainer::TensorDim({1, 1, 1, feature_size}),
+                            true);
+  const float gamma_vals[feature_size] = {1.0f, 2.0f, 0.5f, 1.5f};
+  std::copy(gamma_vals, gamma_vals + feature_size, gamma_v.getData<float>());
+  gamma_g.setZero();
+  weights.emplace_back(gamma_v, gamma_g, nntrainer::Tensor(), "gamma");
+
+  inputs.emplace_back(init_context.getInputDimensions()[0],
+                      nntrainer::Initializer::NONE, true, true, "input");
+  outputs.emplace_back(init_context.getOutSpecs()[0].variable_spec.dim,
+                       nntrainer::Initializer::NONE, true, true, "output");
+
+  const unsigned int n = height * width;
+  std::vector<float> x(n), dy(n);
+  for (unsigned int i = 0; i < n; ++i) {
+    x[i] = std::sin(0.5f * i + 0.2f) * 0.6f;
+    dy[i] = std::cos(0.7f * i + 0.3f) * 0.4f;
+  }
+  std::copy(x.begin(), x.end(), inputs[0].getVariableRef().getData<float>());
+
+  auto rc = makeRunContext("reshaped_gradw", weights, inputs, outputs, tensors);
+  std::copy(dy.begin(), dy.end(), rc.getOutputGradUnsafe(0).getData<float>());
+
+  layer.forwarding(rc, true);
+  layer.calcGradient(rc);
+
+  std::vector<float> analytic(rc.getWeightGrad(0).getData<float>(),
+                              rc.getWeightGrad(0).getData<float>() +
+                                feature_size);
+
+  auto forward = [&]() -> const float * {
+    layer.forwarding(rc, true);
+    return rc.getOutput(0).getData<float>();
+  };
+  checkGradient(rc.getWeight(0).getData<float>(), analytic.data(), dy.data(),
+                feature_size, n, forward);
+}

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -234,7 +234,7 @@ if get_option('enable-test')
     'unittest_lora_backward_gradcheck',
     meson.current_source_dir() / 'layers' / 'unittest_lora_backward_gradcheck.cpp',
     dependencies: [nntrainer_dep, gtest_main_dep, causallm_rms_norm_dep,
-                   causallm_reshaped_rms_norm_dep],
+                   causallm_reshaped_rms_norm_dep, causallm_swiglu_dep],
     include_directories: causallm_layer_inc,
     build_by_default: true,
     install: false,

--- a/Applications/CausalLM/meson.build
+++ b/Applications/CausalLM/meson.build
@@ -230,6 +230,22 @@ if get_option('enable-test')
     suite: 'unittests'
   )
 
+  unittest_lora_backward_gradcheck = executable(
+    'unittest_lora_backward_gradcheck',
+    meson.current_source_dir() / 'layers' / 'unittest_lora_backward_gradcheck.cpp',
+    dependencies: [nntrainer_dep, gtest_main_dep, causallm_rms_norm_dep,
+                   causallm_reshaped_rms_norm_dep],
+    include_directories: causallm_layer_inc,
+    build_by_default: true,
+    install: false,
+  )
+
+  test('unittest_lora_backward_gradcheck', unittest_lora_backward_gradcheck,
+    args: '--gtest_output=xml:@0@/@1@.xml'.format(meson.build_root(), 'unittest_lora_backward_gradcheck'),
+    timeout: 60,
+    suite: 'unittests'
+  )
+
   unittest_kv_cache_manager = executable(
     'unittest_kv_cache_manager',
     meson.source_root() / 'test' / 'unittest' / 'layers' / 'unittest_kv_cache_manager.cpp',

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -164,12 +164,24 @@ void FullyConnectedLayer::finalize(InitLayerContext &context) {
                             context.getActivationDataType()),
       is_nchw ? 0b1011 : 0b1101);
 
+    /**
+     * @note Standard LoRA initialization (Hu et al. 2021): A is drawn from a
+     * zero-mean distribution and B is zero, so the adapter contributes
+     * B*A == 0 at step 0 and the pretrained model is reproduced exactly.
+     *
+     * The reverse assignment (A zero, B random) also gives B*A == 0, but is
+     * badly conditioned: with A == 0 the only non-zero gradient at step 0 is
+     * dL/dA = x^T (dy B^T) * scaling, i.e. the first update to A is steered
+     * entirely by the *random* B, so the initial step is a large step in an
+     * arbitrary direction. Empirically that made training diverge above
+     * lr ~1e-6 on Qwen3-0.6B, whereas this ordering is stable at 1e-4.
+     */
     lora_idx[LORAParams::loraA] = context.requestWeight(
-      loraA_dim, Initializer::ZEROS, weight_regularizer,
+      loraA_dim, Initializer::LECUN_NORMAL, weight_regularizer,
       weight_regularizer_constant, weight_decay, "loraA", true);
 
     lora_idx[LORAParams::loraB] = context.requestWeight(
-      loraB_dim, Initializer::LECUN_NORMAL, weight_regularizer,
+      loraB_dim, Initializer::ZEROS, weight_regularizer,
       weight_regularizer_constant, weight_decay, "loraB", true);
 
     lora_idx[LORAParams::loraTmp] =

--- a/nntrainer/layers/fc_layer.cpp
+++ b/nntrainer/layers/fc_layer.cpp
@@ -17,6 +17,7 @@
  * @brief	This is Fully Connected Layer Class for Neural Network
  * @see		https://github.com/nntrainer/nntrainer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
+ * @author	Anirudh Bocha <b.saianirud@samsung.com>
  * @bug		No known bugs except for NYI items
  *
  */
@@ -266,17 +267,30 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
   Tensor &weight = context.getWeight(weight_idx[FCParams::weight]);
   Tensor &input_ = context.getInput(SINGLE_INOUT_IDX);
   Tensor &hidden_ = context.getOutput(SINGLE_INOUT_IDX);
-  Tensor loraA, loraB, hidden_tmp_lora, hidden_out_lora;
+  Tensor loraA, loraB;
+  TensorDim hidden_tmp_lora_dim, hidden_out_lora_dim;
 
   bool is_prefill = !from || (to - from) > 1;
   if (skip_prefill && is_prefill)
     return;
 
-  if (!std::get<props::LoraRank>(fc_props).empty()) {
+  const bool has_lora = !std::get<props::LoraRank>(fc_props).empty();
+  if (has_lora) {
     loraA = context.getWeight(lora_idx[LORAParams::loraA]);
     loraB = context.getWeight(lora_idx[LORAParams::loraB]);
-    hidden_tmp_lora = context.getTensor(lora_idx[LORAParams::loraTmp]);
-    hidden_out_lora = context.getTensor(lora_idx[LORAParams::loraOut]);
+    /**
+     * @note loraTmp/loraOut are requested with FORWARD_GRAD_LIFESPAN /
+     * FORWARD_FUNC_LIFESPAN, which are not allocated when the graph is
+     * compiled without a backward pass (pure inference). This function is
+     * the inference/decode path, so only shape metadata is read from them
+     * here (always valid, independent of data allocation); the actual
+     * scratch computation below uses freshly-allocated local tensors rather
+     * than a shared-data view into this possibly-unallocated storage.
+     */
+    hidden_tmp_lora_dim =
+      context.getTensor(lora_idx[LORAParams::loraTmp]).getDim();
+    hidden_out_lora_dim =
+      context.getTensor(lora_idx[LORAParams::loraOut]).getDim();
   }
 
   TensorDim input_dim = input_.getDim();
@@ -301,25 +315,19 @@ void FullyConnectedLayer::incremental_forwarding(RunLayerContext &context,
 
     input_step.dot(weight, hidden_step, false, false);
 
-    if (!std::get<props::LoraRank>(fc_props).empty()) {
-      nntrainer::TensorDim hidden_tmp_lora_step_dim = hidden_tmp_lora.getDim();
+    if (has_lora) {
+      nntrainer::TensorDim hidden_tmp_lora_step_dim = hidden_tmp_lora_dim;
       hidden_tmp_lora_step_dim.batch(1);
       if (hidden_tmp_lora_step_dim.height() > 1)
         hidden_tmp_lora_step_dim.height(to - from);
 
-      nntrainer::TensorDim hidden_out_lora_step_dim = hidden_out_lora.getDim();
+      nntrainer::TensorDim hidden_out_lora_step_dim = hidden_out_lora_dim;
       hidden_out_lora_step_dim.batch(1);
       if (hidden_out_lora_step_dim.height() > 1)
         hidden_out_lora_step_dim.height(to - from);
 
-      nntrainer::Tensor hidden_tmp_lora_step =
-        hidden_tmp_lora.getSharedDataTensor(
-          hidden_tmp_lora_step_dim,
-          b * hidden_tmp_lora.height() * hidden_tmp_lora.width(), true);
-      nntrainer::Tensor hidden_out_lora_step =
-        hidden_out_lora.getSharedDataTensor(
-          hidden_out_lora_step_dim,
-          b * hidden_out_lora.height() * hidden_out_lora.width(), true);
+      nntrainer::Tensor hidden_tmp_lora_step(hidden_tmp_lora_step_dim, true);
+      nntrainer::Tensor hidden_out_lora_step(hidden_out_lora_step_dim, true);
 
       input_step.dot(loraA, hidden_tmp_lora_step, false, false);
       hidden_tmp_lora_step.dot(loraB, hidden_out_lora_step, false, false);


### PR DESCRIPTION
## Dependency of the PR

- Depends on #4270 (must merge after it).
- Part of a 12-PR stack adding LoRA / QAT training support to CausalLM. Must merge in stack order.

## Commits to be reviewed in this PR

<details><summary>[CausalLM] add backprop (derivative + gradient) for rms_norm and reshaped_rms_norm</summary><br />

These layers had no calcDerivative/calcGradient support and could not be
part of a training graph. Both use the standard RMSNorm backward:

```
dx = inv_rms * (gamma*dy - x * mean(gamma*dy*x) * inv_rms^2)
dgamma[k] += sum_rows dy*x*inv_rms
```

inv_rms is cached from the forward pass (an ITERATION_LIFESPAN tensor) so
calcDerivative doesn't recompute the norm. reshaped_rms_norm applies the
same math per feature_size chunk and is a no-op when use_gamma is false.

Under the default LoRA-only recipe these layers stay frozen (gamma is not
a LoRA target), so calcGradient is unused there; it exists for the
"LoRA + norms" recipe (lora_train_norms) where gamma is also trained.

Verified against finite-difference gradient checks (new
unittest_lora_backward_gradcheck, 4 tests covering calcDerivative and
calcGradient for both layers).

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped

Signed-off-by: Niket Agarwal <niket.a@samsung.com>

</details>

<details><summary>[CausalLM] add backprop for swiglu</summary><br />

calcDerivative implements the SwiGLU backward:

```
d_up   = Swish(gate) * dy
d_gate = Swish'(gate) * up * dy,  Swish(g) = g * sigmoid(g)
```

nntrainer aliases each layer's outgoing derivative onto the same buffer as
the corresponding input, so writing d_up (which aliases the up input)
before d_gate is computed would silently corrupt up's value out from under
the d_gate computation. The implementation snapshots gate/up/dy into
locals before any output write, and a dedicated regression test
(SwiGLUCalcDerivativeIsSafeWhenGradAliasesInput) reconstructs that exact
aliasing to catch regressions of this class directly rather than relying
on the other gradient checks, which use independently-allocated buffers
and don't exercise it.

swiglu has no weights, so there is no calcGradient to add.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped

Signed-off-by: Niket Agarwal <niket.a@samsung.com>

</details>

### Summary

- Adds `calcDerivative()`/`calcGradient()` to `rms_norm` and `reshaped_rms_norm`, which previously had no backward implementation and therefore could not participate in a training graph.
- Adds `calcDerivative()` to `swiglu`. The implementation is written to be safe against nntrainer's derivative/input buffer aliasing, which would otherwise corrupt the `up` input before `d_gate` is computed.
- Adds `unittest_lora_backward_gradcheck` with finite-difference gradient checks for both norm layers, plus a dedicated aliasing regression test for SwiGLU.
- No behavioural change to inference: these paths are only exercised when the graph is compiled for training.

Note: the checkboxes above are intentionally left unticked — build/run results should be filled in by the submitter after running them locally.

Signed-off-by: Niket Agarwal <niket.a@samsung.com>
