### PR TITLE
[CausalLM] Bound RoPE LUTs to runtime context

### DIFF
--- a/Applications/CausalLM/layers/mha_core.cpp
+++ b/Applications/CausalLM/layers/mha_core.cpp
@@ -154,15 +154,13 @@ void MHACoreLayer::finalize(nntrainer::InitLayerContext &context) {
   const unsigned int max_timestep =
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
 
-  /** max position embeddings */
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
-
   /** local window size */
   local_window_size = std::get<props::SlidingWindow>(mha_core_props).get();
 
   /** use rope */
   use_rope = std::get<props::UseRope>(mha_core_props).get();
+  if (use_rope)
+    checkMaxTimestepBound(max_timestep);
 
   /** attention scaling computation */
   rope_scaling_type = std::get<props::RopeScalingType>(mha_core_props).get();
@@ -864,9 +862,19 @@ void MHACoreLayer::one_batch_incremental_forwarding(
 
 /************************************************************** */
 
+void MHACoreLayer::checkMaxTimestepBound(unsigned int max_timestep) {
+  const unsigned int max_position_embeddings =
+    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
+  NNTR_THROW_IF(max_timestep > max_position_embeddings, std::invalid_argument)
+    << "max_timestep (" << max_timestep << ") exceeds max_position_embeddings ("
+    << max_position_embeddings
+    << "); RoPE positions would extrapolate beyond the model's trained "
+       "context length";
+}
+
 /**
  * @brief rotary embedding-related member function
- * @note seq_len -> max_position_embeddings
+ * @note seq_len is the runtime KV-cache capacity (max_timestep)
  */
 void MHACoreLayer::precompute_freqs(int head_dim, unsigned int seq_len,
                                     float theta, bool is_fp16) {
@@ -1086,11 +1094,15 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
   unsigned int max_timestep =
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
 
+  // RoPE positions are indexed by the runtime KV-cache position. The model's
+  // max_position_embeddings can be much larger than the configured execution
+  // length, so using it here would allocate unused LUT entries.
+
   if (in.getDataType() == ml::train::TensorDim::DataType::FP32) {
-    if (freqs_fp32 == nullptr) {
+    if (freqs_fp32 == nullptr || freqs_fp32->cos.size() < max_timestep) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
-      if (freqs_fp32 == nullptr) {
-        precompute_freqs(head_dim, max_position_embeddings, theta, false);
+      if (freqs_fp32 == nullptr || freqs_fp32->cos.size() < max_timestep) {
+        precompute_freqs(head_dim, max_timestep, theta, false);
       }
     }
     std::vector<float> *cos_ = nullptr;
@@ -1138,10 +1150,10 @@ void MHACoreLayer::apply_rotary_emb_tensor_v2(nntrainer::Tensor &in,
     }
   } else if (in.getDataType() == ml::train::TensorDim::DataType::FP16) {
 #ifdef ENABLE_FP16
-    if (freqs_fp16 == nullptr) {
+    if (freqs_fp16 == nullptr || freqs_fp16->cos.size() < max_timestep) {
       const std::lock_guard<std::mutex> lock(rope_init_mtx);
-      if (freqs_fp16 == nullptr) {
-        precompute_freqs(head_dim, max_position_embeddings, theta, true);
+      if (freqs_fp16 == nullptr || freqs_fp16->cos.size() < max_timestep) {
+        precompute_freqs(head_dim, max_timestep, theta, true);
       }
     }
     std::vector<_FP16> *cos_ = nullptr;
@@ -1515,9 +1527,9 @@ void MHACoreLayer::updateTensorsByInputDimensions(
     std::get<nntrainer::props::MaxTimestep>(mha_core_props).get();
   unsigned int &max_new_tokens =
     std::get<props::MaxNewTokens>(mha_core_props).get();
-  max_position_embeddings =
-    std::get<props::MaxPositionEmbeddings>(mha_core_props).get();
   max_timestep = height + max_new_tokens;
+  if (use_rope)
+    checkMaxTimestepBound(max_timestep);
 
   ml::train::TensorDim kv_dim = input_dimensions[0];
   kv_dim.width(kv_dim.width() / (num_heads_Q / num_heads_KV));

--- a/Applications/CausalLM/layers/mha_core.h
+++ b/Applications/CausalLM/layers/mha_core.h
@@ -403,9 +403,6 @@ private:
   std::array<unsigned int, 7> tensor_idx;
   unsigned int sink_idx;
 
-  /** attention parameters */
-  unsigned int max_position_embeddings;
-
   /** rope_scaling parameters */
   std::string rope_scaling_type;
   float attention_scaling = 1.0f;
@@ -451,6 +448,14 @@ private:
    */
   void precompute_freqs(int head_dim, unsigned int seq_len,
                         float theta = 10000.0, bool is_fp16 = false);
+
+  /**
+   * @brief verify that the runtime KV-cache capacity does not exceed the
+   * model's trained max_position_embeddings, since RoPE positions beyond
+   * that range were never seen during training
+   * @param[in] max_timestep runtime KV-cache capacity to validate
+   */
+  void checkMaxTimestepBound(unsigned int max_timestep);
 
   /**
    * @brief _compute frequency parameters for default ROPE

--- a/test/unittest/models/unittest_causallm_gemma4.cpp
+++ b/test/unittest/models/unittest_causallm_gemma4.cpp
@@ -95,7 +95,9 @@ causallm::json makeTinyGemma4Config() {
        {"hidden_size_per_layer_input", 32},
        {"intermediate_size", 64},
        {"layer_types", {"sliding_attention", "full_attention"}},
-       {"max_position_embeddings", 8},
+       // Keep the model context deliberately larger than the runtime
+       // max_seq_len (8) so this fixture covers runtime-bounded RoPE LUTs.
+       {"max_position_embeddings", 131072},
        {"num_attention_heads", 8},
        {"num_hidden_layers", tiny_gemma4_num_layers},
        {"num_key_value_heads", 4},


### PR DESCRIPTION
## Dependency of the PR

## Commits to be reviewed in this PR


<details><summary>d96ab492 [CausalLM] Bound RoPE LUTs to runtime context</summary><br />

[CausalLM] Bound RoPE LUTs to runtime context

Use the runtime KV-cache capacity instead of the model context length when building RoPE lookup tables.

Co-authored-by: Codex <noreply@openai.com>
Signed-off-by: jayden0701 <jrock.oh@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jayden0701 <jrock.oh@samsung.com>

</details>

### Summary

- [CausalLM] Bound RoPE LUTs to runtime context: RoPE lookup tables (cos/sin
  freqs) were previously built using `max_position_embeddings` from the model
  config, which can be far larger than the actual runtime KV-cache capacity
  (`max_timestep`). This caused unnecessary memory allocation for LUT entries
  that are never accessed at runtime. This commit changes the LUT size to be
  bounded by the runtime `max_timestep`, and removes the now-unused
  `max_position_embeddings` member from `MHACoreLayer`. The double-checked
  locking in `apply_rotary_emb_tensor_v2` is also hardened to re-check the LUT
  size so that a smaller table is rebuilt when the runtime capacity grows. The
  gemma4 unit-test fixture is updated to set `max_position_embeddings` to a
  deliberately large value (131072) so that the runtime-bounded RoPE LUT path
  is covered.

#### Theoretical memory savings

For Gemma4 (`max_position_embeddings = 131,072`, `head_dim = 256`, runtime
`max_seq_len = 2,048`), the RoPE LUT stores cos/sin tables of size
`seq_len × head_dim` per type (FP32 / FP16):

| | Before (max_position_embeddings) | After (max_timestep) | Savings |
|---|---|---|---|
| FP32 LUT | 2 × 131,072 × 256 × 4 B = **256 MB** | 2 × 2,048 × 256 × 4 B = **4 MB** | **~252 MB** |
| FP16 LUT | 2 × 131,072 × 256 × 2 B = **128 MB** | 2 × 2,048 × 256 × 2 B = **2 MB** | **~126 MB** |

#### Measured performance (Gemma4, S26U, 8 threads. prefill 1027 tokens + generation 296 tokens)

| Metric | Before | After | Change |
|---|---|---|---|
| Peak memory | 4,316,444 KB | 3,355,232 KB | **−961,212 KB (≈ 938 MB, −22.3%)** |
| Prefill TPS | 492.094 | 525.858 | **+6.9%** |
| Prefill time | 2,087 ms | 1,953 ms | **−134 ms (−6.4%)** |
| Generation TPS | 27.5246 | 27.8562 | **+1.2%** |
| Generation time | 10,754 ms | 10,626 ms | **−128 ms (−1.2%)** |

The measured memory reduction (~938 MB) exceeds the theoretical LUT savings
(~252 MB FP32) because the `std::vector<std::vector<float>>` structure incurs
per-vector allocation overhead (metadata + malloc headers) for each of the
131,072 rows, which is eliminated when the table is sized to the runtime
capacity.

Signed-off-by: jayden0701 <jrock.oh@samsung.com>
