### PR TITLE
[CausalLM] Add QS4CX lmhead

### DIFF
--- a/Applications/CausalLM/layers/lm_head.cpp
+++ b/Applications/CausalLM/layers/lm_head.cpp
@@ -173,6 +173,14 @@ void LmHeadLayer::calcGradient(nntrainer::RunLayerContext &context) {
     "calcGradient for LMHead layer is not supported");
 }
 
+void LmHeadLayer::pack(nntrainer::RunLayerContext &context) {
+  for (auto &w : context.getWeights()) {
+    auto &var = w->getVariableRef();
+    if (var.getDataType() == nntrainer::TensorDim::DataType::QS4CX)
+      var.pack();
+  }
+}
+
 void LmHeadLayer::exportTo(nntrainer::Exporter &exporter,
                            const ml::train::ExportMethods &method) const {
   LayerImpl::exportTo(exporter, method);

--- a/Applications/CausalLM/layers/lm_head.h
+++ b/Applications/CausalLM/layers/lm_head.h
@@ -86,6 +86,11 @@ public:
   WIN_EXPORT void calcGradient(nntrainer::RunLayerContext &context) override;
 
   /**
+   * @copydoc Layer::pack(RunLayerContext &context)
+   */
+  WIN_EXPORT void pack(nntrainer::RunLayerContext &context) override;
+
+  /**
    * @copydoc Layer::exportTo(Exporter &exporter, ml::train::ExportMethods
    * method)
    */


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>[CausalLM] Add QS4CX lmhead</summary><br />

This commit adds QS4CX type lmhead by adding pack() implementation.
Since tensor dimension is in appropriate order, we don't need to add
additional changes.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>

</details>

### Summary
Let's support QS4CX type for lmhead layer.

Signed-off-by: Jaemin Shin <jaemin980311@gmail.com>
