### PR TITLE
[Tizen] AArch32 dot-product kernels for q4_0/q8_0 and an arm_tune build knob

### DIFF
--- a/docs/hotdoc/sitemap.txt
+++ b/docs/hotdoc/sitemap.txt
@@ -2,6 +2,7 @@ index.md
 	docs/hotdoc/index.md
 		docs/getting-started.md
 		docs/how-to-run-examples.md
+		docs/how-to-build-tizen.md
 		docs/how-to-use-testcases.md
 		docs/configuration-ini.md
 		docs/coding-convention.md

--- a/docs/how-to-build-tizen.md
+++ b/docs/how-to-build-tizen.md
@@ -1,0 +1,105 @@
+# How to build NNTrainer for Tizen
+
+NNTrainer is packaged for Tizen with GBS. This page covers picking the right
+target architecture, and how to build for a device whose CPU is newer than the
+Tizen reference baseline.
+
+## Prerequisites
+
+Install GBS and point it at the Tizen snapshot repositories:
+
+```bash
+echo "deb [trusted=yes] http://download.tizen.org/tools/latest-release/Ubuntu_22.04/ /" \
+  | sudo tee /etc/apt/sources.list.d/tizen.list
+sudo apt-get update && sudo apt-get install -y gbs
+cp .github/workflows/tizen.gbs.conf ~/.gbs.conf
+```
+
+## A plain build
+
+```bash
+gbs build -A armv7l  --define "unit_test 0"
+gbs build -A aarch64 --define "unit_test 0"
+gbs build -A x86_64  --define "unit_test 1"
+```
+
+`-A` must match the **RPM architecture of the target image**, not the CPU. A
+64-bit core running a 32-bit Tizen rootfs is an `armv7l` target. Check on the
+device with:
+
+```bash
+rpm --eval '%{_arch}'          # armv7l / aarch64 - this is the -A value
+uname -m
+grep -m1 'CPU part' /proc/cpuinfo   # e.g. 0xd0b = Cortex-A76
+```
+
+## Optional features
+
+| Define | Effect |
+| --- | --- |
+| `--define "_with_fp16 1"` | Enable float16. Requires an ARMv8.2-A target; off by default because the aarch64 Tizen reference is ARMv8.0-A |
+| `--define "_with_gpu 1"` | Enable the OpenCL backend |
+| `--define "unit_test 1"` | Run the unit tests as part of the build |
+| `--define "arm_tune <flags>"` | Raise the ARM baseline for a known device, see below |
+
+## Building for a specific ARM core
+
+The Tizen reference `Optflags` target the oldest core each architecture has to
+support:
+
+| Arch | Reference optflags |
+| --- | --- |
+| armv7l | `-march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp -mthumb` |
+| aarch64 | `-march=armv8-a+fp+simd+crc+crypto -mtune=cortex-a57.cortex-a53` |
+
+`arm_tune` is appended to `CFLAGS`/`CXXFLAGS` last, so it overrides both those
+defaults and the `-march` that `meson.build` hardcodes for aarch64 (meson places
+environment flags after `add_project_arguments()`).
+
+### armv7l on an ARMv8.2-A core
+
+This is the interesting case: a 32-bit Tizen rootfs on something like a
+Cortex-A76. The core implements `FEAT_DotProd` at EL0 in AArch32, so the ggml
+q4_0/q8_0 kernels can use `VSDOT` even though userspace is 32-bit. Without
+`arm_tune` those kernels stay on their scalar path.
+
+```bash
+gbs build -A armv7l --include-all --skip-srcrpm \
+  --define "_skip_debug_rpm 1" \
+  --define "unit_test 0" \
+  --define "arm_tune -march=armv8.2-a+dotprod -mtune=cortex-a76 -mfpu=neon-fp-armv8 -mfp16-format=ieee"
+```
+
+Each flag is load-bearing:
+
+| Flag | Why |
+| --- | --- |
+| `-march=armv8.2-a` | gcc rejects `+dotprod` on plain `armv8-a` for A32 |
+| `+dotprod` | defines `__ARM_FEATURE_DOTPROD`, which gates the kernels |
+| `-mtune=cortex-a76` | scheduling only, no ISA effect |
+| `-mfpu=neon-fp-armv8` | FMA plus fp16 <-> fp32 conversion |
+| `-mfp16-format=ieee` | needed for `float16x4_t` and the block scale conversions |
+
+Do **not** put `-mfloat-abi` in `arm_tune`: `softfp` is part of the armv7l ABI
+and changing it breaks linking against the platform libraries. Do not add
+`+i8mm` for Cortex-A76 either, since `FEAT_I8MM` is ARMv8.6-A and the core does
+not implement it.
+
+### Checking that the flags took effect
+
+Tizen's global cflags include `-frecord-gcc-switches`, so the compile line is
+recorded in the binary:
+
+```bash
+rpm2cpio ~/GBS-ROOT/local/repos/tizen/armv7l/RPMS/nntrainer-core-*.armv7l.rpm | cpio -idm
+readelf -A usr/lib/debug/usr/lib/libnntrainer.so.debug | head -8
+```
+
+An `arm_tune`d armv7l build reports `Tag_CPU_arch: v8` and `Tag_FP_arch: FP for
+ARMv8`; the reference build reports `v7` and `VFPv3`.
+
+## Compatibility
+
+An `arm_tune`d RPM no longer runs on cores below the baseline you pick. Build it
+only for images pinned to known hardware, and keep the plain build for anything
+that ships broadly.

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
@@ -377,10 +377,10 @@ void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
           int8x16_t b2 = vld1q_s8(bq + 32); // k = 1, cols 0-1
           int8x16_t b3 = vld1q_s8(bq + 48); // k = 1, cols 2-3
 
-          int8x8_t t0 = vld1_s8(aq);       // k = 0, low nibble operand
-          int8x8_t t1 = vld1_s8(aq + 32);  // k = 1, low
-          int8x8_t t2 = vld1_s8(aq + 64);  // k = 0, high
-          int8x8_t t3 = vld1_s8(aq + 96);  // k = 1, high
+          int8x8_t t0 = vld1_s8(aq);      // k = 0, low nibble operand
+          int8x8_t t1 = vld1_s8(aq + 32); // k = 1, low
+          int8x8_t t2 = vld1_s8(aq + 64); // k = 0, high
+          int8x8_t t3 = vld1_s8(aq + 96); // k = 1, high
           int8x16_t a0 = vcombine_s8(t0, t0);
           int8x16_t a1 = vcombine_s8(t1, t1);
           int8x16_t a2 = vcombine_s8(t2, t2);
