### PR TITLE
[CI] Fix GBS RPM cache size growing bug

### DIFF
--- a/.github/workflows/daily_build_tizen_arm.yml
+++ b/.github/workflows/daily_build_tizen_arm.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-    - name: restore gbs cache from main branch
+    - name: restore gbs RPM cache from main branch
       uses: actions/cache/restore@v4
       with:
         path: ~/GBS-ROOT/local/cache
@@ -46,7 +46,14 @@ jobs:
       run: |
         gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A ${{ matrix.gbs_build_arch }} ${{ matrix.gbs_build_option }}
 
-    - name: save gbs cache
+    - name: prune gbs RPM cache
+      # RPM cache includes packages which are necessary for gbs build.
+      # When these packages are newly updated, actions/cache/save saves both old and new packages which causes
+      # RPM cache size explosion.
+      # By running pruning script, let's save newest packages only.
+      run: bash .github/workflows/gbs-cache-prune.sh
+
+    - name: save gbs RPM cache
       uses: actions/cache/save@v4
       with:
         path: ~/GBS-ROOT/local/cache

--- a/.github/workflows/daily_build_tizen_x86_64.yml
+++ b/.github/workflows/daily_build_tizen_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-    - name: restore gbs cache from main branch
+    - name: restore gbs RPM cache from main branch
       uses: actions/cache/restore@v4
       with:
         path: ~/GBS-ROOT/local/cache
@@ -38,7 +38,14 @@ jobs:
       run: |
         gbs build --skip-srcrpm --define "_skip_debug_rpm 1" -A x86_64 --define "unit_test 1"
 
-    - name: save gbs cache
+    - name: prune gbs RPM cache
+      # RPM cache includes packages which are necessary for gbs build.
+      # When these packages are newly updated, actions/cache/save saves both old and new packages which causes
+      # RPM cache size explosion.
+      # By running pruning script, let's save newest packages only.
+      run: bash .github/workflows/gbs-cache-prune.sh
+
+    - name: save gbs RPM cache
       uses: actions/cache/save@v4
       with:
         path: ~/GBS-ROOT/local/cache

--- a/.github/workflows/gbs-cache-prune.sh
+++ b/.github/workflows/gbs-cache-prune.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+##
+# @file  gbs-cache-prune.sh
+# @brief Keep only the newest version of each RPM in the GBS RPM cache.
+#
+# GBS never purges superseded packages from ~/GBS-ROOT/local/cache.
+# This keeps, per package (name+arch), only the most-recently-downloaded .rpm
+# and deletes older versions, bounding the cache to one snapshot.
+
+# A wrongly-pruned package only costs a re-download on the next run, never a
+# build failure, so erring toward pruning is safe.
+set -u
+
+CACHE="${1:-$HOME/GBS-ROOT/local/cache}"
+
+if [ ! -d "$CACHE" ]; then
+  echo "gbs-cache-prune: no cache dir at $CACHE, nothing to do"
+  exit 0
+fi
+
+echo "== gbs package cache before prune =="
+du -sh "$CACHE" 2>/dev/null || true
+before=$(find "$CACHE" -name '*.rpm' 2>/dev/null | wc -l)
+echo "rpm files: $before"
+
+# newest first (by mtime); keep first occurrence of each package key, list the rest
+prune_list=$(
+  find "$CACHE" -type f -name '*.rpm' -printf '%T@\t%p\n' 2>/dev/null \
+    | sort -rn \
+    | awk -F'\t' '
+        {
+          path = $2
+          n = split(path, seg, "/"); base = seg[n]
+          key = base
+          # strip trailing -<version>-<release>.<arch>.rpm to group all versions
+          sub(/-[^-]+-[^-]+\.[^.]+\.rpm$/, "", key)
+          if (key in seen) { print path }   # older duplicate -> prune
+          else             { seen[key] = 1 }
+        }'
+)
+
+# surface how aggressive the prune is, so a runaway regex is visible in the log
+pruned=$(printf '%s' "$prune_list" | grep -c . || true)
+echo "pruning $pruned of $before rpm(s)"
+if [ -n "$prune_list" ]; then
+  printf '%s\n' "$prune_list" | while IFS= read -r f; do [ -n "$f" ] && rm -f "$f"; done
+fi
+
+echo "== gbs package cache after prune =="
+du -sh "$CACHE" 2>/dev/null || true
+after=$(find "$CACHE" -name '*.rpm' 2>/dev/null | wc -l)
+echo "rpm files: $after"
+
+# a correct prune always keeps the newest of each key, so it can never empty a
+# non-empty cache; if it did, the key logic is broken -- flag it loudly
+if [ "$before" -gt 0 ] && [ "$after" -eq 0 ]; then
+  echo "gbs-cache-prune: ERROR pruned all $before rpm(s); key logic broken" >&2
+fi


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR

<details><summary>[CI] Fix GBS RPM cache size growing bug</summary><br />

RPM cache includes packages which are necessary for gbs build.
When these packages are newly updated, actions/cache/save saves both old
and new packages which causes RPM cache size explosion.
Let's use pruning script to save newest packages only.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>


### Summary
As of now, gbs RPM cache consumes most of the cache capacity due to bug.
Let's fix it and make free spaces for this repository's cache.

* Before this PR
<img width="680" height="167" alt="a" src="https://github.com/user-attachments/assets/4016e2d5-d1db-427e-99b4-fe609ca1af36" />

* After this PR
<img width="676" height="167" alt="b" src="https://github.com/user-attachments/assets/aa489c7d-d85d-4c16-bedc-fec2a62fec34" />

* 5.88GB -> 1.05GB

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

