### PR TITLE
[api] Hide internal C++ weak STL symbols in libcapi and libccapi

### DIFF
--- a/api/capi/capi-nntrainer.map
+++ b/api/capi/capi-nntrainer.map
@@ -1,0 +1,6 @@
+{
+  global:
+    ml_train_*;
+  local:
+    *;
+};

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -45,12 +45,21 @@ endif
 if get_option('platform') == 'android'
   nntrainer_capi_dep = declare_dependency(include_directories: capi_inc)
 else
+  capi_link_args = []
+  capi_link_depends = []
+  if host_machine.system() != 'windows'
+    capi_link_args += ['-Wl,--version-script=' + meson.current_source_dir() / 'capi-nntrainer.map']
+    capi_link_depends += [meson.current_source_dir() / 'capi-nntrainer.map']
+  endif
+
   shared_library('capi-nntrainer',
     capi_src,
     dependencies: capi_deps,
     include_directories: capi_inc,
     install: true,
     install_dir: nntrainer_libdir,
+    link_args: capi_link_args,
+    link_depends: capi_link_depends,
   )
 
   nntrainer_capi_lib = static_library('capi-nntrainer',

--- a/api/ccapi/ccapi-nntrainer.map
+++ b/api/ccapi/ccapi-nntrainer.map
@@ -1,0 +1,11 @@
+{
+  global:
+    _ZN2ml5train*;
+    _ZNK2ml5train*;
+    _ZTVN2ml5train*;
+    _ZTTN2ml5train*;
+    _ZTIN2ml5train*;
+    _ZTSN2ml5train*;
+  local:
+    *;
+};

--- a/api/ccapi/meson.build
+++ b/api/ccapi/meson.build
@@ -30,12 +30,21 @@ ccapi_deps = [
 if get_option('platform') == 'android'
   nntrainer_ccapi_dep = declare_dependency(include_directories: ccapi_inc)
 else
+  ccapi_link_args = []
+  ccapi_link_depends = []
+  if host_machine.system() != 'windows'
+    ccapi_link_args += ['-Wl,--version-script=' + meson.current_source_dir() / 'ccapi-nntrainer.map']
+    ccapi_link_depends += [meson.current_source_dir() / 'ccapi-nntrainer.map']
+  endif
+
   shared_library('ccapi-nntrainer',
     ccapi_src,
     dependencies: ccapi_deps,
     include_directories: ccapi_inc,
     install: true,
     install_dir: nntrainer_libdir,
+    link_args: ccapi_link_args,
+    link_depends: ccapi_link_depends,
   )
 
   nntrainer_ccapi_lib = static_library('ccapi-nntrainer',


### PR DESCRIPTION
 - Added Linker Version Script map files (capi-nntrainer.map, ccapi-nntrainer.map)
 - Configured shared_library definitions to use maps for exporting only public APIs
 - Hides standard C++ template/weak symbols to prevent dependency propagation (DT_NEEDED) to consumer applications

 ## Dependency of the PR
 None

 ## Commits to be reviewed in this PR


 <details><summary>3fe862367</summary><br />

 [api] Hide internal C++ weak STL symbols in libcapi and libccapi

 - Added Linker Version Script map files (capi-nntrainer.map, ccapi-nntrainer.map)
 - Configured shared_library definitions to use maps for exporting only public APIs
 - Hides standard C++ template/weak symbols to prevent dependency propagation (DT_NEEDED) to consumer applications

 **Self evaluation:**
 1. Build test: [X]Passed [ ]Failed [ ]Skipped
 2. Run test: [X]Passed [ ]Failed [ ]Skipped

 Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

 </details>

 ### Summary

 - Introduced linker version scripts (`capi-nntrainer.map` and `ccapi-nntrainer.map`) to restrict exported symbols from the shared C/C++ API libraries.
 - Standardized public symbol exports so that internal C++ STL weak/template symbols are hidden, preventing unnecessary runtime dependency propagation (`DT_NEEDED`) to downstream consumer applications.

 Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>