### PR TITLE
[Android] Prepare ml-api only when the C-API is enabled

### DIFF
--- a/api/meson.build
+++ b/api/meson.build
@@ -3,13 +3,11 @@ if get_option('enable-ccapi')
   subdir('ccapi')
 endif
 
-if get_option('enable-capi').enabled()
-  if not get_option('enable-ccapi')
+# build_capi is computed in the top-level meson.build.
+if build_capi
+  if get_option('enable-capi').enabled() and not get_option('enable-ccapi')
     error('enable-ccapi must be set for capi as well')
   endif
-  enable_capi = true
-  subdir('capi')
-elif get_option('enable-capi').auto() and get_option('enable-ccapi') and nnstreamer_capi_dep.found()
   enable_capi = true
   subdir('capi')
 endif

--- a/jni/Android.mk.in
+++ b/jni/Android.mk.in
@@ -2,6 +2,13 @@ LOCAL_PATH := $(call my-dir)
 
 MESON_HAS_TFLITE := @MESON_HAS_TFLITE@
 
+# ml-api include path; empty when ml-api is absent (capi off).
+MESON_HAS_ML_API := @MESON_HAS_ML_API@
+ML_API_INCLUDE :=
+ifeq ($(MESON_HAS_ML_API),1)
+ML_API_INCLUDE := @MESON_ML_API_COMMON_ROOT@/include
+endif
+
 ifeq ($(MESON_HAS_TFLITE),1)
 
 include $(CLEAR_VARS)
@@ -25,15 +32,18 @@ LOCAL_EXPORT_CFLAGS += -DUSE_BLAS=1
 
 include $(PREBUILT_STATIC_LIBRARY)
 
+# guarded: ml-api prebuilt only exists when capi is enabled.
+ifeq ($(MESON_HAS_ML_API),1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := ml-api-inference
 
 LOCAL_SRC_FILES := @MESON_ML_API_COMMON_ROOT@/lib/arm64-v8a/libnnstreamer-native.so
-LOCAL_EXPORT_C_INCLUDES := @MESON_ML_API_COMMON_ROOT@/include
+LOCAL_EXPORT_C_INCLUDES := $(ML_API_INCLUDE)
 LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 
 include $(PREBUILT_SHARED_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 
@@ -186,11 +196,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE        := nntrainer
 LOCAL_SRC_FILES     := @MESON_NNTRAINER_SRCS@
 # @todo ML_API_COMMON_ROOT should be included by exporting ml-api-common lib later
-LOCAL_C_INCLUDES    := @MESON_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/include
+LOCAL_C_INCLUDES    := @MESON_NNTRAINER_INCS@ $(ML_API_INCLUDE)
 LOCAL_EXPORT_C_INCLUDES  := $(LOCAL_C_INCLUDES)
 
-LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@ @ML_API_COMMON@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid
@@ -217,11 +227,11 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE        := ccapi-nntrainer
 LOCAL_SRC_FILES     := @MESON_CCAPI_NNTRAINER_SRCS@
-LOCAL_C_INCLUDES    := @MESON_CCAPI_NNTRAINER_INCS@ @MESON_ML_API_COMMON_ROOT@/include
+LOCAL_C_INCLUDES    := @MESON_CCAPI_NNTRAINER_INCS@ $(ML_API_INCLUDE)
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
-LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@ @ML_API_COMMON@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@ @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions -DVERSION_MAJOR=@VERSION_MAJOR@ -DVERSION_MINOR=@VERSION_MINOR@ -DVERSION_MICRO=@VERSION_MICRO@ @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid
@@ -231,6 +241,8 @@ LOCAL_SHARED_LIBRARIES += nntrainer
 
 include $(BUILD_SHARED_LIBRARY)
 
+# capi-nntrainer needs ml-api, so build it only when ml-api is present.
+ifeq ($(MESON_HAS_ML_API),1)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE        := capi-nntrainer
@@ -238,8 +250,8 @@ LOCAL_SRC_FILES     := @MESON_CAPI_NNTRAINER_SRCS@
 LOCAL_C_INCLUDES    := @MESON_CAPI_NNTRAINER_INCS@
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
-LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@ @ML_API_COMMON@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@
+LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @MESON_CXXFLAGS@
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid
@@ -248,6 +260,7 @@ LOCAL_LDFLAGS 	    += "-Wl,-z,max-page-size=16384"
 LOCAL_SHARED_LIBRARIES += ccapi-nntrainer nntrainer ml-api-inference
 
 include $(BUILD_SHARED_LIBRARY)
+endif
 
 ifeq (@MESON_ENABLE_NPU@,1)
 
@@ -258,8 +271,8 @@ LOCAL_SRC_FILES     := @MESON_QNN_SRCS@
 LOCAL_C_INCLUDES    := @MESON_QNN_INCS@ @MESON_ML_API_COMMON_ROOT@/include @MESON_NNTRAINER_INCS@
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_INCLUDES)
 
-LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@ @ML_API_COMMON@
-LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @ML_API_COMMON@ @MESON_CXXFLAGS@ -DENABLE_QNN=1 -DPLUGGABLE=1
+LOCAL_CFLAGS        += -pthread -fexceptions @MESON_CFLAGS@
+LOCAL_CXXFLAGS      += -std=c++17 -frtti -fexceptions @MESON_CXXFLAGS@ -DENABLE_QNN=1 -DPLUGGABLE=1
 LOCAL_MODULE_TAGS   := optional
 
 LOCAL_LDLIBS        := -llog -landroid

--- a/jni/meson.build
+++ b/jni/meson.build
@@ -104,8 +104,6 @@ else
   and_conf.set('MESON_HAS_TFLITE', 0)
 endif
 
-# -DML_API_COMMON=[01]
-and_conf.set('ML_API_COMMON', ml_api_common_flag)
 
 if blas_dep.found()
   and_conf.set('MESON_BLAS_ROOT', blas_root)
@@ -113,10 +111,14 @@ else
   error('blas is needed for the android build')
 endif
 
+# ml-api is only prepared when capi is enabled (see meson.build); when absent,
+# expose MESON_HAS_ML_API=0 instead of erroring (Android.mk guards on it).
 if ml_api_common_dep.found()
+  and_conf.set('MESON_HAS_ML_API', 1)
   and_conf.set('MESON_ML_API_COMMON_ROOT', ml_api_common_root)
 else
-  error('ml api common dep is needed for the android build')
+  and_conf.set('MESON_HAS_ML_API', 0)
+  and_conf.set('MESON_ML_API_COMMON_ROOT', '')
 endif
 
 if get_option('enable-npu')

--- a/meson.build
+++ b/meson.build
@@ -408,34 +408,35 @@ nntrainer_conf.set('INCLUDE_INSTALL_DIR', nntrainer_includedir / '..')
 nntrainer_conf.set('FLASH_STORAGE_UTILIZATION', nntrainer_enable_fsu)
 nntrainer_conf.set('FLASH_STORAGE_UTILIZATION_PATH', nntrainer_fsudir)
 
-ml_api_common_flag = '-DML_API_COMMON=0'
-
-# if ml-api-support is disabled, enable dummy common api interfaces and disable related dependencies.
-ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required : get_option('ml-api-support').enabled())
+ml_api_common_dep = dummy_dep
 nnstreamer_capi_dep = dummy_dep
