### PR TITLE
[ci] Make the C++ format check work on large and stacked PRs

### DIFF
--- a/.github/workflows/cpp_linter.yml
+++ b/.github/workflows/cpp_linter.yml
@@ -18,29 +18,42 @@ jobs:
           echo "Checking whitespace errors on changed lines"
           git diff --check ${{ github.event.pull_request.base.sha }}...HEAD \
             -- . ':(exclude).github' ':(exclude)Applications/CausalLM/third_party'
-      - name: install dev packages
+      - name: install clang-format
         run: |
-          echo "Install mandatory dev packages to avoid false-positive reports from cpp-linter"
           sudo apt-get update
-          sudo apt-get install libstdc++-*-dev
-      - uses: cpp-linter/cpp-linter-action@v2.9.0
+          sudo apt-get install -y clang-format-14
+      - name: check the format of changed lines
         id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: file
-          version: 14
-          lines-changed-only: true
-          file-annotations: false
-          step-summary: true
-          format-review: true
-          tidy-checks: '-*' # disable clang-tidy checks.
+        run: |
+          set -o pipefail
+          # Collect the changed lines with git rather than with the pull request
+          # patch endpoint, which refuses to serve a diff longer than 20000
+          # lines. Same base.sha...HEAD range as the whitespace check above.
+          #
           # third_party/ holds vendored upstream code (minja, ...) that is not
           # formatted to nntrainer style; skip it like static.check.yml does.
-          ignore: '.github|Applications/CausalLM/third_party'
-
-      - name: failing fast
-        if: steps.linter.outputs.clang-format-checks-failed > 0
-        run: |
-          echo "This PR failed to pass the C++ source file format checks."
-          exit 1
+          RANGE='${{ github.event.pull_request.base.sha }}...HEAD'
+          PATHS=('*.c' '*.h' '*.C' '*.H' '*.cpp' '*.hpp' '*.cc' '*.hh'
+                 '*.cxx' '*.hxx' '*.c++' '*.h++'
+                 ':(exclude).github' ':(exclude)Applications/CausalLM/third_party')
+          echo "Changed C/C++ files:"
+          git diff --name-only "$RANGE" -- "${PATHS[@]}"
+          # clang-format-diff reformats only the lines the diff touches, so
+          # untouched code in an edited file is never reported.
+          git diff -U0 "$RANGE" -- "${PATHS[@]}" |
+            clang-format-diff-14 -p1 -style=file > suggestions.diff
+          if [ -s suggestions.diff ]; then
+            {
+              echo '### C++ format check failed'
+              echo
+              echo 'Apply this patch, or run clang-format-14 on the changed lines.'
+              echo
+              echo '```diff'
+              cat suggestions.diff
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            cat suggestions.diff
+            echo "This PR failed to pass the C++ source file format checks."
+            exit 1
+          fi
+          echo "The changed C/C++ lines are correctly formatted."


### PR DESCRIPTION
The C++ format checker discovers its changed-file set through the pull
request patch endpoint. That endpoint refuses to serve a diff longer than
20000 lines, answering

    406 Sorry, the diff exceeded the maximum number of lines (20000)

after which the linter aborts with `KeyError: 'no patch found'` before a
single file is examined. The job is red, and the style check never ran at
all. A recent example is run 33314181488, where the discovery step failed
1.2 seconds in.

This is not a rare corner. Any large pull request hits it, and so does
every pull request of a stacked series, because each one carries the whole
stack against `main`. #4313 and #4314 are both showing a spurious red from
this today: their branches are correctly formatted, but the check cannot
reach them.

The fix is to take the changed lines from git rather than over REST. The
checkout already uses `fetch-depth: 0`, and the whitespace step directly
above already diffs `base.sha...HEAD`, so this reuses the same range and
pipes it into `clang-format-diff`. A local diff has no size limit.

Behaviour is otherwise unchanged: the same clang-format 14, the same
`.clang-format` style file, the same `.github` and `third_party`
exclusions, and the same changed-lines-only scope, since clang-format-diff
reformats only the lines the diff touches. Violations are printed and
mirrored into the job summary, and the job still fails on them. The one
thing lost is inline review comments on the pull request; a check that runs
seemed worth more than annotations that do not. The `libstdc++` dev
packages only existed to suppress clang-tidy false positives and clang-tidy
was already disabled, so that step goes away as well.

Verified locally, since the workflow itself can only be exercised on a real
pull request:

- On the #4314 branch, a 41590-line diff that trips the cap, the new step
  computes 211 changed C/C++ files and reports no violations, in 11s.
- On a deliberately misformatted file it exits 1 and emits the expected
  clang-format patch into the job summary.
- On a commit that edits a correctly formatted line in a file whose other
  lines are misformatted, it stays silent, confirming the changed-lines-only
  scope survives.

Signed-off-by: Jijoong Moon <jijoong.moon@samsung.com>