### PR TITLE
[graph/layers] Fix OOB access for no-input layers and assert in-place aliasing invariants

### DIFF
--- a/nntrainer/graph/network_graph.cpp
+++ b/nntrainer/graph/network_graph.cpp
@@ -808,6 +808,22 @@ NetworkGraph::finalizeContext(const std::shared_ptr<LayerNode> &lnode,
   if (lnode->getInPlaceType() != InPlaceType::NONE && lnode->supportInPlace()) {
     setInplaceSharedMemoryConfigByLayer(lnode, shared_var, shared_grad);
 
+    /** in-place output specs below alias input tensors by name; an output
+     * that cannot be mapped back to an input means the graph is broken,
+     * so fail loudly instead of silently aliasing a wrong tensor */
+    if (lnode->getType() == IdentityLayer::type) {
+      NNTR_THROW_IF(out_specs.size() > inputs.size(), std::runtime_error)
+        << "Identity layer " << lnode->getName() << " has " << out_specs.size()
+        << " outputs but only " << inputs.size() << " inputs";
+    } else if (lnode->getInPlaceDirection() == InPlaceDirection::RIGHT) {
+      NNTR_THROW_IF(inputs.size() < 2, std::runtime_error)
+        << "In-place direction RIGHT requires two inputs: " << lnode->getName();
+    } else if (lnode->getType() != WeightLayer::type) {
+      NNTR_THROW_IF(inputs.empty(), std::runtime_error)
+        << "In-place layer without input cannot be finalized: "
+        << lnode->getName();
+    }
+
     for (unsigned int i = 0; i < out_specs.size(); ++i) {
       auto &s = out_specs.at(i);
       if (shared_var) {
@@ -987,6 +1003,23 @@ NetworkGraph::refinalizeContext(const std::shared_ptr<LayerNode> &lnode,
   bool shared_var = false, shared_grad = false;
   if (lnode->getInPlaceType() != InPlaceType::NONE) {
     setInplaceSharedMemoryConfigByLayer(lnode, shared_var, shared_grad);
+
+    /** in-place output specs below alias input tensors by name; an output
+     * that cannot be mapped back to an input means the graph is broken,
+     * so fail loudly instead of silently aliasing a wrong tensor */
+    if (lnode->getType() == IdentityLayer::type) {
+      NNTR_THROW_IF(out_specs.size() > inputs.size(), std::runtime_error)
+        << "Identity layer " << lnode->getName() << " has " << out_specs.size()
+        << " outputs but only " << inputs.size() << " inputs";
+    } else if (lnode->getInPlaceDirection() == InPlaceDirection::RIGHT) {
+      NNTR_THROW_IF(inputs.size() < 2, std::runtime_error)
+        << "In-place direction RIGHT requires two inputs: " << lnode->getName();
+    } else {
+      NNTR_THROW_IF(inputs.empty(), std::runtime_error)
+        << "In-place layer without input cannot be refinalized: "
+        << lnode->getName();
+    }
+
     for (unsigned int i = 0; i < out_specs.size(); ++i) {
       auto &s = out_specs.at(i);
       if (shared_var) {

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -564,7 +564,14 @@ bool RunLayerContext::validate(bool skip_input, bool skip_label) {
 #ifdef DEBUG
   std::function<bool(const Var_Grad *, bool)> matcher;
 
-  if (tensor_map.empty() || !tensor_map[inputs[0]->getName()]) {
+  /** layers without an input connection (e.g. WeightLayer) have an empty
+   * inputs vector; for them only tensor_map.empty() triggers the rebuild */
+  auto has_valid_entry = [this](const std::string &name) {
+    auto iter = tensor_map.find(name);
+    return iter != tensor_map.end() && iter->second != nullptr;
+  };
+  if (tensor_map.empty() ||
+      (!inputs.empty() && !has_valid_entry(inputs[0]->getName()))) {
     auto filler = [this](const auto &vec) {
       for (auto const &val : vec) {
         if (val->getVariableRef().getTensorType().data_type ==

--- a/nntrainer/layers/layer_context.cpp
+++ b/nntrainer/layers/layer_context.cpp
@@ -12,6 +12,8 @@
  * @brief  This is the layer context for each layer
  */
 
+#include <map>
+
 #include "nntrainer_error.h"
 #include <functional>
 #include <memory>
@@ -579,7 +581,44 @@ bool RunLayerContext::validate(bool skip_input, bool skip_label) {
 #else
           throw std::invalid_argument("Error: enable-fp16 is not enabled");
 #endif
-        } else {
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::UINT32) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint32_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint32_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::UINT16) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint16_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint16_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::UINT8) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint8_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint8_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::UINT4) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint8_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint8_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::Q4_0) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint8_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint8_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::Q4_K) {
+          tensor_map[val->getName()] =
+            val->getVariableRef().template getData<uint8_t>();
+          tensor_map[val->getGradientName()] =
+            val->getGradientRef().template getData<uint8_t>();
+        } else if (val->getVariableRef().getTensorType().data_type ==
+                   TensorDim::DataType::Q6_K) {
           tensor_map[val->getName()] =
             val->getVariableRef().template getData<uint8_t>();
           tensor_map[val->getGradientName()] =


### PR DESCRIPTION
## Dependency of the PR

None. (Split out of #4246 per review — the same fixes will be dropped from #4246 by rebase once this PR is merged.)

## Commits to be reviewed in this PR


<details><summary>[layer] fix validate DEBUG mode issue</summary><br />

 - Added code for data type is neither fp32 nor fp16
 - Close #3775

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>

</details>



<details><summary>[graph/layers] Fix OOB access for no-input layers and assert in-place aliasing invariants</summary><br />

Fix an out-of-bounds crash in RunLayerContext::validate() (DEBUG build):
layers without an input connection (e.g. WeightLayer) have an empty
inputs vector, but the tensor_map rebuild condition unconditionally
accessed inputs[0]. Guard the access with !inputs.empty() and replace
the operator[] lookup, which inserts a default entry on a missing key,
with a find() based lookup.

In NetworkGraph::finalizeContext()/refinalizeContext(), the in-place
output specs alias input tensors by namr,
inputs[1] for InPlaceDirection::RIGHT, inputs[0] otherwise). Analysis
shows these indices cannot go out of range with the current layer set:
IdentityLayer always has as many inputs as outputs, RIGHT is only set
for binary layers, and no in-place layer other than WeightLayer has                                   zero inputs. Instead of silently substie,
assert these invariants with NNTR_THROW_IF so that a future layer                                     violating them fails loudly at finalize
wrong tensor.                                                                                         
Changes:
- RunLayerContext::validate(): skip the inputs[0] staleness probe for                                   layers with no inputs; use find() ins
- NetworkGraph::finalizeContext()/refinalizeContext(): add explicit
  NNTR_THROW_IF invariant checks before the in-place aliasing loop and                                  keep the direct indexing
- Applied clang-format 14 to normalize code style and ensure CI compliance
                                                                                                      **Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>                                                   
</details>                                                                                            
### Summary                                                                                           
- Fix a DEBUG-build out-of-bounds crash in `RunLayerContext::validate()`: layers without an input conn(e.g. `WeightLayer`) have an empty `inpp rebuild condition unconditionallyaccessed `inputs[0]`. Also replace the `operator[]` lookup (which inserts a default entry on a missing key) with a `find()` based lookup.                                                                         - Handle data types other than fp32/fp1path (Close #3775).
- In `NetworkGraph::finalizeContext()/refinalizeContext()`, assert the in-place aliasing invariants (`out_specs.size() <= inputs.size()` for IdentityLayer, two inputs for `InPlaceDirection::RIGHT`, non-empty inputs otherwise) with `NNTR_THROW_IF` so a future layer violating them fails loudly at finalize time instead of silently aliasing a wrong te do not fire on the existing test suite(49/49 pass on x86).

Signed-off-by: Hyeonseok Lee <hs89.lee@samsung.com>