@@ -615,7 +615,8 @@ void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
 
     for (int b = 0; b < nb; b++) {
       // Separate vld1q_s8 rather than vld1q_s8_x4: on A32 gcc declares the _xN
-      // forms as taking const uint8_t *, and four plain loads schedule the same.
+      // forms as taking const uint8_t *, and four plain loads schedule the
+      // same.
       const int8_t *bq = (const int8_t *)vb_ptr->qs;
       const int8_t *aq = (const int8_t *)va_ptr->qs;
       float16x4_t bd = vld1_f16((const __fp16 *)vb_ptr->d);
@@ -718,8 +719,8 @@ void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
 
         // qs is int8_t[128] laid out as {k, row/col, i}: 4 groups of 32 bytes,
         // each group holding four 8-byte lanes.
-        // See the q4_0 kernel above: hoist the scale conversion so the innermost
-        // loop stays free of out-of-line calls.
+        // See the q4_0 kernel above: hoist the scale conversion so the
+        // innermost loop stays free of out-of-line calls.
         float32x4_t ad = vcvt_f32_f16(vld1_f16((const __fp16 *)va_ptr[l].d));
 
         auto row = [&](const int8_t *ap, float32x4_t scale, float32x4_t acc) {
@@ -813,8 +814,8 @@ void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
     float32x4_t acc = vdupq_n_f32(0);
 
     for (int b = 0; b < nb; b++) {
-      // Separate loads rather than vld1q_s8_x4 / vld1_s8_x4: on A32 gcc declares
-      // the _xN forms as taking const uint8_t *.
+      // Separate loads rather than vld1q_s8_x4 / vld1_s8_x4: on A32 gcc
+      // declares the _xN forms as taking const uint8_t *.
       const int8_t *bq = (const int8_t *)vb_ptr->qs;
       const int8_t *aq = (const int8_t *)va_ptr->qs;
       float16x4_t bd = vld1_f16((const __fp16 *)vb_ptr->d);

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
@@ -357,44 +357,30 @@ void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
     for (int x = 0; x < nc / ncols_interleaved; x++) {
       const block_q4_0x4 *vb_ptr = (const block_q4_0x4 *)vx + (x * nb);
 
-      // One named accumulator per row rather than an acc[4] array, so the
-      // register allocator can keep them live. Some spilling is unavoidable
-      // either way: eight split B vectors plus four accumulators plus the
-      // per-row temporaries exceed the sixteen Q registers A32 has, which is
-      // why the aarch64 kernel (32 registers) can hold a much wider tile.
-      float32x4_t acc0 = vdupq_n_f32(0);
-      float32x4_t acc1 = vdupq_n_f32(0);
-      float32x4_t acc2 = vdupq_n_f32(0);
-      float32x4_t acc3 = vdupq_n_f32(0);
+      // Row-outer: only one accumulator is live across the block loop, which
+      // is what keeps this inside the sixteen Q registers A32 has. Re-reading
+      // B once per row costs four L1 hits per block; carrying four
+      // accumulators plus four rows of A instead costs far more in spills.
+      for (int m = 0; m < 4; m++) {
+        float32x4_t acc = vdupq_n_f32(0);
+        // Walk the blocks with plain increments; indexing vb_ptr[l] makes gcc
+        // redo a 72/136-byte stride multiply every iteration.
+        const block_q4_0x4 *bp = vb_ptr;
+        const block_q8_0x4 *ap = va_ptr;
 
-      for (int l = 0; l < nb; l++) {
-        const int8_t *bq = (const int8_t *)vb_ptr[l].qs;
-        int8x16_t b0 = vld1q_s8(bq);      // k = 0, cols 0-1
-        int8x16_t b1 = vld1q_s8(bq + 16); // k = 0, cols 2-3
-        int8x16_t b2 = vld1q_s8(bq + 32); // k = 1, cols 0-1
-        int8x16_t b3 = vld1q_s8(bq + 48); // k = 1, cols 2-3
+        for (int l = 0; l < nb; l++, bp++, ap++) {
+          const int8_t *bq = (const int8_t *)bp->qs;
+          const int8_t *aq = (const int8_t *)ap->qs + m * 8;
 
-        int8x16_t b0l = b0 << 4;
-        int8x16_t b1l = b1 << 4;
-        int8x16_t b2l = b2 << 4;
-        int8x16_t b3l = b3 << 4;
-        int8x16_t b0h = b0 & 0xf0U;
-        int8x16_t b1h = b1 & 0xf0U;
-        int8x16_t b2h = b2 & 0xf0U;
-        int8x16_t b3h = b3 & 0xf0U;
+          int8x16_t b0 = vld1q_s8(bq);      // k = 0, cols 0-1
+          int8x16_t b1 = vld1q_s8(bq + 16); // k = 0, cols 2-3
+          int8x16_t b2 = vld1q_s8(bq + 32); // k = 1, cols 0-1
+          int8x16_t b3 = vld1q_s8(bq + 48); // k = 1, cols 2-3
 
-        float32x4_t bd = vcvt_f32_f16(vld1_f16((const __fp16 *)vb_ptr[l].d));
-
-        // qs is int8_t[128]: 8 bytes per {k, row} for the low nibbles, then
-        // the same again from byte 64 for the high nibbles. Loaded as bytes so
-        // gcc cannot attach a :64 alignment qualifier (see the GEMV above).
-        const int8_t *aq = (const int8_t *)va_ptr[l].qs;
-
-        auto row = [&](const int8_t *ap, int m, float32x4_t acc) {
-          int8x8_t t0 = vld1_s8(ap);
-          int8x8_t t1 = vld1_s8(ap + 32);
-          int8x8_t t2 = vld1_s8(ap + 64);
-          int8x8_t t3 = vld1_s8(ap + 96);
+          int8x8_t t0 = vld1_s8(aq);       // k = 0, low nibble operand
+          int8x8_t t1 = vld1_s8(aq + 32);  // k = 1, low
+          int8x8_t t2 = vld1_s8(aq + 64);  // k = 0, high
+          int8x8_t t3 = vld1_s8(aq + 96);  // k = 1, high
           int8x16_t a0 = vcombine_s8(t0, t0);
           int8x16_t a1 = vcombine_s8(t1, t1);
           int8x16_t a2 = vcombine_s8(t2, t2);
@@ -403,32 +389,27 @@ void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
           int32x4_t r0 = vdupq_n_s32(0);
           int32x4_t r1 = vdupq_n_s32(0);
 
-          r0 = vdotq_s32(r0, b0l, a0);
-          r1 = vdotq_s32(r1, b1l, a0);
-          r0 = vdotq_s32(r0, b2l, a1);
-          r1 = vdotq_s32(r1, b3l, a1);
+          r0 = vdotq_s32(r0, b0 << 4, a0);
+          r1 = vdotq_s32(r1, b1 << 4, a0);
+          r0 = vdotq_s32(r0, b2 << 4, a1);
+          r1 = vdotq_s32(r1, b3 << 4, a1);
 
-          r0 = vdotq_s32(r0, b0h, a2);
-          r1 = vdotq_s32(r1, b1h, a2);
-          r0 = vdotq_s32(r0, b2h, a3);
-          r1 = vdotq_s32(r1, b3h, a3);
+          r0 = vdotq_s32(r0, b0 & 0xf0U, a2);
+          r1 = vdotq_s32(r1, b1 & 0xf0U, a2);
+          r0 = vdotq_s32(r0, b2 & 0xf0U, a3);
+          r1 = vdotq_s32(r1, b3 & 0xf0U, a3);
 
-          float ad = nntr_compute_fp16_to_fp32(va_ptr[l].d[m]);
-          return vfmaq_f32(acc, vcvtq_n_f32_s32(vpaddq_s32(r0, r1), 4),
-                           vmulq_n_f32(bd, ad));
-        };
+          float32x4_t bd = vcvt_f32_f16(vld1_f16((const __fp16 *)bp->d));
+          // Inline __fp16 conversion, not nntr_compute_fp16_to_fp32: an
+          // out-of-line call here spills every live vector register.
+          __fp16 adh;
+          memcpy(&adh, &ap->d[m], sizeof(adh));
 
-        acc0 = row(aq, 0, acc0);
-        acc1 = row(aq + 8, 1, acc1);
-        acc2 = row(aq + 16, 2, acc2);
-        acc3 = row(aq + 24, 3, acc3);
+          acc = vfmaq_f32(acc, vcvtq_n_f32_s32(vpaddq_s32(r0, r1), 4),
+                          vmulq_n_f32(bd, (float)adh));
+        }
+        vst1q_f32(&s[(y * 4 + m) * bs + x * ncols_interleaved], acc);
       }
-
-      float *out = &s[(y * 4) * bs + x * ncols_interleaved];
-      vst1q_f32(out, acc0);
-      vst1q_f32(out + bs, acc1);
-      vst1q_f32(out + 2 * bs, acc2);
-      vst1q_f32(out + 3 * bs, acc3);
     }
   }
 #else
@@ -737,7 +718,11 @@ void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
 
         // qs is int8_t[128] laid out as {k, row/col, i}: 4 groups of 32 bytes,
         // each group holding four 8-byte lanes.
-        auto row = [&](const int8_t *ap, int m, float32x4_t acc) {
+        // See the q4_0 kernel above: hoist the scale conversion so the innermost
+        // loop stays free of out-of-line calls.
+        float32x4_t ad = vcvt_f32_f16(vld1_f16((const __fp16 *)va_ptr[l].d));
+
+        auto row = [&](const int8_t *ap, float32x4_t scale, float32x4_t acc) {
           int32x4_t r0 = vdupq_n_s32(0);
           int32x4_t r1 = vdupq_n_s32(0);
           for (int k = 0; k < 4; k++) {
@@ -746,15 +731,13 @@ void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
             r0 = vdotq_s32(r0, vld1q_s8(bq + k * 32), a);      // cols 0-1
             r1 = vdotq_s32(r1, vld1q_s8(bq + k * 32 + 16), a); // cols 2-3
           }
-          float ad = nntr_compute_fp16_to_fp32(va_ptr[l].d[m]);
-          return vfmaq_f32(acc, vcvtq_f32_s32(vpaddq_s32(r0, r1)),
-                           vmulq_n_f32(bd, ad));
+          return vfmaq_f32(acc, vcvtq_f32_s32(vpaddq_s32(r0, r1)), scale);
         };
 
-        acc0 = row(aq, 0, acc0);
-        acc1 = row(aq + 8, 1, acc1);
-        acc2 = row(aq + 16, 2, acc2);
-        acc3 = row(aq + 24, 3, acc3);
+        acc0 = row(aq, vmulq_laneq_f32(bd, ad, 0), acc0);
+        acc1 = row(aq + 8, vmulq_laneq_f32(bd, ad, 1), acc1);
+        acc2 = row(aq + 16, vmulq_laneq_f32(bd, ad, 2), acc2);
+        acc3 = row(aq + 24, vmulq_laneq_f32(bd, ad, 3), acc3);
       }
 
       float *out = &s[(y * 4) * bs + x * ncols_interleaved];

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_fallback.cpp
@@ -218,6 +218,74 @@ void nntr_gemv_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
   assert(n % qk == 0);
   assert(nc % ncols_interleaved == 0);
 
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path. aarch64 gets this kernel from
+   * nntr_ggml_impl_neon.cpp; armv7l lands here instead, and Advanced SIMD in
+   * ARMv8.2-A exposes the same VSDOT, so the schedule carries over unchanged.
+   * Needs -march=armv8.2-a+dotprod (armv8-a rejects +dotprod on A32) and
+   * -mfp16-format=ieee for the scale conversions.
+   *
+   * Both nibbles are lifted into the high half of a byte (<<4 and &0xf0), so
+   * every product carries a factor of 16 that vcvtq_n_f32_s32(.., 4) removes
+   * when the accumulator is converted. That matches the scalar `>> 4` exactly:
+   * the summed pair is always a multiple of 16, so nothing is rounded away.
+   */
+  (void)blocklen;
+  const block_q4_0x4 *vb_ptr = (const block_q4_0x4 *)vx;
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *va_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+
+    for (int b = 0; b < nb; b++) {
+      const int8_t *bq = (const int8_t *)vb_ptr->qs;
+      int8x16_t b0 = vld1q_s8(bq);      // k = 0, cols 0-1
+      int8x16_t b1 = vld1q_s8(bq + 16); // k = 0, cols 2-3
+      int8x16_t b2 = vld1q_s8(bq + 32); // k = 1, cols 0-1
+      int8x16_t b3 = vld1q_s8(bq + 48); // k = 1, cols 2-3
+      float16x4_t bd = vld1_f16((const __fp16 *)vb_ptr->d);
+
+      // Load as bytes, not as int64: block_q8_0 puts qs at offset 2, so an
+      // int64_t* would let gcc emit `vld1.64 [rN:64]`, whose :64 qualifier
+      // faults on a 2-byte-aligned address. aarch64 has no such constraint on
+      // LD1R, which is why the kernel there can dup straight from memory.
+      const int8_t *aq = (const int8_t *)va_ptr->qs;
+      int8x8_t t0 = vld1_s8(aq);      // k = 0, low nibble operand
+      int8x8_t t1 = vld1_s8(aq + 8);  // k = 1, low
+      int8x8_t t2 = vld1_s8(aq + 16); // k = 0, high
+      int8x8_t t3 = vld1_s8(aq + 24); // k = 1, high
+      int8x16_t a0 = vcombine_s8(t0, t0);
+      int8x16_t a1 = vcombine_s8(t1, t1);
+      int8x16_t a2 = vcombine_s8(t2, t2);
+      int8x16_t a3 = vcombine_s8(t3, t3);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&va_ptr->d);
+
+      int32x4_t ret0 = vdupq_n_s32(0);
+      int32x4_t ret1 = vdupq_n_s32(0);
+
+      ret0 = vdotq_s32(ret0, b0 << 4, a0);
+      ret1 = vdotq_s32(ret1, b1 << 4, a0);
+      ret0 = vdotq_s32(ret0, b2 << 4, a1);
+      ret1 = vdotq_s32(ret1, b3 << 4, a1);
+
+      ret0 = vdotq_s32(ret0, b0 & 0xf0U, a2);
+      ret1 = vdotq_s32(ret1, b1 & 0xf0U, a2);
+      ret0 = vdotq_s32(ret0, b2 & 0xf0U, a3);
+      ret1 = vdotq_s32(ret1, b3 & 0xf0U, a3);
+
+      // { col0, col1, col2, col3 } once each column's two lanes are folded
+      int32x4_t ret = vpaddq_s32(ret0, ret1);
+
+      acc = vfmaq_f32(acc, vcvtq_n_f32_s32(ret, 4),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      va_ptr++;
+      vb_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+#else
+
   float sumf[4];
   int sumi;
 
@@ -252,6 +320,7 @@ void nntr_gemv_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
     for (int j = 0; j < ncols_interleaved; j++)
       s[x * ncols_interleaved + j] = sumf[j];
   }
+#endif
 }
 
 //============================================================================
@@ -269,6 +338,100 @@ void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
   assert(n % qk == 0);
   assert(nr % 4 == 0);
   assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path; the aarch64 kernel in nntr_ggml_impl_neon.cpp uses
+   * SMMLA, which needs FEAT_I8MM (armv8.6-a) and has no A32 form here, so the
+   * four rows of the tile are driven through VSDOT instead. B is loaded once
+   * per block and reused across all four rows.
+   *
+   * Scalar reference folds `>> 4` into each i-step and scales per k; both are
+   * hoisted here. The shift is exact because every product is a multiple of 16
+   * (both nibbles sit in the high half of the byte), and the two k halves share
+   * one scale pair, so folding them before the FMA is algebraically identical.
+   */
+  (void)blocklen;
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *va_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q4_0x4 *vb_ptr = (const block_q4_0x4 *)vx + (x * nb);
+
+      // One named accumulator per row rather than an acc[4] array, so the
+      // register allocator can keep them live. Some spilling is unavoidable
+      // either way: eight split B vectors plus four accumulators plus the
+      // per-row temporaries exceed the sixteen Q registers A32 has, which is
+      // why the aarch64 kernel (32 registers) can hold a much wider tile.
+      float32x4_t acc0 = vdupq_n_f32(0);
+      float32x4_t acc1 = vdupq_n_f32(0);
+      float32x4_t acc2 = vdupq_n_f32(0);
+      float32x4_t acc3 = vdupq_n_f32(0);
+
+      for (int l = 0; l < nb; l++) {
+        const int8_t *bq = (const int8_t *)vb_ptr[l].qs;
+        int8x16_t b0 = vld1q_s8(bq);      // k = 0, cols 0-1
+        int8x16_t b1 = vld1q_s8(bq + 16); // k = 0, cols 2-3
+        int8x16_t b2 = vld1q_s8(bq + 32); // k = 1, cols 0-1
+        int8x16_t b3 = vld1q_s8(bq + 48); // k = 1, cols 2-3
+
+        int8x16_t b0l = b0 << 4;
+        int8x16_t b1l = b1 << 4;
+        int8x16_t b2l = b2 << 4;
+        int8x16_t b3l = b3 << 4;
+        int8x16_t b0h = b0 & 0xf0U;
+        int8x16_t b1h = b1 & 0xf0U;
+        int8x16_t b2h = b2 & 0xf0U;
+        int8x16_t b3h = b3 & 0xf0U;
+
+        float32x4_t bd = vcvt_f32_f16(vld1_f16((const __fp16 *)vb_ptr[l].d));
+
+        // qs is int8_t[128]: 8 bytes per {k, row} for the low nibbles, then
+        // the same again from byte 64 for the high nibbles. Loaded as bytes so
+        // gcc cannot attach a :64 alignment qualifier (see the GEMV above).
+        const int8_t *aq = (const int8_t *)va_ptr[l].qs;
+
+        auto row = [&](const int8_t *ap, int m, float32x4_t acc) {
+          int8x8_t t0 = vld1_s8(ap);
+          int8x8_t t1 = vld1_s8(ap + 32);
+          int8x8_t t2 = vld1_s8(ap + 64);
+          int8x8_t t3 = vld1_s8(ap + 96);
+          int8x16_t a0 = vcombine_s8(t0, t0);
+          int8x16_t a1 = vcombine_s8(t1, t1);
+          int8x16_t a2 = vcombine_s8(t2, t2);
+          int8x16_t a3 = vcombine_s8(t3, t3);
+
+          int32x4_t r0 = vdupq_n_s32(0);
+          int32x4_t r1 = vdupq_n_s32(0);
+
+          r0 = vdotq_s32(r0, b0l, a0);
+          r1 = vdotq_s32(r1, b1l, a0);
+          r0 = vdotq_s32(r0, b2l, a1);
+          r1 = vdotq_s32(r1, b3l, a1);
+
+          r0 = vdotq_s32(r0, b0h, a2);
+          r1 = vdotq_s32(r1, b1h, a2);
+          r0 = vdotq_s32(r0, b2h, a3);
+          r1 = vdotq_s32(r1, b3h, a3);
+
+          float ad = nntr_compute_fp16_to_fp32(va_ptr[l].d[m]);
+          return vfmaq_f32(acc, vcvtq_n_f32_s32(vpaddq_s32(r0, r1), 4),
+                           vmulq_n_f32(bd, ad));
+        };
+
+        acc0 = row(aq, 0, acc0);
+        acc1 = row(aq + 8, 1, acc1);
+        acc2 = row(aq + 16, 2, acc2);
+        acc3 = row(aq + 24, 3, acc3);
+      }
+
+      float *out = &s[(y * 4) * bs + x * ncols_interleaved];
+      vst1q_f32(out, acc0);
+      vst1q_f32(out + bs, acc1);
+      vst1q_f32(out + 2 * bs, acc2);
+      vst1q_f32(out + 3 * bs, acc3);
+    }
+  }
+#else
 
   float sumf[4][4];
   int sumi;
