### PR TITLE
[Build] Build nntrainer on Ubuntu 26.04 (gcc 15): <cstdint> in quantizer.h, gcc fallback

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nntrainer
 Section: libs
 Priority: optional
 Maintainer: Jijoong Moon <jijoong.moon@samsung.com>
-Build-Depends: gcc-13 | gcc-12 | gcc-11 | gcc-10 | gcc-9 | gcc-8 | gcc-7 (>=7.5),
+Build-Depends: gcc-13 | gcc-12 | gcc-11 | gcc-10 | gcc-9 | gcc-8 | gcc-7 (>=7.5) | gcc,
  python3, python3-numpy,
  pkg-config, cmake, ninja-build, meson (>=0.50), debhelper (>=9),
  libopenblas-dev, libiniparser-dev (>=4.1), tensorflow2-lite-dev, libjsoncpp-dev,

--- a/nntrainer/tensor/quantizer.h
+++ b/nntrainer/tensor/quantizer.h
@@ -12,6 +12,7 @@
 #define __QUANTIZER_H__
 #ifdef __cplusplus
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <unordered_map>


### PR DESCRIPTION
## Why

`ppa:nnstreamer/ppa` now publishes nnstreamer, nnstreamer-edge, ssat, tensorflow2-lite and edgetpu for Ubuntu 26.04 (resolute), and ml-api is on its way (nnstreamer/api#692). nntrainer cannot follow yet, for two reasons found by building the package in an `ubuntu:26.04` container:

1. `debian/control` accepts only `gcc-13 | ... | gcc-7`. Resolute still has `gcc-13` today, but it is not the default compiler there and will be dropped like `gcc-9` was on 24.10+; nnstreamer, nnstreamer-edge and ml-api already carry the unversioned `gcc` fallback for exactly this reason, and the Launchpad recipe build resolves the committed control on every series.
2. With gcc 15.2 / libstdc++ 15 the build stops immediately in `nntrainer/tensor/quantizer.h`: `enum class QScheme : uint16_t` is declared without `<cstdint>`, which older libstdc++ pulled in transitively and 15 no longer does. `QScheme` then never gets declared and every tensor translation unit fails with hundreds of follow-on errors (`'QScheme' has not been declared`, `no matching function for call to 'GgmlQuantizer(int&)'`, ...).

## What

- `debian/control`: append `| gcc` as the last compiler alternative. Older alternatives stay first, so 22.04 / 24.04 resolve exactly as before.
- `nntrainer/tensor/quantizer.h`: `#include <cstdint>`.

## How it was verified

- `ubuntu:26.04` container, `ppa:nnstreamer/ppa` enabled plus the ml-api 1.8.8 debs from nnstreamer/api#692, `mk-build-deps` from the modified control, `dpkg-buildpackage -us -uc -b` with gcc 15.2.0 / meson 1.10: without commit 2 the build dies as described; with both commits it completes, `override_dh_auto_test` (`meson test -C build -t 2.0`) passes, and all eleven `.deb`s are produced.
- Control: the same tree without these commits builds and passes tests in an `ubuntu:24.04` container, so the failure is specific to gcc 15.

No functional change; the existing unit tests are what the header fix makes buildable again on 26.04, so no new test case is added.

Part of the 26.04 PPA work tracked in nnstreamer/nnstreamer#4902. After this merges, `nntrainer-daily` on Launchpad needs Resolute added and a build requested (I can do that once ml-api is published for resolute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