-if (ml_api_common_dep.found())
-  nnstreamer_capi_dep = dependency(get_option('capi-ml-inference-actual'), required : get_option('ml-api-support').enabled())
-  if (nnstreamer_capi_dep.found())
-    nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
-    extra_defines += '-DML_API_COMMON=1'
-    ml_api_common_flag = '-DML_API_COMMON=1'
-    extra_defines += '-DNNSTREAMER_AVAILABLE=1'
-    # accessing this variable when dep_.not_found() remains hard error on purpose
-    supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')
-    if not supported_nnstreamer_capi
-      extra_defines += '-DUNSUPPORTED_NNSTREAMER=1'
-      warning('capi-nnstreamer version is too old, we do not know if it works with older nnstreamer version')
-    endif
-  else
-    # if nnstreamer_capi is not there and ml-api-support is "auto", disable it.
-    message ('ml-api-support is disabled although capi-ml-api-common is found: capi-ml-api-inference is not available and ml-api-support is configured to be auto')
-    nntrainer_conf.set('CAPI_ML_COMMON_DEP', '')
-    extra_defines += '-DML_API_COMMON=0'
+
+# android should not use host packages
+if get_option('platform') != 'android'
+  ml_api_common_dep = dependency(get_option('capi-ml-common-actual'), required : get_option('ml-api-support').enabled())
+  if ml_api_common_dep.found()
+    nnstreamer_capi_dep = dependency(get_option('capi-ml-inference-actual'), required : get_option('ml-api-support').enabled())
+  endif
+endif
+
+if nnstreamer_capi_dep.found()
+  nntrainer_conf.set('CAPI_ML_COMMON_DEP', get_option('capi-ml-common-actual'))
+  extra_defines += '-DML_API_COMMON=1'
+  extra_defines += '-DNNSTREAMER_AVAILABLE=1'
+  # accessing this variable when dep_.not_found() remains hard error on purpose
+  supported_nnstreamer_capi = nnstreamer_capi_dep.version().version_compare('>=1.7.0')
+  if not supported_nnstreamer_capi
+    extra_defines += '-DUNSUPPORTED_NNSTREAMER=1'
+    warning('capi-nnstreamer version is too old, we do not know if it works with older nnstreamer version')
   endif
 else
   nntrainer_conf.set('CAPI_ML_COMMON_DEP', '')
   extra_defines += '-DML_API_COMMON=0'