@@ -313,6 +476,7 @@ void nntr_gemm_q4_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
       }
     }
   }
+#endif
 }
 
 //============================================================================
@@ -352,6 +516,58 @@ void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
   assert(nr % 4 == 0);
   assert(nc % ncols_interleaved == 0);
 
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path, ported from nntr_ggml_impl_neon.cpp. vmulq_laneq_f32
+   * is aarch64-only and comes from the shim in nntr_ggml_impl_utils.h.
+   */
+  (void)blocklen;
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *va_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *vb_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+      float32x4_t sf0 = vdupq_n_f32(0);
+      float32x4_t sf1 = vdupq_n_f32(0);
+      float32x4_t sf2 = vdupq_n_f32(0);
+      float32x4_t sf3 = vdupq_n_f32(0);
+
+      for (int l = 0; l < nb; l++) {
+        float32x4_t a_d = vcvt_f32_f16(vld1_f16((const __fp16 *)va_ptr[l].d));
+        float32x4_t b_d = vcvt_f32_f16(vld1_f16((const __fp16 *)vb_ptr[l].d));
+
+        int32x4_t si0 = vdupq_n_s32(0);
+        int32x4_t si1 = vdupq_n_s32(0);
+        int32x4_t si2 = vdupq_n_s32(0);
+        int32x4_t si3 = vdupq_n_s32(0);
+
+        const int8_t *aq = (const int8_t *)va_ptr[l].qs;
+        const int8_t *bq = (const int8_t *)vb_ptr[l].qs;
+
+        for (int kk = 0; kk < 8; kk++) {
+          int8x16_t av = vld1q_s8(aq + 16 * kk);
+          int8x16_t bv = vld1q_s8(bq + 16 * kk);
+          si0 = vdotq_laneq_s32(si0, bv, av, 0);
+          si1 = vdotq_laneq_s32(si1, bv, av, 1);
+          si2 = vdotq_laneq_s32(si2, bv, av, 2);
+          si3 = vdotq_laneq_s32(si3, bv, av, 3);
+        }
+
+        sf0 = vmlaq_f32(sf0, vmulq_laneq_f32(b_d, a_d, 0), vcvtq_f32_s32(si0));
+        sf1 = vmlaq_f32(sf1, vmulq_laneq_f32(b_d, a_d, 1), vcvtq_f32_s32(si1));
+        sf2 = vmlaq_f32(sf2, vmulq_laneq_f32(b_d, a_d, 2), vcvtq_f32_s32(si2));
+        sf3 = vmlaq_f32(sf3, vmulq_laneq_f32(b_d, a_d, 3), vcvtq_f32_s32(si3));
+      }
+
+      float *out = &s[(y * 4) * bs + x * ncols_interleaved];
+      vst1q_f32(out, sf0);
+      vst1q_f32(out + bs, sf1);
+      vst1q_f32(out + 2 * bs, sf2);
+      vst1q_f32(out + 3 * bs, sf3);
+    }
+  }
+#else
+
   float sumf[4][4];
   int sumi;
 
