### PR TITLE
[tensor] Fix unsigned affine quantization parameters

### DIFF
--- a/nntrainer/tensor/float_tensor.cpp
+++ b/nntrainer/tensor/float_tensor.cpp
@@ -1139,6 +1139,16 @@ void FloatTensor::copyData(const Tensor &from) {
     o->scopy_int8_to_fp32_u(from.size(), from.getData<uint8_t>(), 1,
                             (float *)getData(), 1);
     break;
+  case ml::train::TensorDim::DataType::UINT4: {
+    const uint8_t *packed = from.getData<uint8_t>();
+    float *unpacked = static_cast<float *>(getData());
+    for (size_t i = 0; i < from.size(); ++i) {
+      const uint8_t value = packed[i / 2];
+      unpacked[i] = static_cast<float>(
+        i % 2 == 0 ? (value >> 4) & 0x0F : value & 0x0F);
+    }
+    break;
+  }
   default:
     throw std::invalid_argument(
       "[FloatTensor::copyData] Error: Unsupported data type");

--- a/nntrainer/tensor/quantizer.cpp
+++ b/nntrainer/tensor/quantizer.cpp
@@ -61,20 +61,24 @@ std::unique_ptr<Quantizer> PerTensorAffineQuantizer::create() {
 
 void PerTensorAffineQuantizer::calculateQParams(const Tensor &input,
                                                 Tdatatype qtype) {
-  float max_val = input.max_abs();
-  scale = max_val / ((quant_max - quant_min) / 2.0f);
-  scale = std::max(scale, std::numeric_limits<float>::epsilon());
+  const bool is_unsigned = qtype == Tdatatype::UINT4 ||
+                           qtype == Tdatatype::UINT8 ||
+                           qtype == Tdatatype::UINT16;
 
-  if (qtype == Tdatatype::UINT4) {
+  if (is_unsigned) {
+    const float min_val = std::min(input.minValue(), 0.0f);
+    const float max_val = std::max(input.maxValue(), 0.0f);
+    scale = (max_val - min_val) / (quant_max - quant_min);
+    scale = std::max(scale, std::numeric_limits<float>::epsilon());
+
+    const long int rounded_zero_point =
+      std::lround(quant_min - min_val / scale);
     zero_point =
-      (unsigned int)(std::round(scale * input.minValue()) + std::pow(2, 3));
-  } else if (qtype == Tdatatype::UINT8) {
-    zero_point =
-      (unsigned int)(std::round(scale * input.minValue()) + std::pow(2, 7));
-  } else if (qtype == Tdatatype::UINT16) {
-    zero_point =
-      (unsigned int)(std::round(scale * input.minValue()) + std::pow(2, 15));
+      static_cast<unsigned int>(clip(rounded_zero_point, quant_min, quant_max));
   } else {
+    const float max_val = input.max_abs();
+    scale = max_val / ((quant_max - quant_min) / 2.0f);
+    scale = std::max(scale, std::numeric_limits<float>::epsilon());
     zero_point = 0;
   }
 }

--- a/nntrainer/tensor/quantizer.cpp
+++ b/nntrainer/tensor/quantizer.cpp
@@ -167,7 +167,7 @@ Tensor &PerTensorAffineQuantizer::quantize(const Tensor &input, Tensor &output,
 Tensor PerTensorAffineQuantizer::dequantize(const Tensor &input,
                                             Tdatatype dtype) {
   Tensor output = input.clone(dtype);
-  if (output.getDataType() == Tdatatype::UINT4 ||
+  if (input.getDataType() == Tdatatype::UINT4 ||
       input.getDataType() == Tdatatype::UINT8 ||
       input.getDataType() == Tdatatype::UINT16) {
     output.subtract_i(static_cast<float>(*input.getZeroPoint()));

--- a/test/unittest/unittest_nntrainer_quantizer.cpp
+++ b/test/unittest/unittest_nntrainer_quantizer.cpp
@@ -13,6 +13,7 @@
 
 #include "nntrainer_test_util.h"
 #include "util_func.h"
+#include <array>
 #include <fstream>
 #include <nntrainer_error.h>
 #include <quantizer.h>
@@ -403,6 +404,86 @@ TEST(nntrainer_Quantizer, per_tensor_affine_05_p) {
 
   ASSERT_EQ(output_s8, float_answer);
   ASSERT_EQ(output_u8, float_answer);
+}
+
+/**
+ * @brief Automatically calculate UINT8 affine parameters and round-trip data.
+ */
+TEST(nntrainer_Quantizer, per_tensor_affine_uint8_auto_qparams) {
+  const std::array<std::array<float, 3>, 3> inputs = {{
+    {-127.5f, 0.0f, 127.5f},
+    {0.0f, 127.5f, 255.0f},
+    {-255.0f, -127.5f, 0.0f},
+  }};
+  const std::array<unsigned int, 3> expected_zero_points = {128, 0, 255};
+
+  std::unique_ptr<nntrainer::Quantizer> quantizer =
+    nntrainer::Quantization::createQuantizer(
+      nntrainer::QScheme::PER_TENSOR_AFFINE);
+
+  for (unsigned int i = 0; i < inputs.size(); ++i) {
+    nntrainer::Tensor input({1, 1, 1, 3}, inputs[i].data());
+    nntrainer::Tensor quantized =
+      quantizer->quantize(input, nntrainer::Tdatatype::UINT8);
+
+    EXPECT_EQ(*quantized.getZeroPoint(), expected_zero_points[i]);
+    EXPECT_FLOAT_EQ(*quantized.getScale<float>(), 1.0f);
+
+    nntrainer::Tensor output =
+      quantizer->dequantize(quantized, nntrainer::Tdatatype::FP32);
+    for (unsigned int w = 0; w < 3; ++w)
+      EXPECT_NEAR(output.getValue(0, 0, 0, w), inputs[i][w], 0.5f);
+  }
+}
+
+/**
+ * @brief Automatically calculate UINT16 and UINT4 affine parameters.
+ */
+TEST(nntrainer_Quantizer, per_tensor_affine_other_unsigned_auto_qparams) {
+  float uint16_data[] = {-32767.5f, 0.0f, 32767.5f};
+  nntrainer::Tensor uint16_input({1, 1, 1, 3}, uint16_data);
+  float uint4_data[] = {-7.5f, 0.0f, 7.5f};
+  nntrainer::Tensor uint4_input({1, 1, 1, 3}, uint4_data);
+
+  std::unique_ptr<nntrainer::Quantizer> quantizer =
+    nntrainer::Quantization::createQuantizer(
+      nntrainer::QScheme::PER_TENSOR_AFFINE);
+
+  nntrainer::Tensor uint16_quantized =
+    quantizer->quantize(uint16_input, nntrainer::Tdatatype::UINT16);
+  EXPECT_EQ(*uint16_quantized.getZeroPoint(), 32768u);
+  EXPECT_FLOAT_EQ(*uint16_quantized.getScale<float>(), 1.0f);
+  EXPECT_EQ(uint16_quantized.getValue<uint16_t>(0), 0u);
+  EXPECT_EQ(uint16_quantized.getValue<uint16_t>(1), 32768u);
+  EXPECT_EQ(uint16_quantized.getValue<uint16_t>(2), 65535u);
+
+  nntrainer::Tensor uint4_quantized =
+    quantizer->quantize(uint4_input, nntrainer::Tdatatype::UINT4);
+  EXPECT_EQ(*uint4_quantized.getZeroPoint(), 8u);
+  EXPECT_FLOAT_EQ(*uint4_quantized.getScale<float>(), 1.0f);
+}
+
+/**
+ * @brief UINT8 automatic affine codes are invariant under unit scaling.
+ */
+TEST(nntrainer_Quantizer, per_tensor_affine_uint8_unit_invariance) {
+  float input_data[] = {-128.0f, 0.0f, 127.0f};
+  float scaled_input_data[] = {-256.0f, 0.0f, 254.0f};
+  nntrainer::Tensor input({1, 1, 1, 3}, input_data);
+  nntrainer::Tensor scaled_input({1, 1, 1, 3}, scaled_input_data);
+
+  std::unique_ptr<nntrainer::Quantizer> quantizer =
+    nntrainer::Quantization::createQuantizer(
+      nntrainer::QScheme::PER_TENSOR_AFFINE);
+  nntrainer::Tensor quantized =
+    quantizer->quantize(input, nntrainer::Tdatatype::UINT8);
+  nntrainer::Tensor scaled_quantized =
+    quantizer->quantize(scaled_input, nntrainer::Tdatatype::UINT8);
+
+  EXPECT_EQ(*quantized.getZeroPoint(), *scaled_quantized.getZeroPoint());
+  for (unsigned int w = 0; w < 3; ++w)
+    EXPECT_EQ(quantized.getValue<uint8_t>(w),
+              scaled_quantized.getValue<uint8_t>(w));
 }
 
 /**

--- a/test/unittest/unittest_nntrainer_quantizer.cpp
+++ b/test/unittest/unittest_nntrainer_quantizer.cpp
@@ -432,7 +432,7 @@ TEST(nntrainer_Quantizer, per_tensor_affine_uint8_auto_qparams) {
     nntrainer::Tensor output =
       quantizer->dequantize(quantized, nntrainer::Tdatatype::FP32);
     for (unsigned int w = 0; w < 3; ++w)
-      EXPECT_NEAR(output.getValue(0, 0, 0, w), inputs[i][w], 0.5f);
+      EXPECT_NEAR(output.getValue(0, 0, 0, w), inputs[i][w], 0.50001f);
   }
 }
 
@@ -461,6 +461,11 @@ TEST(nntrainer_Quantizer, per_tensor_affine_other_unsigned_auto_qparams) {
     quantizer->quantize(uint4_input, nntrainer::Tdatatype::UINT4);
   EXPECT_EQ(*uint4_quantized.getZeroPoint(), 8u);
   EXPECT_FLOAT_EQ(*uint4_quantized.getScale<float>(), 1.0f);
+
+  nntrainer::Tensor uint4_output =
+    quantizer->dequantize(uint4_quantized, nntrainer::Tdatatype::FP32);
+  for (unsigned int w = 0; w < 3; ++w)
+    EXPECT_NEAR(uint4_output.getValue(0, 0, 0, w), uint4_data[w], 0.50001f);
 }
 
 /**


### PR DESCRIPTION
## Dependency of the PR

Fixes #4324.

## Commits to be reviewed in this PR

<details><summary>[tensor] Fix unsigned affine quantization parameters</summary><br />

[tensor] Fix unsigned affine quantization parameters

Derive unsigned affine scales from a zero-inclusive range and calculate zero
points from `qmin - min / scale`, followed by rounding and saturation. Add
regression coverage for UINT8, UINT16, UINT4, one-sided ranges, and invariance
under a change of units.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: kadyrbekovhamit-cyber <288885044+kadyrbekovhamit-cyber@users.noreply.github.com>

</details>

### Summary

- Replace scale-dependent unsigned zero-point calculations with the affine ratio required by the documented quantize/dequantize contract.
- Include real zero in automatically inferred unsigned ranges and saturate the rounded zero point to the destination type.
- Add automatic-parameter regression tests for UINT8, UINT16, and UINT4, including positive-only, negative-only, and unit-scaled inputs.
- Preserve the existing signed quantization behavior.

Signed-off-by: kadyrbekovhamit-cyber <288885044+kadyrbekovhamit-cyber@users.noreply.github.com>
