### PR TITLE
[CI] disable android build CI temporarily

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,8 @@
 name: "Build Test - Android NDK"
 
 on:
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/causallm_android.yml
+++ b/.github/workflows/causallm_android.yml
@@ -1,8 +1,8 @@
 name: "CausalLM Android Build"
 
 on:
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[CI] disable android build CI temporarily</summary><br />

Currently, android CI keeps failing due to missing ml api artifact.
Let's disable them temporarily until this issue fixes.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
Let's disable android CI until ml api issue fixes.

Here's the plan how to fix it.
- build ml api in local if there's no any artifact in AWS
- store ml api artifact in cache
  - need to handle gbs cache explosion bug, first

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