@@ -388,6 +604,7 @@ void nntr_gemm_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
       }
     }
   }
+#endif
 }
 
 void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
@@ -401,6 +618,52 @@ void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
   assert(nr == 1);
   assert(n % qk == 0);
   assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path, ported from the aarch64 kernel in
+   * nntr_ggml_impl_neon.cpp. Every intrinsic it uses exists in A32 Advanced
+   * SIMD once -march=armv8.2-a+dotprod is on, vdotq_laneq_s32 included.
+   */
+  (void)blocklen;
+  const block_q8_0x4 *vb_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *va_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+
+    for (int b = 0; b < nb; b++) {
+      // Separate vld1q_s8 rather than vld1q_s8_x4: on A32 gcc declares the _xN
+      // forms as taking const uint8_t *, and four plain loads schedule the same.
+      const int8_t *bq = (const int8_t *)vb_ptr->qs;
+      const int8_t *aq = (const int8_t *)va_ptr->qs;
+      float16x4_t bd = vld1_f16((const __fp16 *)vb_ptr->d);
+
+      int8x16_t a_lo = vld1q_s8(aq);
+      int8x16_t a_hi = vld1q_s8(aq + 16);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&va_ptr->d);
+
+      int32x4_t ret = vdupq_n_s32(0);
+
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq), a_lo, 0);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 16), a_lo, 1);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 32), a_lo, 2);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 48), a_lo, 3);
+
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 64), a_hi, 0);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 80), a_hi, 1);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 96), a_hi, 2);
+      ret = vdotq_laneq_s32(ret, vld1q_s8(bq + 112), a_hi, 3);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      va_ptr++;
+      vb_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+#else
 
   float sumf[4];
   int sumi;