+  if ml_api_common_dep.found()
+    message('ml-api-support disabled: capi-ml-inference not found though capi-ml-common is')
+  endif
 endif
+
 blas_dep = dummy_dep
 # Dependencies
 if get_option('enable-cublas')
@@ -669,18 +670,31 @@ else
 endif
 endif # enable ruy
 
+build_capi = get_option('enable-capi').enabled() or \
+  (get_option('enable-capi').auto() and get_option('enable-ccapi') and nnstreamer_capi_dep.found())
+
 if get_option('platform') == 'android'
-  message('preparing ml api')
-  run_command([meson.source_root() / 'jni' / 'prepare_ml-api.sh', meson.build_root() / 'ml-api-inference'], check: true)
-  ml_api_common_root = meson.build_root() / 'ml-api-inference'
-  ml_api_inc = ml_api_common_root / 'include'
-  meson.add_install_script(
-    'sh', '-c', 'cp @0@ ${DESTDIR}@1@'.format(ml_api_inc / 'ml-api-common.h', nntrainer_includedir)
-  )
-  meson.add_install_script(
-    'sh', '-c', 'cp @0@ ${DESTDIR}@1@'.format(ml_api_inc / 'tizen_error.h', nntrainer_includedir)
-  )
-  ml_api_common_dep = declare_dependency(include_directories: ['ml-api-inference/include'])
+  # ml-api is only consumed by capi, prepare it only when capi is built.
+  if build_capi
+    message('preparing ml api')
+    run_command([meson.source_root() / 'jni' / 'prepare_ml-api.sh', meson.build_root() / 'ml-api-inference'], check: true)
+    ml_api_common_root = meson.build_root() / 'ml-api-inference'
+    ml_api_inc = ml_api_common_root / 'include'
+    meson.add_install_script(
+      'sh', '-c', 'cp @0@ ${DESTDIR}@1@'.format(ml_api_inc / 'ml-api-common.h', nntrainer_includedir)
+    )
+    meson.add_install_script(
+      'sh', '-c', 'cp @0@ ${DESTDIR}@1@'.format(ml_api_inc / 'tizen_error.h', nntrainer_includedir)
+    )
+    ml_api_common_dep = declare_dependency(include_directories: ['ml-api-inference/include'])
+    # ml-api available now: enable ML_API_COMMON (default was disabled above).
+    extra_defines += '-DML_API_COMMON=1'
+    extra_defines += '-DNNSTREAMER_AVAILABLE=1'
+  else
+    message('capi is disabled; skipping ml-api preparation for android build')
+    ml_api_common_root = ''
+    ml_api_common_dep = dummy_dep
+  endif
 endif
 
 if get_option('enable-nnstreamer-backbone') and get_option('platform') != 'android'


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[Android] Prepare ml-api only when the C-API is enabled</summary><br />

Problem:
- The android build always prepared the ml-api dependency (downloaded from
  the nnstreamer S3) at meson configure time.
- But the default android build never uses ml-api. Only the C-API (capi)
  needs it, and capi is off by default on android; the core library and
  ccapi do not need it.
- So when the S3 artifact was missing, the whole android build failed for a
  dependency that nothing actually used.
- Detection also probed host pkg-config, which is wrong for the android cross
  target (ml-api comes from a prebuilt zip, not pkg-config). On a dev host
  with capi-ml-common installed this wrongly turned on ML_API_COMMON, so the
  compile broke on a header that was enabled but never prepared.

Fix:
- Add build_capi as the single source of truth for building capi (shared with
  api/meson.build). On android it ignores host pkg-config, so capi, and thus
  ml-api, is prepared only with -Denable-capi=enabled.
- Skip the ml-api download/build and keep ML_API_COMMON=0 for the default
  android build.
- Guard the ml-api-inference and capi-nntrainer ndk modules on MESON_HAS_ML_API
  so the generated Android.mk stays valid without ml-api.
- Drop the redundant ml_api_common_flag / @ML_API_COMMON@; ML_API_COMMON is
  already passed via extra_defines / MESON_CFLAGS.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary

Let's skip ml api check for android build when it's not used.

Note that this PR doesn't fundamentally solve nnstreamer(capi) issue, following work should be needed.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
