### PR TITLE
[bugfix] Fix ggml_vdotq_s32 NEON emulation to match SDOT semantics

### DIFF
--- a/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
+++ b/nntrainer/tensor/cpu_backend/ggml_interface/nntr_ggml_impl/nntr_ggml_impl_utils.h
@@ -1099,7 +1099,7 @@ inline static int32x4_t ggml_vdotq_s32(int32x4_t acc, int8x16_t a,
   const int16x8_t p0 = vmull_s8(vget_low_s8(a), vget_low_s8(b));
   const int16x8_t p1 = vmull_s8(vget_high_s8(a), vget_high_s8(b));
 
-  return vaddq_s32(acc, vaddq_s32(vpaddlq_s16(p0), vpaddlq_s16(p1)));
+  return vaddq_s32(acc, vpaddq_s32(vpaddlq_s16(p0), vpaddlq_s16(p1)));
 }
 
 #else


### PR DESCRIPTION
## Dependency of the PR

None. (Split out of #4246 per review — the same fix will be dropped from #4246 by rebase once this PR is merged.)

## Commits to be reviewed in this PR


<details><summary>[cpu_backend] Fix lane placement in the non-dotprod ggml_vdotq_s32 emulation</summary><br />

On NEON builds without __ARM_FEATURE_DOTPROD, ggml_vdotq_s32 emulates
SDOT with pairwise additions. The emulation combined the two partial
sums with vaddq_s32, which adds lane-wise across the low and high byte
products, so lane j mixed products of bytes {2j, 2j+1} and
{2j+8, 2j+9} instead of accumulating bytes 4j..4j+3:

```
A = vpaddlq_s16(p0) = [a0.b0+a1.b1, a2.b2+a3.b3, ...]   (bytes 0..7)
B = vpaddlq_s16(p1) = same for bytes 8..15
vaddq_s32(A, B)  -> [A0+B0, A1+B1, A2+B2, A3+B3]   (wrong lanes)
vpaddq_s32(A, B) -> [A0+A1, A2+A3, B0+B
On NEON builds without __ARM_FEATURE_DOTPROD, ggml_vdotq_s32 emulates
SDOT with pairwise additions. The emulation combined the two partial
sums with vaddq_s32, which adds lane-wite
products, so lane j mixed products of bytes {2j, 2j+1} and
{2j+8, 2j+9} instead of accumulating bytes 4j..4j+3:

```
A = vpaddlq_s16(p0) = [a0.b0+a1.b1, a2.b2+a3.b3, ...]   (bytes 0..7)
B = vpaddlq_s16(p1) = same for bytes 8.
vaddq_s32(A, B)  -> [A0+B0, A1+B1, A2+B2, A3+B3]   (wrong lanes)
vpaddq_s32(A, B) -> [A0+A1, A2+A3, B0+B
```

As a result every quantized GEMM/GEMV built for targets without the
dotprod extension (e.g. -march=armv8-a) silently produced wrong values.
Replace vaddq_s32 with vpaddq_s32, matc

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]S
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@

</details>



<details><summary>[test] Add SDOT semantics regression test for ggml_vdotq_s32</summary><br />

Compare ggml_vdotq_s32 against a scalar SDOT reference on random
vectors. On builds without __ARM_FEATUR
NEON emulation path and fails against the previous vaddq_s32 lane
mixing; on dotprod builds it sanity-checks the hardware instruction.

Verified with qemu-aarch64: fails on the pre-fix code built with
-march=armv8-a (4000/4000 lane mismatches) and passes with the fix on
both -march=armv8-a and -march=armv8.2-

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Ski

Signed-off-by: Hyeonseok Lee <hs89.lee@

</details>

### Summary

- Fix the SDOT emulation of `ggml_vdotq_s32` used on NEON builds without `__ARM_FEATURE_DOTPROD`: `vaddq_s32` mixed lanes across the low/high byte products, so quantized GEMM/GEMV silently produced wrong values on such targets (e.g. `-march=arq_s32`, matching upstream llama.cpp.
- Add a regression test comparing `ggml_vdotq_s32` against a scalar SDOT reference. Verified with qemu-aarch64 that it fails on the pre-fix code (4000/4000 lane mismatches on armv8-a) and passes with the fix on both the emulation and dotprod paths.

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>  