@@ -430,6 +693,7 @@ void nntr_gemv_q8_0_4x4_q8_0(int n, float *__restrict s, size_t bs,
       s[x * ncols_interleaved + j] = sumf[j];
     }
   }
+#endif
 }
 
 //============================================================================
@@ -448,6 +712,60 @@ void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
   assert(nr % 4 == 0);
   assert(nc % ncols_interleaved == 0);
 
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path. The aarch64 kernel drives this shape with SMMLA
+   * (vmmlaq_s32), which needs FEAT_I8MM: absent on Cortex-A76 and with no A32
+   * form, so this is built on VSDOT instead, in the same 4x4 tile shape as the
+   * q4_0 4x8 kernel above. B is loaded once per block and reused per row.
+   */
+  (void)blocklen;
+  for (int y = 0; y < nr / 4; y++) {
+    const block_q8_0x4 *va_ptr = (const block_q8_0x4 *)vy + (y * nb);
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+      const block_q8_0x4 *vb_ptr = (const block_q8_0x4 *)vx + (x * nb);
+
+      float32x4_t acc0 = vdupq_n_f32(0);
+      float32x4_t acc1 = vdupq_n_f32(0);
+      float32x4_t acc2 = vdupq_n_f32(0);
+      float32x4_t acc3 = vdupq_n_f32(0);
+
+      for (int l = 0; l < nb; l++) {
+        const int8_t *bq = (const int8_t *)vb_ptr[l].qs;
+        const int8_t *aq = (const int8_t *)va_ptr[l].qs;
+        float32x4_t bd = vcvt_f32_f16(vld1_f16((const __fp16 *)vb_ptr[l].d));
+
+        // qs is int8_t[128] laid out as {k, row/col, i}: 4 groups of 32 bytes,
+        // each group holding four 8-byte lanes.
+        auto row = [&](const int8_t *ap, int m, float32x4_t acc) {
+          int32x4_t r0 = vdupq_n_s32(0);
+          int32x4_t r1 = vdupq_n_s32(0);
+          for (int k = 0; k < 4; k++) {
+            int8x8_t t = vld1_s8(ap + k * 32);
+            int8x16_t a = vcombine_s8(t, t);
+            r0 = vdotq_s32(r0, vld1q_s8(bq + k * 32), a);      // cols 0-1
+            r1 = vdotq_s32(r1, vld1q_s8(bq + k * 32 + 16), a); // cols 2-3
+          }
+          float ad = nntr_compute_fp16_to_fp32(va_ptr[l].d[m]);
+          return vfmaq_f32(acc, vcvtq_f32_s32(vpaddq_s32(r0, r1)),
+                           vmulq_n_f32(bd, ad));
+        };
+
+        acc0 = row(aq, 0, acc0);
+        acc1 = row(aq + 8, 1, acc1);
+        acc2 = row(aq + 16, 2, acc2);
+        acc3 = row(aq + 24, 3, acc3);
+      }
+
+      float *out = &s[(y * 4) * bs + x * ncols_interleaved];
+      vst1q_f32(out, acc0);
+      vst1q_f32(out + bs, acc1);
+      vst1q_f32(out + 2 * bs, acc2);
+      vst1q_f32(out + 3 * bs, acc3);
+    }
+  }
+#else
+
   float sumf[4][4];
   int sumi;
 
@@ -484,6 +802,7 @@ void nntr_gemm_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
       }
     }
   }
+#endif
 }
 
 void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
@@ -497,6 +816,59 @@ void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
   assert(nr == 1);
   assert(n % qk == 0);
   assert(nc % ncols_interleaved == 0);
+
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+  /**
+   * A32 dot-product path, ported from nntr_ggml_impl_neon.cpp. vpaddq_s32 is
+   * the only aarch64-ism and it already has a shim in nntr_ggml_impl_utils.h.
+   */
+  (void)blocklen;
+  const block_q8_0x4 *vb_ptr = (const block_q8_0x4 *)vx;
+
+  for (int c = 0; c < nc; c += ncols_interleaved) {
+    const block_q8_0 *va_ptr = (const block_q8_0 *)vy;
+    float32x4_t acc = vdupq_n_f32(0);
+
+    for (int b = 0; b < nb; b++) {
+      // Separate loads rather than vld1q_s8_x4 / vld1_s8_x4: on A32 gcc declares
+      // the _xN forms as taking const uint8_t *.
+      const int8_t *bq = (const int8_t *)vb_ptr->qs;
+      const int8_t *aq = (const int8_t *)va_ptr->qs;
+      float16x4_t bd = vld1_f16((const __fp16 *)vb_ptr->d);
+
+      int8x8_t t0 = vld1_s8(aq);
+      int8x8_t t1 = vld1_s8(aq + 8);
+      int8x8_t t2 = vld1_s8(aq + 16);
+      int8x8_t t3 = vld1_s8(aq + 24);
+      int8x16_t a0 = vcombine_s8(t0, t0);
+      int8x16_t a1 = vcombine_s8(t1, t1);
+      int8x16_t a2 = vcombine_s8(t2, t2);
+      int8x16_t a3 = vcombine_s8(t3, t3);
+      float16x4_t ad = vld1_dup_f16((const __fp16 *)&va_ptr->d);
+
+      int32x4_t ret0 = vdupq_n_s32(0);
+      int32x4_t ret1 = vdupq_n_s32(0);
+
+      ret0 = vdotq_s32(ret0, vld1q_s8(bq), a0); // k = 0
+      ret1 = vdotq_s32(ret1, vld1q_s8(bq + 16), a0);
+      ret0 = vdotq_s32(ret0, vld1q_s8(bq + 32), a1); // k = 1
+      ret1 = vdotq_s32(ret1, vld1q_s8(bq + 48), a1);
+      ret0 = vdotq_s32(ret0, vld1q_s8(bq + 64), a2); // k = 2
+      ret1 = vdotq_s32(ret1, vld1q_s8(bq + 80), a2);
+      ret0 = vdotq_s32(ret0, vld1q_s8(bq + 96), a3); // k = 3
+      ret1 = vdotq_s32(ret1, vld1q_s8(bq + 112), a3);
+
+      int32x4_t ret = vpaddq_s32(ret0, ret1);
+
+      acc = vfmaq_f32(acc, vcvtq_f32_s32(ret),
+                      vmulq_f32(vcvt_f32_f16(ad), vcvt_f32_f16(bd)));
+      va_ptr++;
+      vb_ptr++;
+    }
+    vst1q_f32(s, acc);
+    s += ncols_interleaved;
+  }
+#else
 
   float sumf[4];
   int sumi;
@@ -526,6 +898,7 @@ void nntr_gemv_q8_0_4x8_q8_0(int n, float *__restrict s, size_t bs,
       s[x * ncols_interleaved + j] = sumf[j];
     }
   }
+#endif
 }
 
 //============================================================================
@@ -591,8 +964,41 @@ void nntr_quantize_mat_q8_0_4x4(const float *__restrict x, void *__restrict vy,
 
 void nntr_quantize_mat_q8_0_4x8(const float *__restrict x, void *__restrict vy,
                                 int64_t k) {
-  // NYI: Fallback quantization - requires row-by-row implementation
-  throw std::runtime_error("NYI: nntr_quantize_mat_q8_0_4x8 fallback");
+  assert(QK8_0 == 32);
+  assert(k % QK8_0 == 0);
+  const int nb = k / QK8_0;
+
+  block_q8_0x4 *__restrict y = (block_q8_0x4 *)vy;
+
+  // Same shape as nntr_quantize_mat_q8_0_4x4, with an 8-wide interleave.
+  const int blck_size_interleave = 8;
+  float srcv[4][QK8_0];
+  float id[4];
+
+  for (int i = 0; i < nb; i++) {
+    for (int row_iter = 0; row_iter < 4; row_iter++) {
+      float amax = 0.0f; // absolute max
+
+      for (int j = 0; j < QK8_0; j++) {
+        srcv[row_iter][j] = x[row_iter * k + i * QK8_0 + j];
+        amax = MAX(amax, fabsf(srcv[row_iter][j]));
+      }
+
+      const float d = amax / ((1 << 7) - 1);
+      id[row_iter] = d ? 1.0f / d : 0.0f;
+
+      y[i].d[row_iter] = nntr_compute_fp32_to_fp16(d);
+    }
+
+    for (int j = 0; j < QK8_0 * 4; j++) {
+      int src_offset = (j / (4 * blck_size_interleave)) * blck_size_interleave;
+      int src_id = (j % (4 * blck_size_interleave)) / blck_size_interleave;
+      src_offset += (j % blck_size_interleave);
+
+      float x0 = srcv[src_id][src_offset] * id[src_id];
+      y[i].qs[j] = roundf(x0);
+    }
+  }
 }
 
 void nntr_quantize_mat_q8_K_4x8(const float *__restrict x, void *__restrict vy,

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
@@ -867,6 +867,7 @@ static inline __m256 __avx_rearranged_f32cx8_load(nntr_fp16_t *x,
 // vpaddq_s16
 // vpaddq_s32
 // vaddvq_s32
+// vmulq_laneq_f32
 // vaddvq_f32
 // vmaxvq_f32
 // vcvtnq_s32_f32
@@ -894,6 +895,13 @@ inline static int32_t vaddvq_s32(int32x4_t v) {
   return vgetq_lane_s32(v, 0) + vgetq_lane_s32(v, 1) + vgetq_lane_s32(v, 2) +
          vgetq_lane_s32(v, 3);
 }
+
+// A32 only has the 64-bit lane form of the by-scalar multiply, so select the
+// half of `b` that holds the requested lane. `lane` must be a literal, which
+// is also what vmulq_lane_f32 itself requires.
+#define vmulq_laneq_f32(a, b, lane)                                            \
+  vmulq_lane_f32((a), ((lane) < 2 ? vget_low_f32(b) : vget_high_f32(b)),       \
+                 (lane) & 1)
 
 #if not(defined(ARMV7)) || !(ARMV7)
 

--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
@@ -901,7 +901,7 @@ inline static int32_t vaddvq_s32(int32x4_t v) {
 // is also what vmulq_lane_f32 itself requires.
 #define vmulq_laneq_f32(a, b, lane)                                            \
   vmulq_lane_f32((a), ((lane) < 2 ? vget_low_f32(b) : vget_high_f32(b)),       \
-                 (lane) & 1)
+                 (lane) % 2)
 
 #if not(defined(ARMV7)) || !(ARMV7)
 

--- a/packaging/nntrainer.spec
+++ b/packaging/nntrainer.spec
@@ -48,18 +48,52 @@
 
 %endif # 0%{tizen_version_major}%{tizen_version_minor} >= 65
 
-%define enable_fp16 0
-### nntrainer fp16 implementation relies on NEON, which requires armv8.2-a
+## Float16 / ARMv8.2-A support
+## nntrainer fp16 implementation relies on NEON, which requires armv8.2-a.
+## Off by default because the reference aarch64 Tizen target is armv8.0-a; a
+## plain %define here would shadow the command line, so this follows the same
+## bcond idiom as the gpu flag below. To build for an armv8.2-a device:
+##   gbs build -A aarch64 --define "_with_fp16 1"
 ### armv7l Tizen: do not support fp16 neon.
-### aarch64 Tizen: uses armv8.0a. no fp16 neon.
 ### x86/x64 Tizen: it has gcc9. x86 requires gcc >= 12 for fp16
+%bcond_with fp16
 
-## Float16 support
-%if 0%{?enable_fp16}
-%define fp16_support -Denable-fp16=true
+%if %{with fp16}
+%define enable_fp16 1
+### -Darm-arch= selects the aarch64 NEON/SVE sources in nntr_ggml_impl; passing
+### it on armv7l would pull aarch64-only assembly into a 32-bit build.
+%ifarch aarch64
+%define fp16_support -Denable-fp16=true -Darm-arch=armv8.2-a
 %else
+%define fp16_support -Denable-fp16=true
+%endif
+%else
+%define enable_fp16 0
 %define fp16_support -Denable-fp16=false
-%endif # enable_fp16
+%endif # fp16
+
+## Device-specific ARM tuning
+## The Tizen reference optflags target the oldest supported core:
+##   armv7l : -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp -mthumb
+##   aarch64: -march=armv8-a+fp+simd+crc+crypto -mtune=cortex-a57.cortex-a53
+## A build pinned to a known newer device can raise that baseline. The value is
+## appended to CFLAGS/CXXFLAGS last in %build, so it beats both the reference
+## optflags and the -march that meson.build hardcodes for aarch64 (meson places
+## environment flags after add_project_arguments()).
+##   gbs build -A armv7l --define "arm_tune -march=armv8.2-a+dotprod -mtune=cortex-a76 -mfpu=neon-fp-armv8 -mfp16-format=ieee"
+##
+## On armv7l that exact set is what turns on the A32 dot-product kernels for
+## q4_0 in nntr_ggml_impl_fallback.cpp; without it they stay scalar:
+##   armv8.2-a       gcc rejects +dotprod on plain armv8-a for A32
+##   +dotprod        defines __ARM_FEATURE_DOTPROD, which gates the kernels
+##   neon-fp-armv8   FMA and fp16<->fp32 conversion
+##   -mfp16-format=ieee  needed for float16x4_t / the scale conversions
+## Cortex-A76 implements FEAT_DotProd at EL0 in AArch32, so VSDOT is available
+## even though the userspace is 32-bit.
+##
+## Do not put -mfloat-abi here: softfp is part of the armv7l ABI. Do not add
+## +i8mm for Cortex-A76 either; FEAT_I8MM is armv8.6-a and the core lacks it.
+## The resulting rpm no longer runs on cores below the baseline you pick.
 
 
 ## GPU flag
@@ -430,8 +464,16 @@ export CXXFLAGS+=" -fprofile-arcs -ftest-coverage"
 %endif
 
 %if 0%{?enable_fp16}
+%ifarch aarch64
 export CFLAGS+=" -march=armv8.2-a+fp16+dotprod+i8mm"
 export CXXFLAGS+=" -march=armv8.2-a+fp16+dotprod+i8mm"
+%endif
+%endif
+
+# Appended last: see the arm_tune comment near the top of this spec.
+%ifarch %arm aarch64
+export CFLAGS+=" %{?arm_tune}"
+export CXXFLAGS+=" %{?arm_tune}"
 %endif
 
 # Add backward competibility for tizen < 6


### PR DESCRIPTION
## Problem

A 32-bit Tizen rootfs is routinely deployed on ARMv8.2-A cores (Cortex-A76 and
friends). Today that configuration gets nothing from the quantized path:

- `nntr_ggml_impl_fallback.cpp` has **no SIMD at all**. The q4_0 4x8 GEMM is a
  seven-deep scalar loop doing one int8 MAC at a time.
- KleidiAI is excluded on `arch == 'arm'` (`arm/meson.build:13`), and the
  aarch64 kernels in `nntr_ggml_impl_neon.cpp` are AArch64 assembly.
- `nntr_quantize_mat_q8_0_4x8` threw `std::runtime_error("NYI")`, so
  `__ggml_q8_0_4x8_q8_0_GEMM` aborted outright for `M > 1`.
- The spec had no way to raise the ARM baseline, and `enable_fp16` was a plain
  `%define`, which shadows `--define` on the command line.

This is not a hardware limit: those cores implement `FEAT_DotProd` at EL0 in
AArch32, so `VSDOT` is available to the very same kernels.

## What this does

**Kernels** — A32 dot-product paths for `gemv`/`gemm` of q4_0 4x8 and q8_0
4x4/4x8, behind `#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)`,
with every scalar loop kept as the `#else`. Builds without `+dotprod`,
**including the Tizen armv7l default, are byte-for-byte unchanged**.

The two 4x8 GEMMs are new rather than ported: aarch64 drives that shape with
SMMLA, which needs `FEAT_I8MM` (ARMv8.6-A) and has no A32 form, so both are
rebuilt around `vdotq_s32` in a 4x4 tile.

**Spec** — adds `%{?arm_tune}`, appended to `CFLAGS`/`CXXFLAGS` last in
`%build`. Meson places environment flags after `add_project_arguments()`, so it
also overrides the `-march` that `meson.build` hardcodes for aarch64. Also
converts `enable_fp16` to the `%bcond_with` idiom already used by the gpu flag,
and arch-guards the fp16 `-march` export and `-Darm-arch=` (on armv7l the
latter makes `nntr_ggml_impl/meson.build` select the aarch64-only NEON source
and the build fails).

**Docs** — `docs/how-to-build-tizen.md`, registered in the hotdoc sitemap.

## Two bugs found along the way

1. **`vld1q_dup_s64` is unsafe on A32.** `block_q8_0` places `qs` at offset 2,
   and an `int64_t *` lets gcc emit `vld1.64 [rN:64]`, whose `:64` qualifier
   faults on a 2-byte-aligned address (SIGBUS). AArch64 has no such constraint
   on `LD1R`, which is why the original kernels get away with it. The new code
   loads bytes and combines.

2. **`nntr_gemm_q8_0_4x8_q8_0` is mis-guarded on aarch64.**
   `nntr_ggml_impl_neon.cpp:1366` uses `vmmlaq_s32` (SMMLA, i8mm) inside
   `#if defined(__ARM_FEATURE_DOTPROD)`. i8mm is ARMv8.6-A, so on a
   dotprod-only core such as Cortex-A76 that kernel is a SIGILL. Not touched
   here since it is outside this change's scope, but it wants a follow-up.

## Build

```bash
gbs build -A armv7l --define "unit_test 0" \
  --define "arm_tune -march=armv8.2-a+dotprod -mtune=cortex-a76 -mfpu=neon-fp-armv8 -mfp16-format=ieee"
```

Without `arm_tune` nothing changes. See `docs/how-to-build-tizen.md` for why
each flag is needed and how to confirm from the shipped binary that they took
effect.

## Verification

Cross-compiled with the Tizen armv7l toolchain and run as real ARM code under
qemu-arm. The reference side is *the same file* compiled without `+dotprod`
(so it takes the scalar `#else` branches) with its kernel symbols renamed, so
there is no hand-written reference to drift out of sync.

```
== q4_0 4x8 ==          7 shapes : all ok
== q8_0 4x4 / 4x8 ==    7 shapes : all ok   (gemv and gemm, both variants)
== quantize_mat_q8_0_4x8 (interleave) ==  k=32/64/256/1024 : ok
*** ALL PASS ***  (0 mismatches)
```

The quantizer has no NEON variant to diff against, so it is checked directly:
that the value the GEMM reads at `qs[k*32+m*8+i]` is row `m` element `k*8+i`.

Measured dynamic instruction counts (exact, `qemu-arm -one-insn-per-tb`,
K=256 N=16 M=8):

| kernel | scalar | VSDOT | |
| --- | ---: | ---: | ---: |
| q4_0 gemv 4x8 | 17,528 | 1,888 | 9.3x |
| q4_0 gemm 4x8 | 135,299 | 19,372 | 7.0x |
| q8_0 gemv 4x8 | 27,168 | 2,167 | 12.5x |
| q8_0 gemm 4x8 | 212,096 | 22,622 | 9.4x |
| q8_0 gemm 4x4 | 551,402 | 7,516 | 73.4x |

Regressions checked: the scalar path still builds with the Tizen armv7l
reference flags (`-march=armv7-a -mfpu=neon`), and x86_64 is unaffected.